### PR TITLE
Sync permission groups during existing migrations

### DIFF
--- a/database/migrations/2026_06_07_231000_sync_permission_groups_for_existing_environments.php
+++ b/database/migrations/2026_06_07_231000_sync_permission_groups_for_existing_environments.php
@@ -1,0 +1,25 @@
+<?php
+
+use Database\Seeders\ShieldSeeder;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        $tableNames = config('permission.table_names');
+
+        if (! Schema::hasTable($tableNames['roles'] ?? 'roles')
+            || ! Schema::hasTable($tableNames['permissions'] ?? 'permissions')) {
+            return;
+        }
+
+        ShieldSeeder::syncRolesAndPermissions();
+    }
+
+    public function down(): void
+    {
+        //
+    }
+};

--- a/database/seeders/ShieldSeeder.php
+++ b/database/seeders/ShieldSeeder.php
@@ -23,6 +23,13 @@ class ShieldSeeder extends Seeder
 
     public function run(): void
     {
+        static::syncRolesAndPermissions();
+
+        $this->command?->info('Shield Seeding Completed.');
+    }
+
+    public static function syncRolesAndPermissions(): void
+    {
         app()[PermissionRegistrar::class]->forgetCachedPermissions();
 
         $permissions = static::getPermissionNames();
@@ -32,7 +39,7 @@ class ShieldSeeder extends Seeder
         static::makeFinanceWithPermissions($permissions);
         static::makeInfirmaryWithPermissions($permissions);
 
-        $this->command->info('Shield Seeding Completed.');
+        app()[PermissionRegistrar::class]->forgetCachedPermissions();
     }
 
     protected static function makeSuperAdminWithPermissions(array $permissions): void

--- a/tests/Browser/admin-panel-layout.spec.js
+++ b/tests/Browser/admin-panel-layout.spec.js
@@ -337,6 +337,19 @@ test('authenticated Filament notifications render above the branded topbar', asy
     });
 });
 
+test('authenticated permission groups list includes the finance role', async ({ page }) => {
+    await signIn(page);
+
+    await page.goto(`${adminBaseUrl}/admin/roles`, { waitUntil: 'domcontentloaded' });
+    await waitForFilamentClient(page);
+
+    await expect(page.locator('h1')).toContainText(/Grupos de permissões/i);
+    await expect(page.getByRole('cell', { name: 'Financeiro', exact: true })).toBeVisible();
+    await expect(page.getByRole('cell', { name: 'Super Administrador', exact: true })).toBeVisible();
+    await expect(page.getByRole('cell', { name: 'Administrador', exact: true })).toBeVisible();
+    await expect(page.getByRole('cell', { name: 'Enfermaria', exact: true })).toBeVisible();
+});
+
 test('authenticated Filament sidebar flyouts stay above table surfaces when collapsed', async ({ page }) => {
     await mkdir('storage/app/screenshots', { recursive: true });
 

--- a/tests/Feature/FinancialDashboardSecurityTest.php
+++ b/tests/Feature/FinancialDashboardSecurityTest.php
@@ -5,7 +5,10 @@ use App\Filament\Pages\FinancialDashboard;
 use App\Models\User;
 use Database\Seeders\ShieldSeeder;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Spatie\Permission\Models\Permission;
 use Spatie\Permission\Models\Role;
+use Spatie\Permission\PermissionRegistrar;
 
 uses(RefreshDatabase::class);
 
@@ -38,4 +41,49 @@ it('allows finance users to access the financial dashboard without exposing the 
     $this->actingAs($commonUser)
         ->get(FinancialDashboard::getUrl())
         ->assertForbidden();
+});
+
+it('repairs existing environments missing the finance permission group when migrations run', function () {
+    $this->seed(ShieldSeeder::class);
+
+    $role = Role::findByName('Financeiro');
+    $tableNames = config('permission.table_names');
+    $rolePivotKey = config('permission.column_names.role_pivot_key') ?? 'role_id';
+
+    DB::table($tableNames['model_has_roles'])
+        ->where($rolePivotKey, $role->id)
+        ->delete();
+    DB::table($tableNames['role_has_permissions'])
+        ->where($rolePivotKey, $role->id)
+        ->delete();
+
+    $role->delete();
+
+    Permission::query()
+        ->whereIn('name', [
+            'page_financial_dashboard',
+            'view_any_lancamento',
+            'view_lancamento',
+            'view_any_categoria_lancamento',
+            'view_categoria_lancamento',
+        ])
+        ->delete();
+
+    app(PermissionRegistrar::class)->forgetCachedPermissions();
+
+    $migrationFiles = glob(database_path('migrations/*_sync_permission_groups_for_existing_environments.php'));
+
+    expect($migrationFiles)->toHaveCount(1);
+
+    $migration = include $migrationFiles[0];
+    $migration->up();
+
+    $role = Role::findByName('Financeiro');
+
+    expect($role->id)->toBe(RoleEnum::Financeiro->value)
+        ->and($role->hasPermissionTo('page_financial_dashboard'))->toBeTrue()
+        ->and($role->hasPermissionTo('view_any_lancamento'))->toBeTrue()
+        ->and($role->hasPermissionTo('view_lancamento'))->toBeTrue()
+        ->and($role->hasPermissionTo('view_any_categoria_lancamento'))->toBeTrue()
+        ->and($role->hasPermissionTo('view_categoria_lancamento'))->toBeTrue();
 });


### PR DESCRIPTION
- Reuses ShieldSeeder role and permission syncing from a migration so existing environments recover missing groups like Financeiro
- Covers the repaired role list and financial dashboard permissions with tests