### PR TITLE
Allow report page users to access standard reports

### DIFF
--- a/app/Http/Controllers/Admin/PrintableReportController.php
+++ b/app/Http/Controllers/Admin/PrintableReportController.php
@@ -15,7 +15,7 @@ class PrintableReportController
 
         $type = CampistaReportType::tryFrom((string) $request->query('type'));
         abort_unless($type instanceof CampistaReportType, 404);
-        abort_unless($user->can($type->permission()), 403);
+        abort_unless($type->canBeAccessedBy($user), 403);
 
         return view('admin.reports.print', [
             'report' => $reports->payload($type, $request->query(), $user),

--- a/app/Support/Reports/CampistaReportData.php
+++ b/app/Support/Reports/CampistaReportData.php
@@ -21,7 +21,7 @@ class CampistaReportData
     public function availableTypes(User $user): array
     {
         return collect(CampistaReportType::cases())
-            ->filter(fn (CampistaReportType $type): bool => $user->can($type->permission()))
+            ->filter(fn (CampistaReportType $type): bool => $type->canBeAccessedBy($user))
             ->map(fn (CampistaReportType $type): array => [
                 'value' => $type->value,
                 'label' => $type->label(),
@@ -402,7 +402,7 @@ class CampistaReportData
 
         if ($size === 'O') {
             return filled(data_get($formData, 'tamanho_camiseta_outro'))
-                ? 'Outro: ' . data_get($formData, 'tamanho_camiseta_outro')
+                ? 'Outro: '.data_get($formData, 'tamanho_camiseta_outro')
                 : 'Outro';
         }
 

--- a/app/Support/Reports/CampistaReportType.php
+++ b/app/Support/Reports/CampistaReportType.php
@@ -2,12 +2,16 @@
 
 namespace App\Support\Reports;
 
+use App\Models\User;
+
 enum CampistaReportType: string
 {
     case RegistrationFichas = 'registration_fichas';
     case TribeQuadrant = 'tribe_quadrant';
     case SensitiveHealth = 'sensitive_health';
     case MissionContacts = 'mission_contacts';
+
+    public const PAGE_PERMISSION = 'page_reports_page';
 
     public function label(): string
     {
@@ -52,5 +56,14 @@ enum CampistaReportType: string
     public function isSensitive(): bool
     {
         return $this === self::SensitiveHealth;
+    }
+
+    public function canBeAccessedBy(User $user): bool
+    {
+        if ($this->isSensitive()) {
+            return $user->can($this->permission());
+        }
+
+        return $user->can(self::PAGE_PERMISSION);
     }
 }

--- a/tests/Feature/ReportsPageTest.php
+++ b/tests/Feature/ReportsPageTest.php
@@ -91,6 +91,39 @@ it('renders the reports launcher only for authorized operational users', functio
         ->assertForbidden();
 });
 
+it('uses the reports page permission to expose standard operational reports', function () {
+    $this->seed(ShieldSeeder::class);
+
+    reportCampista();
+
+    $role = Role::query()->create([
+        'name' => 'Apoio operacional sem permissoes individuais',
+        'guard_name' => 'web',
+    ]);
+    $role->givePermissionTo('page_reports_page');
+
+    $user = User::factory()->create();
+    $user->assignRole($role);
+
+    $this->actingAs($user)
+        ->get(route('filament.admin.pages.reports-page'))
+        ->assertOk()
+        ->assertSee('Fichas de inscrição')
+        ->assertSee('Quadrante por tribo')
+        ->assertSee('Contatos e endereços')
+        ->assertDontSee('Nenhum relatório disponível')
+        ->assertDontSee('Lista médica da enfermaria');
+
+    $this->actingAs($user)
+        ->get(route('admin.reports.print', ['type' => 'registration_fichas']))
+        ->assertOk()
+        ->assertSee('Fichas de inscrição');
+
+    $this->actingAs($user)
+        ->get(route('admin.reports.print', ['type' => 'sensitive_health']))
+        ->assertForbidden();
+});
+
 it('builds the report filters with native Filament form components', function () {
     $page = file_get_contents(app_path('Filament/Pages/ReportsPage.php'));
     $view = file_get_contents(resource_path('views/filament/pages/reports-page.blade.php'));


### PR DESCRIPTION
- Gate non-sensitive reports through the reports page permission
- Keep sensitive health reports behind their specific permission