### PR TITLE
Add itemized financial entries and batch launch creation

### DIFF
--- a/app/Filament/Resources/CampistaResource/CampistaForm.php
+++ b/app/Filament/Resources/CampistaResource/CampistaForm.php
@@ -4,7 +4,7 @@ namespace App\Filament\Resources\CampistaResource;
 
 use App\Enums\StatusInscricao;
 use App\Models\Campista;
-use App\Models\FinancialEntryRegistration;
+use App\Models\LancamentoItem;
 use Carbon\Carbon;
 use Filament\Actions\Action as FormAction;
 use Filament\Forms\Components\Checkbox;
@@ -693,7 +693,7 @@ abstract class CampistaForm
             return new HtmlString(self::paymentSummaryEmptyHtml('Salve a inscrição para vincular lançamentos financeiros.'));
         }
 
-        $payments = $record->financialEntryRegistrations()
+        $payments = $record->lancamentoItems()
             ->with('lancamento')
             ->orderByDesc('id')
             ->get();
@@ -703,7 +703,7 @@ abstract class CampistaForm
         }
 
         $items = $payments
-            ->map(fn (FinancialEntryRegistration $payment): string => self::paymentSummaryItemHtml($payment))
+            ->map(fn (LancamentoItem $payment): string => self::paymentSummaryItemHtml($payment))
             ->implode('');
 
         return new HtmlString('<div style="display:grid;gap:.75rem;">'.$items.'</div>');
@@ -716,7 +716,7 @@ abstract class CampistaForm
             .'</div>';
     }
 
-    private static function paymentSummaryItemHtml(FinancialEntryRegistration $payment): string
+    private static function paymentSummaryItemHtml(LancamentoItem $payment): string
     {
         $lancamento = $payment->lancamento;
         $status = $lancamento?->status?->getLabel() ?? 'Sem status';
@@ -728,7 +728,7 @@ abstract class CampistaForm
             .'<p style="margin:0 0 .35rem;color:#9ddbef;font-size:.72rem;font-weight:900;letter-spacing:.16em;text-transform:uppercase;">Lançamento financeiro</p>'
             .'<strong style="display:block;color:#f4fbfd;font-size:1rem;line-height:1.25;">'.e($name).'</strong>'
             .'<dl style="display:grid;grid-template-columns:repeat(2,minmax(0,1fr));gap:.7rem;margin:.85rem 0 0;">'
-            .self::paymentSummaryFieldHtml('Valor aplicado', self::money((int) $payment->amount))
+            .self::paymentSummaryFieldHtml('Valor aplicado', self::money((int) $payment->valor))
             .self::paymentSummaryFieldHtml('Data', $date)
             .self::paymentSummaryFieldHtml('Forma', $method)
             .self::paymentSummaryFieldHtml('Status', $status)

--- a/app/Filament/Resources/LancamentoResource.php
+++ b/app/Filament/Resources/LancamentoResource.php
@@ -7,7 +7,9 @@ use App\Filament\Exports\LancamentoExporter;
 use App\Filament\Resources\LancamentoResource\Forms\LancamentoForm;
 use App\Filament\Resources\LancamentoResource\Pages;
 use App\Filament\Resources\LancamentoResource\Widgets\StatsFinanceiro;
+use App\Models\CategoriaLancamento;
 use App\Models\Lancamento;
+use App\Models\LancamentoItem;
 use App\Support\IconBadge;
 use Carbon\Carbon;
 use Filament\Actions\EditAction;
@@ -21,6 +23,7 @@ use Filament\Tables\Filters\SelectFilter;
 use Filament\Tables\Grouping\Group;
 use Filament\Tables\Table;
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Support\HtmlString;
 
 class LancamentoResource extends Resource
 {
@@ -44,7 +47,7 @@ class LancamentoResource extends Resource
     public static function table(Table $table): Table
     {
         return $table
-            ->modifyQueryUsing(fn (Builder $query): Builder => $query->with(['categoria', 'registrationPayments.registration']))
+            ->modifyQueryUsing(fn (Builder $query): Builder => $query->with(['items.categoria', 'items.registration']))
             ->columns([
                 TextColumn::make('id')
                     ->label('Código')
@@ -71,18 +74,13 @@ class LancamentoResource extends Resource
                     ->alignCenter()
                     ->label('Lançamento'),
 
-                TextColumn::make('categoria.nome')
-                    ->label('Categoria')
+                TextColumn::make('categories_summary')
+                    ->label('Categorias')
                     ->html()
-                    ->formatStateUsing(fn (?string $state, Lancamento $record) => IconBadge::tileIcon(
-                        $record->categoria,
-                        $state ?? 'Sem categoria',
-                        fallbackIcon: 'heroicon-o-tag',
-                    ))
-                    ->tooltip(fn (?string $state): string => $state ?? 'Sem categoria')
+                    ->formatStateUsing(fn (mixed $state, Lancamento $record): HtmlString => self::categoryBadges($record))
+                    ->tooltip(fn (Lancamento $record): string => $record->categories_summary)
                     ->placeholder('Sem categoria')
-                    ->alignCenter()
-                    ->sortable(),
+                    ->alignCenter(),
 
                 TextColumn::make('registration_payments_summary')
                     ->label('Inscrições')
@@ -96,6 +94,12 @@ class LancamentoResource extends Resource
                     ->alignCenter()
                     ->label('Status'),
 
+                TextColumn::make('batch_code')
+                    ->label('Lote')
+                    ->badge()
+                    ->placeholder('Sem lote')
+                    ->searchable(),
+
                 TextColumn::make('data')
                     ->alignCenter()
                     ->label('Data lançamento')
@@ -106,17 +110,32 @@ class LancamentoResource extends Resource
             ->groups([
                 Group::make('status')->collapsible(),
                 Group::make('tipo')->collapsible(),
-                Group::make('categoria.nome')
-                    ->label('Categoria')
+                Group::make('batch_code')
+                    ->label('Lote')
                     ->collapsible(),
             ])
             ->defaultSort('id', 'desc')
             ->filters([
                 SelectFilter::make('categoria_lancamento_id')
                     ->label('Categoria')
-                    ->relationship('categoria', 'nome')
+                    ->options(fn (): array => CategoriaLancamento::query()
+                        ->orderBy('nome')
+                        ->pluck('nome', 'id')
+                        ->all())
+                    ->query(fn (Builder $query, array $data): Builder => blank($data['value'] ?? null)
+                        ? $query
+                        : $query->whereHas('items', fn (Builder $query): Builder => $query->where('categoria_lancamento_id', $data['value'])))
                     ->searchable()
                     ->preload(),
+                SelectFilter::make('batch_code')
+                    ->label('Lote')
+                    ->options(fn (): array => Lancamento::query()
+                        ->whereNotNull('batch_code')
+                        ->distinct()
+                        ->orderByDesc('batch_code')
+                        ->pluck('batch_code', 'batch_code')
+                        ->all())
+                    ->searchable(),
             ])
             ->actions([
                 EditAction::make()
@@ -143,6 +162,7 @@ class LancamentoResource extends Resource
         return [
             'index' => Pages\ListLancamentos::route('/'),
             'create' => Pages\CreateLancamento::route('/create'),
+            'batch' => Pages\BatchLancamentos::route('/batch'),
             'edit' => Pages\EditLancamento::route('/{record}/edit'),
         ];
     }
@@ -152,5 +172,38 @@ class LancamentoResource extends Resource
         return [
             StatsFinanceiro::class,
         ];
+    }
+
+    private static function categoryBadges(Lancamento $record): HtmlString
+    {
+        $items = $record->relationLoaded('items')
+            ? $record->items
+            : $record->items()->with('categoria')->get();
+
+        $categories = $items
+            ->map(fn (LancamentoItem $item) => $item->categoria)
+            ->filter()
+            ->unique('id')
+            ->values();
+
+        if ($categories->isEmpty()) {
+            return new HtmlString('Sem categoria');
+        }
+
+        $visible = $categories
+            ->take(2)
+            ->map(fn (CategoriaLancamento $category): string => (string) IconBadge::tileIcon(
+                $category,
+                $category->nome,
+                fallbackIcon: 'heroicon-o-tag',
+            ))
+            ->implode('');
+
+        $extra = $categories->count() - 2;
+        $extraBadge = $extra > 0
+            ? '<span title="'.e($categories->skip(2)->pluck('nome')->implode(', ')).'" style="display:inline-flex;align-items:center;justify-content:center;width:2rem;height:2rem;border-radius:999px;background:rgba(148,163,184,.26);color:#f4fbfd;font-size:.75rem;font-weight:900;">+'.e((string) $extra).'</span>'
+            : '';
+
+        return new HtmlString('<span style="display:inline-flex;align-items:center;gap:.25rem;">'.$visible.$extraBadge.'</span>');
     }
 }

--- a/app/Filament/Resources/LancamentoResource/Forms/LancamentoForm.php
+++ b/app/Filament/Resources/LancamentoResource/Forms/LancamentoForm.php
@@ -59,18 +59,6 @@ abstract class LancamentoForm
                                     'xl' => 4,
                                 ]),
 
-                            Money::make('valor')
-                                ->label('Valor')
-                                ->columns(1)
-                                ->intFormat()
-                                ->prefix(RawJs::make('R$'))
-                                ->required()
-                                ->columnSpan([
-                                    'default' => 'full',
-                                    'md' => 1,
-                                    'xl' => 2,
-                                ]),
-
                             DatePicker::make('data')
                                 ->label('Data de Lançamento')
                                 ->required()
@@ -116,7 +104,7 @@ abstract class LancamentoForm
                                 ->inline()
                                 ->live()
                                 ->afterStateUpdated(static function (Set $set, mixed $state): void {
-                                    $set('categoria_lancamento_id', null);
+                                    $set('items', []);
 
                                     if (! self::isExpenseType($state)) {
                                         $set('comprador', null);
@@ -126,21 +114,6 @@ abstract class LancamentoForm
                                 ->columnSpan([
                                     'default' => 'full',
                                     'md' => 2,
-                                    'xl' => 4,
-                                ]),
-
-                            Select::make('categoria_lancamento_id')
-                                ->label('Categoria')
-                                ->options(fn (Get $get): array => self::categoryOptions($get('tipo')))
-                                ->allowHtml()
-                                ->searchable()
-                                ->preload()
-                                ->placeholder('Selecione uma categoria')
-                                ->helperText('As opções acompanham o tipo do lançamento.')
-                                ->disabled(fn (Get $get): bool => blank($get('tipo')))
-                                ->columnSpan([
-                                    'default' => 'full',
-                                    'md' => 1,
                                     'xl' => 4,
                                 ]),
 
@@ -162,17 +135,48 @@ abstract class LancamentoForm
                                 ->columnSpanFull(),
                         ]),
 
-                    Section::make('Inscrições vinculadas')
-                        ->description('Aplique este lançamento em uma ou mais inscrições.')
+                    Section::make('Itens do lançamento')
+                        ->description('Classifique valores, categorias e vínculos financeiros.')
                         ->columnSpan([
                             'default' => 1,
                             'lg' => 8,
                         ])
                         ->schema([
-                            Repeater::make('registration_payments')
-                                ->label('Pagamentos de inscrições')
-                                ->helperText('A soma dos valores aplicados não pode ultrapassar o valor total do lançamento.')
+                            Repeater::make('items')
+                                ->label('Itens')
                                 ->schema([
+                                    TextInput::make('nome')
+                                        ->label('Nome')
+                                        ->required()
+                                        ->maxLength(255)
+                                        ->columnSpan([
+                                            'default' => 'full',
+                                            'lg' => 4,
+                                        ]),
+
+                                    Money::make('valor')
+                                        ->label('Valor')
+                                        ->intFormat()
+                                        ->prefix(RawJs::make('R$'))
+                                        ->required()
+                                        ->columnSpan([
+                                            'default' => 'full',
+                                            'lg' => 2,
+                                        ]),
+
+                                    Select::make('categoria_lancamento_id')
+                                        ->label('Categoria')
+                                        ->options(fn (Get $get): array => self::categoryOptions($get('../../tipo')))
+                                        ->allowHtml()
+                                        ->searchable()
+                                        ->preload()
+                                        ->required()
+                                        ->disabled(fn (Get $get): bool => blank($get('../../tipo')))
+                                        ->columnSpan([
+                                            'default' => 'full',
+                                            'lg' => 3,
+                                        ]),
+
                                     Select::make('registration_type')
                                         ->label('Tipo da inscrição')
                                         ->options(RegistrationPaymentAllocator::registrationTypeOptions())
@@ -180,9 +184,8 @@ abstract class LancamentoForm
                                         ->live()
                                         ->afterStateUpdated(function (Set $set): void {
                                             $set('registration_id', null);
-                                            $set('amount', null);
                                         })
-                                        ->required()
+                                        ->placeholder('Sem vínculo')
                                         ->columnSpan([
                                             'default' => 'full',
                                             'lg' => 3,
@@ -201,30 +204,33 @@ abstract class LancamentoForm
                                                 $get('registration_type'),
                                                 $search,
                                                 $record?->id,
-                                                filled($get('registration_id')) ? (int) $get('registration_id') : null,
-                                            ))
+                                            filled($get('registration_id')) ? (int) $get('registration_id') : null,
+                                        ))
                                         ->searchable()
                                         ->preload()
+                                        ->live()
+                                        ->afterStateUpdated(function (Set $set, Get $get, mixed $state): void {
+                                            $name = self::registrationName($get('registration_type'), $state);
+
+                                            if ($name !== null) {
+                                                $set('nome', $name);
+                                            }
+                                        })
                                         ->disabled(fn (Get $get): bool => blank($get('registration_type')))
-                                        ->required()
                                         ->columnSpan([
                                             'default' => 'full',
                                             'lg' => 6,
                                         ]),
 
-                                    Money::make('amount')
-                                        ->label('Valor aplicado')
-                                        ->intFormat()
-                                        ->prefix(RawJs::make('R$'))
-                                        ->required()
-                                        ->columnSpan([
-                                            'default' => 'full',
-                                            'lg' => 3,
-                                        ]),
+                                    Textarea::make('descricao')
+                                        ->label('Descrição')
+                                        ->rows(2)
+                                        ->columnSpanFull(),
                                 ])
                                 ->columns(12)
-                                ->defaultItems(0)
-                                ->addActionLabel('Adicionar inscrição')
+                                ->defaultItems(1)
+                                ->minItems(1)
+                                ->addActionLabel('Adicionar item')
                                 ->reorderable(false)
                                 ->collapsible()
                                 ->columnSpanFull(),
@@ -278,17 +284,20 @@ abstract class LancamentoForm
     }
 
     /**
-     * @return array<int, array{registration_type: string, registration_id: int, amount: int}>
+     * @return array<int, array{nome: string, valor: int, categoria_lancamento_id: int, registration_type: ?string, registration_id: ?int, descricao: ?string}>
      */
-    public static function registrationPaymentsFormState(Lancamento $lancamento): array
+    public static function itemsFormState(Lancamento $lancamento): array
     {
-        return $lancamento->registrationPayments()
+        return $lancamento->items()
             ->orderBy('id')
-            ->get(['registration_type', 'registration_id', 'amount'])
-            ->map(fn ($payment): array => [
-                'registration_type' => $payment->registration_type,
-                'registration_id' => (int) $payment->registration_id,
-                'amount' => (int) $payment->amount,
+            ->get(['nome', 'valor', 'categoria_lancamento_id', 'registration_type', 'registration_id', 'descricao'])
+            ->map(fn ($item): array => [
+                'nome' => $item->nome,
+                'valor' => (int) $item->valor,
+                'categoria_lancamento_id' => (int) $item->categoria_lancamento_id,
+                'registration_type' => $item->registration_type,
+                'registration_id' => $item->registration_id ? (int) $item->registration_id : null,
+                'descricao' => $item->descricao,
             ])
             ->all();
     }
@@ -495,7 +504,22 @@ abstract class LancamentoForm
         return (int) $paymentMethod === FormaPagamento::Dinheiro->value;
     }
 
-    private static function categoryOptions(mixed $type): array
+    private static function registrationName(?string $registrationType, mixed $registrationId): ?string
+    {
+        if (blank($registrationType) || blank($registrationId)) {
+            return null;
+        }
+
+        if (! array_key_exists($registrationType, RegistrationPaymentAllocator::registrationTypeOptions())) {
+            return null;
+        }
+
+        $registration = $registrationType::query()->find($registrationId);
+
+        return $registration?->getAttribute('nome');
+    }
+
+    public static function categoryOptions(mixed $type): array
     {
         if ($type instanceof TipoLacamento) {
             $type = $type->value;

--- a/app/Filament/Resources/LancamentoResource/LancamentoExport.php
+++ b/app/Filament/Resources/LancamentoResource/LancamentoExport.php
@@ -33,8 +33,11 @@ abstract class LancamentoExport
                     default => 'Indefinido',
                 }),
 
-            ExportColumn::make('categoria.nome')
-                ->label('Categoria'),
+            ExportColumn::make('categories_summary')
+                ->label('Categorias'),
+
+            ExportColumn::make('batch_code')
+                ->label('Lote'),
 
             ExportColumn::make('status')
                 ->label('Status')

--- a/app/Filament/Resources/LancamentoResource/Pages/BatchLancamentos.php
+++ b/app/Filament/Resources/LancamentoResource/Pages/BatchLancamentos.php
@@ -1,0 +1,515 @@
+<?php
+
+namespace App\Filament\Resources\LancamentoResource\Pages;
+
+use App\Enums\TipoLacamento;
+use App\Filament\Resources\LancamentoResource;
+use App\Filament\Resources\LancamentoResource\Forms\LancamentoForm;
+use App\Filament\Resources\LancamentoResource\Tables\LancamentoBatchCampistasTable;
+use App\Filament\Resources\LancamentoResource\Tables\LancamentoBatchEquipeTrabalhoTable;
+use App\Models\Campista;
+use App\Models\EquipeTrabalho;
+use App\Settings\GeneralSettings;
+use App\Support\Financeiro\LancamentoBatchCreator;
+use App\Support\Financeiro\RegistrationPaymentAllocator;
+use Filament\Actions\Action;
+use Filament\Forms\Components\DatePicker;
+use Filament\Forms\Components\Hidden;
+use Filament\Forms\Components\ModalTableSelect;
+use Filament\Forms\Components\Repeater;
+use Filament\Forms\Components\Select;
+use Filament\Forms\Components\Textarea;
+use Filament\Forms\Components\TextInput;
+use Filament\Forms\Components\ToggleButtons;
+use Filament\Notifications\Notification;
+use Filament\Resources\Pages\Page;
+use Filament\Schemas\Components\Html;
+use Filament\Schemas\Components\Section;
+use Filament\Schemas\Components\Utilities\Get;
+use Filament\Schemas\Components\Utilities\Set;
+use Filament\Schemas\Schema;
+use Filament\Support\Enums\Alignment;
+use Filament\Support\Enums\Width;
+use Filament\Support\RawJs;
+use Illuminate\Contracts\Support\Htmlable;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\HtmlString;
+use Leandrocfe\FilamentPtbrFormFields\Money;
+
+class BatchLancamentos extends Page
+{
+    protected static string $resource = LancamentoResource::class;
+
+    protected static ?string $title = 'Lançamentos em lote';
+
+    protected static ?string $breadcrumb = 'Lote';
+
+    protected string $view = 'filament.resources.lancamento-resource.pages.batch-lancamentos';
+
+    /**
+     * @var array<string, mixed>
+     */
+    public array $data = [];
+
+    public function mount(): void
+    {
+        abort_unless(LancamentoResource::canCreate(), 403);
+
+        $this->form->fill($this->defaultFormData());
+    }
+
+    public function getTitle(): string|Htmlable
+    {
+        return 'Lançamentos em lote';
+    }
+
+    public function form(Schema $schema): Schema
+    {
+        return $schema
+            ->statePath('data')
+            ->columns(1)
+            ->components([
+                Section::make('Configuração do lote')
+                    ->description('Defina a origem e os dados comuns dos lançamentos pendentes.')
+                    ->icon('heroicon-o-adjustments-horizontal')
+                    ->columns([
+                        'default' => 1,
+                        'md' => 2,
+                        'xl' => 12,
+                    ])
+                    ->schema([
+                        ToggleButtons::make('mode')
+                            ->label('Origem')
+                            ->options([
+                                LancamentoBatchCreator::MODE_REGISTRATIONS => 'Inscrições',
+                                LancamentoBatchCreator::MODE_MANUAL => 'Avulso',
+                            ])
+                            ->inline()
+                            ->live()
+                            ->required()
+                            ->afterStateUpdated(function (Set $set): void {
+                                $set('registration_ids', []);
+                                $set('registration_items', []);
+                                $set('manual_items', [$this->blankManualItem()]);
+                            })
+                            ->columnSpan([
+                                'default' => 'full',
+                                'xl' => 4,
+                            ]),
+
+                        DatePicker::make('data')
+                            ->label('Data dos lançamentos')
+                            ->format('Y-m-d')
+                            ->displayFormat('d/m/Y')
+                            ->required()
+                            ->columnSpan([
+                                'default' => 'full',
+                                'md' => 1,
+                                'xl' => 3,
+                            ]),
+
+                        Textarea::make('descricao')
+                            ->label('Descrição padrão')
+                            ->rows(2)
+                            ->columnSpan([
+                                'default' => 'full',
+                                'xl' => 5,
+                            ]),
+                    ]),
+
+                Section::make('Inscrições')
+                    ->description('Selecione campistas ou equipe e ajuste os valores antes de criar o lote.')
+                    ->icon('heroicon-o-users')
+                    ->visible(fn (Get $get): bool => $get('mode') === LancamentoBatchCreator::MODE_REGISTRATIONS)
+                    ->columns([
+                        'default' => 1,
+                        'lg' => 12,
+                    ])
+                    ->schema([
+                        Select::make('registration_type')
+                            ->label('Tipo de inscrição')
+                            ->options(RegistrationPaymentAllocator::registrationTypeOptions())
+                            ->native(false)
+                            ->live()
+                            ->required(fn (Get $get): bool => $get('mode') === LancamentoBatchCreator::MODE_REGISTRATIONS)
+                            ->afterStateUpdated(function (Set $set): void {
+                                $set('registration_ids', []);
+                                $set('registration_items', []);
+                            })
+                            ->columnSpan([
+                                'default' => 'full',
+                                'lg' => 3,
+                            ]),
+
+                        Money::make('default_value')
+                            ->label('Valor padrão')
+                            ->intFormat()
+                            ->prefix(RawJs::make('R$'))
+                            ->live(onBlur: true)
+                            ->afterStateUpdated(function (Get $get, Set $set): void {
+                                $items = collect($get('registration_items') ?? [])
+                                    ->map(fn (array $item): array => [
+                                        ...$item,
+                                        'valor' => $get('default_value'),
+                                    ])
+                                    ->all();
+
+                                $set('registration_items', $items);
+                            })
+                            ->columnSpan([
+                                'default' => 'full',
+                                'lg' => 3,
+                            ]),
+
+                        ModalTableSelect::make('registration_ids')
+                            ->label('Inscrições')
+                            ->placeholder('Nenhuma inscrição selecionada')
+                            ->tableConfiguration(fn (Get $get): string => $get('registration_type') === EquipeTrabalho::class
+                                ? LancamentoBatchEquipeTrabalhoTable::class
+                                : LancamentoBatchCampistasTable::class)
+                            ->getOptionLabelsUsing(fn (Get $get, array $values): array => $this->registrationOptionLabels($get('registration_type'), $values))
+                            ->selectAction(fn (Action $action): Action => $action
+                                ->label('Selecionar inscrições')
+                                ->modalHeading('Selecionar inscrições para o lote')
+                                ->modalSubmitActionLabel('Aplicar seleção')
+                                ->modalWidth(Width::SevenExtraLarge)
+                                ->slideOver(false)
+                                ->icon('heroicon-o-magnifying-glass'))
+                            ->multiple()
+                            ->live()
+                            ->disabled(fn (Get $get): bool => blank($get('registration_type')))
+                            ->required(fn (Get $get): bool => $get('mode') === LancamentoBatchCreator::MODE_REGISTRATIONS)
+                            ->afterStateUpdated(function (Get $get, Set $set, mixed $state): void {
+                                $set('registration_items', $this->registrationItemState(
+                                    $get('registration_type'),
+                                    is_array($state) ? $state : [],
+                                    (int) ($get('default_value') ?? $this->defaultRegistrationAmount()),
+                                ));
+                            })
+                            ->columnSpan([
+                                'default' => 'full',
+                                'lg' => 6,
+                            ]),
+
+                        Html::make(fn (): HtmlString => new HtmlString($this->campAmountWarningHtml()))
+                            ->visible(fn (): bool => $this->campAmountNotConfigured())
+                            ->columnSpanFull(),
+
+                        Repeater::make('registration_items')
+                            ->label('Valores por inscrição')
+                            ->schema([
+                                Hidden::make('registration_id'),
+
+                                TextInput::make('nome')
+                                    ->label('Nome')
+                                    ->required()
+                                    ->columnSpan([
+                                        'default' => 'full',
+                                        'lg' => 5,
+                                    ]),
+
+                                Money::make('valor')
+                                    ->label('Valor')
+                                    ->intFormat()
+                                    ->prefix(RawJs::make('R$'))
+                                    ->required()
+                                    ->columnSpan([
+                                        'default' => 'full',
+                                        'lg' => 3,
+                                    ]),
+
+                                Textarea::make('descricao')
+                                    ->label('Descrição do item')
+                                    ->rows(2)
+                                    ->columnSpan([
+                                        'default' => 'full',
+                                        'lg' => 4,
+                                    ]),
+                            ])
+                            ->columns(12)
+                            ->defaultItems(0)
+                            ->addable(false)
+                            ->deletable(false)
+                            ->reorderable(false)
+                            ->columnSpanFull(),
+                    ])
+                    ->footerActions([
+                        Action::make('createBatch')
+                            ->label('Criar lote pendente')
+                            ->icon('heroicon-o-check-circle')
+                            ->color('primary')
+                            ->action(fn (): mixed => $this->createBatch()),
+                    ])
+                    ->footerActionsAlignment(Alignment::End),
+
+                Section::make('Itens avulsos')
+                    ->description('Crie lançamentos pendentes sem vínculo com inscrições.')
+                    ->icon('heroicon-o-list-bullet')
+                    ->visible(fn (Get $get): bool => $get('mode') === LancamentoBatchCreator::MODE_MANUAL)
+                    ->columns([
+                        'default' => 1,
+                        'lg' => 12,
+                    ])
+                    ->schema([
+                        ToggleButtons::make('tipo')
+                            ->label('Tipo')
+                            ->options(TipoLacamento::class)
+                            ->inline()
+                            ->live()
+                            ->required(fn (Get $get): bool => $get('mode') === LancamentoBatchCreator::MODE_MANUAL)
+                            ->afterStateUpdated(function (Set $set): void {
+                                $set('categoria_lancamento_id', null);
+                                $set('manual_items', [$this->blankManualItem()]);
+                            })
+                            ->columnSpan([
+                                'default' => 'full',
+                                'lg' => 4,
+                            ]),
+
+                        Select::make('categoria_lancamento_id')
+                            ->label('Categoria padrão')
+                            ->options(fn (Get $get): array => LancamentoForm::categoryOptions($get('tipo')))
+                            ->allowHtml()
+                            ->searchable()
+                            ->preload()
+                            ->live()
+                            ->required(fn (Get $get): bool => $get('mode') === LancamentoBatchCreator::MODE_MANUAL)
+                            ->afterStateUpdated(function (Get $get, Set $set): void {
+                                $items = collect($get('manual_items') ?? [])
+                                    ->map(fn (array $item): array => [
+                                        ...$item,
+                                        'categoria_lancamento_id' => $get('categoria_lancamento_id'),
+                                    ])
+                                    ->all();
+
+                                $set('manual_items', $items);
+                            })
+                            ->columnSpan([
+                                'default' => 'full',
+                                'lg' => 4,
+                            ]),
+
+                        Money::make('manual_default_value')
+                            ->label('Valor padrão avulso')
+                            ->intFormat()
+                            ->prefix(RawJs::make('R$'))
+                            ->live(onBlur: true)
+                            ->afterStateUpdated(function (Get $get, Set $set): void {
+                                $items = collect($get('manual_items') ?? [])
+                                    ->map(fn (array $item): array => [
+                                        ...$item,
+                                        'valor' => $get('manual_default_value'),
+                                    ])
+                                    ->all();
+
+                                $set('manual_items', $items);
+                            })
+                            ->columnSpan([
+                                'default' => 'full',
+                                'lg' => 4,
+                            ]),
+
+                        Repeater::make('manual_items')
+                            ->label('Lançamentos')
+                            ->schema([
+                                TextInput::make('nome')
+                                    ->label('Nome')
+                                    ->required()
+                                    ->maxLength(255)
+                                    ->columnSpan([
+                                        'default' => 'full',
+                                        'lg' => 4,
+                                    ]),
+
+                                Money::make('valor')
+                                    ->label('Valor')
+                                    ->intFormat()
+                                    ->prefix(RawJs::make('R$'))
+                                    ->required()
+                                    ->columnSpan([
+                                        'default' => 'full',
+                                        'lg' => 2,
+                                    ]),
+
+                                Select::make('categoria_lancamento_id')
+                                    ->label('Categoria')
+                                    ->options(fn (Get $get): array => LancamentoForm::categoryOptions($get('../../tipo')))
+                                    ->allowHtml()
+                                    ->searchable()
+                                    ->preload()
+                                    ->required()
+                                    ->columnSpan([
+                                        'default' => 'full',
+                                        'lg' => 3,
+                                    ]),
+
+                                Textarea::make('descricao')
+                                    ->label('Descrição')
+                                    ->rows(2)
+                                    ->columnSpan([
+                                        'default' => 'full',
+                                        'lg' => 3,
+                                    ]),
+                            ])
+                            ->columns(12)
+                            ->defaultItems(1)
+                            ->minItems(1)
+                            ->addActionLabel('Adicionar lançamento')
+                            ->reorderable(false)
+                            ->columnSpanFull(),
+                    ])
+                    ->footerActions([
+                        Action::make('createBatch')
+                            ->label('Criar lote pendente')
+                            ->icon('heroicon-o-check-circle')
+                            ->color('primary')
+                            ->action(fn (): mixed => $this->createBatch()),
+                    ])
+                    ->footerActionsAlignment(Alignment::End),
+
+                Section::make('Resumo')
+                    ->description('Todos os lançamentos serão criados como pendentes e sem comprovantes.')
+                    ->icon('heroicon-o-clipboard-document-check')
+                    ->schema([
+                        Html::make(fn (Get $get): HtmlString => new HtmlString($this->summaryHtml($get))),
+                    ]),
+            ]);
+    }
+
+    public function createBatch(): void
+    {
+        $data = $this->form->getState();
+
+        if (($data['mode'] ?? null) === LancamentoBatchCreator::MODE_MANUAL) {
+            $data['default_value'] = $data['manual_default_value'] ?? null;
+        }
+
+        $created = app(LancamentoBatchCreator::class)->create($data);
+        $batchCode = $created->first()?->batch_code;
+
+        Notification::make()
+            ->title('Lote financeiro criado')
+            ->body(sprintf('%s lançamento(s) pendente(s)%s.', $created->count(), $batchCode ? ' no lote '.$batchCode : ''))
+            ->success()
+            ->send();
+
+        $this->form->fill($this->defaultFormData());
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function defaultFormData(): array
+    {
+        return [
+            'mode' => LancamentoBatchCreator::MODE_REGISTRATIONS,
+            'registration_type' => Campista::class,
+            'registration_ids' => [],
+            'registration_items' => [],
+            'default_value' => $this->defaultRegistrationAmount(),
+            'tipo' => TipoLacamento::Receita->value,
+            'categoria_lancamento_id' => null,
+            'manual_default_value' => 0,
+            'manual_items' => [$this->blankManualItem()],
+            'data' => now()->toDateString(),
+            'descricao' => null,
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function blankManualItem(): array
+    {
+        return [
+            'nome' => null,
+            'valor' => null,
+            'categoria_lancamento_id' => null,
+            'descricao' => null,
+        ];
+    }
+
+    /**
+     * @param  array<int, mixed>  $ids
+     * @return array<int, array<string, mixed>>
+     */
+    private function registrationItemState(?string $registrationType, array $ids, int $amount): array
+    {
+        if (! is_string($registrationType) || ! array_key_exists($registrationType, RegistrationPaymentAllocator::registrationTypeOptions())) {
+            return [];
+        }
+
+        /** @var class-string<Model> $registrationType */
+        return collect($ids)
+            ->map(fn (mixed $id): int => (int) $id)
+            ->filter()
+            ->unique()
+            ->map(function (int $id) use ($registrationType, $amount): ?array {
+                $registration = $registrationType::query()->find($id);
+
+                if (! $registration) {
+                    return null;
+                }
+
+                return [
+                    'registration_id' => $id,
+                    'nome' => (string) ($registration->getAttribute('nome') ?? 'Inscrição #'.$id),
+                    'valor' => $amount,
+                    'descricao' => null,
+                ];
+            })
+            ->filter()
+            ->values()
+            ->all();
+    }
+
+    /**
+     * @param  array<int, mixed>  $values
+     * @return array<int, string>
+     */
+    private function registrationOptionLabels(?string $registrationType, array $values): array
+    {
+        $options = app(LancamentoBatchCreator::class)->registrationOptions($registrationType);
+
+        return collect($values)
+            ->map(fn (mixed $id): int => (int) $id)
+            ->filter()
+            ->unique()
+            ->mapWithKeys(fn (int $id): array => array_key_exists($id, $options) ? [$id => $options[$id]] : [])
+            ->all();
+    }
+
+    private function defaultRegistrationAmount(): int
+    {
+        return (int) (app(GeneralSettings::class)->valor_acampamento ?? 0);
+    }
+
+    private function campAmountNotConfigured(): bool
+    {
+        return $this->defaultRegistrationAmount() <= 0;
+    }
+
+    private function campAmountWarningHtml(): string
+    {
+        return '<div role="alert" class="rounded-lg border border-warning-500/55 bg-warning-500/10 p-4 text-sm text-warning-100">'
+            .'<strong class="block text-warning-300">Valor do acampamento não configurado</strong>'
+            .'<span>O campo de inscrições pode ficar sem opções enquanto o valor estiver zerado nas configurações.</span>'
+            .'</div>';
+    }
+
+    private function summaryHtml(Get $get): string
+    {
+        $mode = $get('mode');
+        $count = $mode === LancamentoBatchCreator::MODE_MANUAL
+            ? collect($get('manual_items') ?? [])->filter(fn (array $item): bool => filled($item['nome'] ?? null))->count()
+            : count($get('registration_items') ?? []);
+
+        $nextCode = app(LancamentoBatchCreator::class)->nextBatchCode();
+        $label = $mode === LancamentoBatchCreator::MODE_MANUAL ? 'lançamento(s) avulso(s)' : 'lançamento(s) vinculado(s)';
+
+        return '<div class="rounded-lg border border-primary-500/35 bg-primary-500/10 p-4 text-sm text-primary-100">'
+            .'<strong class="block text-primary-300">'.e($nextCode).'</strong>'
+            .'<span>'.e((string) $count).' '.e($label).' serão criados como pendentes.</span>'
+            .'</div>';
+    }
+}

--- a/app/Filament/Resources/LancamentoResource/Pages/CreateLancamento.php
+++ b/app/Filament/Resources/LancamentoResource/Pages/CreateLancamento.php
@@ -2,7 +2,6 @@
 
 namespace App\Filament\Resources\LancamentoResource\Pages;
 
-use App\Enums\TipoLacamento;
 use App\Filament\Resources\LancamentoResource;
 use App\Filament\Resources\LancamentoResource\Forms\LancamentoForm;
 use App\Models\Lancamento;
@@ -16,20 +15,20 @@ class CreateLancamento extends CreateRecord
     /**
      * @var array<int, array<string, mixed>>
      */
-    private array $registrationPaymentData = [];
+    private array $itemData = [];
 
     public function mutateFormDataBeforeCreate(array $data): array
     {
-        $this->registrationPaymentData = $data['registration_payments'] ?? [];
-        unset($data['registration_payments']);
+        $this->itemData = $data['items'] ?? [];
+        unset($data['items']);
 
         $data = LancamentoForm::normalizeCompradorForType($data);
-        $data['valor'] = self::signedValue($data);
+        $data['valor'] = app(RegistrationPaymentAllocator::class)->signedTotalForItems($data['tipo'] ?? null, $this->itemData);
         $data['comprovante'] = LancamentoForm::normalizeComprovanteState($data['comprovante'] ?? null);
 
-        app(RegistrationPaymentAllocator::class)->validateAllocations(
+        app(RegistrationPaymentAllocator::class)->validateItems(
             new Lancamento($data),
-            $this->registrationPaymentData,
+            $this->itemData,
         );
 
         return parent::mutateFormDataBeforeCreate($data);
@@ -37,18 +36,6 @@ class CreateLancamento extends CreateRecord
 
     protected function afterCreate(): void
     {
-        app(RegistrationPaymentAllocator::class)->sync($this->record, $this->registrationPaymentData);
-    }
-
-    private static function signedValue(array $data): int
-    {
-        $value = (int) ($data['valor'] ?? 0);
-        $type = $data['tipo'] ?? null;
-
-        if (($type == TipoLacamento::Despesa->value && $value > 0) || ($type != TipoLacamento::Despesa->value && $value < 0)) {
-            return $value * -1;
-        }
-
-        return $value;
+        app(RegistrationPaymentAllocator::class)->syncItems($this->record, $this->itemData);
     }
 }

--- a/app/Filament/Resources/LancamentoResource/Pages/EditLancamento.php
+++ b/app/Filament/Resources/LancamentoResource/Pages/EditLancamento.php
@@ -2,7 +2,6 @@
 
 namespace App\Filament\Resources\LancamentoResource\Pages;
 
-use App\Enums\TipoLacamento;
 use App\Filament\Resources\LancamentoResource;
 use App\Filament\Resources\LancamentoResource\Forms\LancamentoForm;
 use App\Support\Financeiro\RegistrationPaymentAllocator;
@@ -16,7 +15,7 @@ class EditLancamento extends EditRecord
     /**
      * @var array<int, array<string, mixed>>
      */
-    private array $registrationPaymentData = [];
+    private array $itemData = [];
 
     protected function getHeaderActions(): array
     {
@@ -28,25 +27,25 @@ class EditLancamento extends EditRecord
     protected function mutateFormDataBeforeFill(array $data): array
     {
         $data['comprovante'] = LancamentoForm::comprovanteRepeaterFormState($data['comprovante'] ?? null);
-        $data['registration_payments'] = LancamentoForm::registrationPaymentsFormState($this->record);
+        $data['items'] = LancamentoForm::itemsFormState($this->record);
 
         return parent::mutateFormDataBeforeFill($data);
     }
 
     public function mutateFormDataBeforeSave(array $data): array
     {
-        $this->registrationPaymentData = $data['registration_payments'] ?? [];
-        unset($data['registration_payments']);
+        $this->itemData = $data['items'] ?? [];
+        unset($data['items']);
 
         $data = LancamentoForm::normalizeCompradorForType($data);
-        $data['valor'] = self::signedValue($data);
+        $data['valor'] = app(RegistrationPaymentAllocator::class)->signedTotalForItems($data['tipo'] ?? null, $this->itemData);
         $data['comprovante'] = LancamentoForm::normalizeComprovanteState($data['comprovante'] ?? null);
 
         $this->record->forceFill($data);
 
-        app(RegistrationPaymentAllocator::class)->validateAllocations(
+        app(RegistrationPaymentAllocator::class)->validateItems(
             $this->record,
-            $this->registrationPaymentData,
+            $this->itemData,
         );
 
         return parent::mutateFormDataBeforeSave($data);
@@ -54,18 +53,6 @@ class EditLancamento extends EditRecord
 
     protected function afterSave(): void
     {
-        app(RegistrationPaymentAllocator::class)->sync($this->record, $this->registrationPaymentData);
-    }
-
-    private static function signedValue(array $data): int
-    {
-        $value = (int) ($data['valor'] ?? 0);
-        $type = $data['tipo'] ?? null;
-
-        if (($type == TipoLacamento::Despesa->value && $value > 0) || ($type != TipoLacamento::Despesa->value && $value < 0)) {
-            return $value * -1;
-        }
-
-        return $value;
+        app(RegistrationPaymentAllocator::class)->syncItems($this->record, $this->itemData);
     }
 }

--- a/app/Filament/Resources/LancamentoResource/Pages/ListLancamentos.php
+++ b/app/Filament/Resources/LancamentoResource/Pages/ListLancamentos.php
@@ -13,6 +13,12 @@ class ListLancamentos extends ListRecords
     protected function getHeaderActions(): array
     {
         return [
+            Actions\Action::make('batch')
+                ->label('Lançamento em lote')
+                ->icon('heroicon-o-queue-list')
+                ->color('gray')
+                ->url(LancamentoResource::getUrl('batch'))
+                ->visible(fn (): bool => LancamentoResource::canCreate()),
             Actions\CreateAction::make(),
         ];
     }

--- a/app/Filament/Resources/LancamentoResource/Tables/LancamentoBatchCampistasTable.php
+++ b/app/Filament/Resources/LancamentoResource/Tables/LancamentoBatchCampistasTable.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Filament\Resources\LancamentoResource\Tables;
+
+use App\Filament\Resources\CampistaResource\CampistaTable;
+use App\Models\Campista;
+use App\Support\Financeiro\LancamentoBatchCreator;
+use Filament\Tables\Table;
+use Illuminate\Database\Eloquent\Builder;
+
+class LancamentoBatchCampistasTable
+{
+    public static function configure(Table $table): Table
+    {
+        return $table
+            ->query(fn (): Builder => Campista::query()
+                ->whereKey(array_keys(app(LancamentoBatchCreator::class)->registrationOptions(Campista::class))))
+            ->columns(CampistaTable::getListTableColumns())
+            ->defaultSort('id', 'desc')
+            ->paginationPageOptions([5, 10, 30, 50])
+            ->extremePaginationLinks()
+            ->striped();
+    }
+}

--- a/app/Filament/Resources/LancamentoResource/Tables/LancamentoBatchEquipeTrabalhoTable.php
+++ b/app/Filament/Resources/LancamentoResource/Tables/LancamentoBatchEquipeTrabalhoTable.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Filament\Resources\LancamentoResource\Tables;
+
+use App\Filament\Resources\EquipeTrabalhoResource\EquipeTrabalhoTable;
+use App\Models\EquipeTrabalho;
+use App\Support\Financeiro\LancamentoBatchCreator;
+use Filament\Tables\Table;
+use Illuminate\Database\Eloquent\Builder;
+
+class LancamentoBatchEquipeTrabalhoTable
+{
+    public static function configure(Table $table): Table
+    {
+        return $table
+            ->query(fn (): Builder => EquipeTrabalho::query()
+                ->whereKey(array_keys(app(LancamentoBatchCreator::class)->registrationOptions(EquipeTrabalho::class))))
+            ->columns(EquipeTrabalhoTable::getColumns())
+            ->defaultSort('id', 'desc')
+            ->paginationPageOptions([5, 10, 30, 50])
+            ->extremePaginationLinks()
+            ->striped();
+    }
+}

--- a/app/Filament/Widgets/Financial/RecentFinancialEntriesTable.php
+++ b/app/Filament/Widgets/Financial/RecentFinancialEntriesTable.php
@@ -47,8 +47,8 @@ class RecentFinancialEntriesTable extends TableWidget
                     ->label('Tipo')
                     ->badge()
                     ->alignCenter(),
-                TextColumn::make('categoria.nome')
-                    ->label('Categoria')
+                TextColumn::make('categories_summary')
+                    ->label('Categorias')
                     ->placeholder('Sem categoria')
                     ->badge(),
                 TextColumn::make('status')

--- a/app/Livewire/CampistaForm.php
+++ b/app/Livewire/CampistaForm.php
@@ -6,6 +6,7 @@ use App\Models\Campista;
 use App\Models\User;
 use App\Settings\GeneralSettings;
 use App\Support\CampistaRegistrationAvailability;
+use App\Support\FilamentUploadState;
 use App\Support\RegistrationAgeLimits;
 use Filament\Actions\Concerns\InteractsWithActions;
 use Filament\Actions\Contracts\HasActions;
@@ -694,7 +695,7 @@ class CampistaForm extends Component implements HasActions, HasForms
 
             $this->data = Arr::only($this->data, ['nome', 'avatar_url', 'form_data']);
 
-            $this->data['avatar_url'] = $this->data['avatar_url'][array_key_first($this->data['avatar_url'])]->store('foto-formulario', 'public');
+            $this->data['avatar_url'] = FilamentUploadState::storedPath($this->data['avatar_url'] ?? null, 'foto-formulario');
 
             $campista = Campista::create($this->data);
 

--- a/app/Livewire/EquipeTrabalhoForm.php
+++ b/app/Livewire/EquipeTrabalhoForm.php
@@ -5,6 +5,7 @@ namespace App\Livewire;
 use App\Models\EquipeTrabalho;
 use App\Models\User;
 use App\Settings\GeneralSettings;
+use App\Support\FilamentUploadState;
 use Filament\Actions\Concerns\InteractsWithActions;
 use Filament\Actions\Contracts\HasActions;
 use Filament\Forms\Concerns\InteractsWithForms;
@@ -57,7 +58,7 @@ class EquipeTrabalhoForm extends Component implements HasActions, HasForms
 
             $this->data = Arr::only($this->data, ['nome', 'avatar_url', 'data_form']);
 
-            $this->data['avatar_url'] = $this->data['avatar_url'][array_key_first($this->data['avatar_url'])]->store('foto-formulario-equipe-trabalho', 'public');
+            $this->data['avatar_url'] = FilamentUploadState::storedPath($this->data['avatar_url'] ?? null, 'foto-formulario-equipe-trabalho');
 
             $voluntario = EquipeTrabalho::create($this->data);
 

--- a/app/Models/Campista.php
+++ b/app/Models/Campista.php
@@ -41,8 +41,8 @@ class Campista extends Model implements Auditable
         return $this->belongsTo(Tribo::class);
     }
 
-    public function financialEntryRegistrations(): MorphMany
+    public function lancamentoItems(): MorphMany
     {
-        return $this->morphMany(FinancialEntryRegistration::class, 'registration');
+        return $this->morphMany(LancamentoItem::class, 'registration');
     }
 }

--- a/app/Models/CategoriaLancamento.php
+++ b/app/Models/CategoriaLancamento.php
@@ -5,6 +5,7 @@ namespace App\Models;
 use App\Enums\TipoLacamento;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 
 class CategoriaLancamento extends Model
@@ -48,9 +49,19 @@ class CategoriaLancamento extends Model
         static::deleting(fn (CategoriaLancamento $categoriaLancamento): bool => ! $categoriaLancamento->isSystemDefault());
     }
 
-    public function lancamentos(): HasMany
+    public function items(): HasMany
     {
-        return $this->hasMany(Lancamento::class, 'categoria_lancamento_id');
+        return $this->hasMany(LancamentoItem::class, 'categoria_lancamento_id');
+    }
+
+    public function lancamentos(): BelongsToMany
+    {
+        return $this->belongsToMany(
+            Lancamento::class,
+            'lancamento_items',
+            'categoria_lancamento_id',
+            'lancamento_id',
+        )->distinct();
     }
 
     public function isSystemDefault(): bool

--- a/app/Models/EquipeTrabalho.php
+++ b/app/Models/EquipeTrabalho.php
@@ -28,8 +28,8 @@ class EquipeTrabalho extends Model implements Auditable
         'status' => StatusInscricaoEquipeTrabalho::class,
     ];
 
-    public function financialEntryRegistrations(): MorphMany
+    public function lancamentoItems(): MorphMany
     {
-        return $this->morphMany(FinancialEntryRegistration::class, 'registration');
+        return $this->morphMany(LancamentoItem::class, 'registration');
     }
 }

--- a/app/Models/Lancamento.php
+++ b/app/Models/Lancamento.php
@@ -7,7 +7,7 @@ use App\Enums\StatusLacamento;
 use App\Enums\TipoLacamento;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
-use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 
 class Lancamento extends Model
@@ -21,10 +21,10 @@ class Lancamento extends Model
         'data',
         'valor',
         'tipo',
-        'categoria_lancamento_id',
         'status',
         'forma_pagamento',
         'comprovante',
+        'batch_code',
         'user_id',
     ];
 
@@ -36,40 +36,64 @@ class Lancamento extends Model
         'valor' => 'integer',
     ];
 
-    public function categoria(): BelongsTo
+    public function items(): HasMany
     {
-        return $this->belongsTo(CategoriaLancamento::class, 'categoria_lancamento_id');
+        return $this->hasMany(LancamentoItem::class);
     }
 
-    public function registrationPayments(): HasMany
+    public function categories(): BelongsToMany
     {
-        return $this->hasMany(FinancialEntryRegistration::class, 'lancamento_id');
+        return $this->belongsToMany(
+            CategoriaLancamento::class,
+            'lancamento_items',
+            'lancamento_id',
+            'categoria_lancamento_id',
+        )->distinct();
     }
 
     public function getRegistrationPaymentsSummaryAttribute(): string
     {
-        $payments = $this->relationLoaded('registrationPayments')
-            ? $this->registrationPayments
-            : $this->registrationPayments()->with('registration')->get();
+        $items = $this->relationLoaded('items')
+            ? $this->items
+            : $this->items()->with('registration')->get();
 
-        if ($payments->isEmpty()) {
+        $registrationItems = $items->filter(fn (LancamentoItem $item): bool => filled($item->registration_type) && filled($item->registration_id));
+
+        if ($registrationItems->isEmpty()) {
             return 'Sem inscrições vinculadas';
         }
 
-        return $payments
-            ->map(function (FinancialEntryRegistration $payment): string {
-                $registration = $payment->registration;
+        return $registrationItems
+            ->map(function (LancamentoItem $item): string {
+                $registration = $item->registration;
                 $type = $registration instanceof Campista ? 'Campista' : 'Equipe';
                 $name = (string) ($registration?->getAttribute('nome') ?? 'Inscrição removida');
 
                 return sprintf(
                     '%s #%s - %s (%s)',
                     $type,
-                    $payment->registration_id,
+                    $item->registration_id,
                     $name,
-                    'R$ '.number_format($payment->amount / 100, 2, ',', '.'),
+                    'R$ '.number_format($item->valor / 100, 2, ',', '.'),
                 );
             })
             ->implode("\n");
+    }
+
+    public function getCategoriesSummaryAttribute(): string
+    {
+        $items = $this->relationLoaded('items')
+            ? $this->items
+            : $this->items()->with('categoria')->get();
+
+        $categories = $items
+            ->map(fn (LancamentoItem $item): ?string => $item->categoria?->nome)
+            ->filter()
+            ->unique()
+            ->values();
+
+        return $categories->isEmpty()
+            ? 'Sem categoria'
+            : $categories->implode(', ');
     }
 }

--- a/app/Models/LancamentoItem.php
+++ b/app/Models/LancamentoItem.php
@@ -2,26 +2,36 @@
 
 namespace App\Models;
 
+use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\MorphTo;
 
-class FinancialEntryRegistration extends Model
+class LancamentoItem extends Model
 {
+    use HasFactory;
+
     protected $fillable = [
-        'lancamento_id',
+        'nome',
+        'descricao',
+        'valor',
+        'categoria_lancamento_id',
         'registration_type',
         'registration_id',
-        'amount',
     ];
 
     protected $casts = [
-        'amount' => 'integer',
+        'valor' => 'integer',
     ];
 
     public function lancamento(): BelongsTo
     {
-        return $this->belongsTo(Lancamento::class, 'lancamento_id');
+        return $this->belongsTo(Lancamento::class);
+    }
+
+    public function categoria(): BelongsTo
+    {
+        return $this->belongsTo(CategoriaLancamento::class, 'categoria_lancamento_id');
     }
 
     public function registration(): MorphTo

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -2,10 +2,12 @@
 
 namespace App\Providers;
 
+use App\Support\Livewire\FilamentNotificationsWireableSynth;
 use Filament\Support\Colors\Color;
 use Filament\Support\Facades\FilamentColor;
 use Filament\Tables\Table;
 use Illuminate\Support\ServiceProvider;
+use Livewire\Livewire;
 
 class AppServiceProvider extends ServiceProvider
 {
@@ -29,5 +31,7 @@ class AppServiceProvider extends ServiceProvider
         Table::configureUsing(function (Table $table): void {
             $table->deferColumnManager(false);
         });
+
+        Livewire::propertySynthesizer(FilamentNotificationsWireableSynth::class);
     }
 }

--- a/app/Support/Dashboard/FinancialDashboardData.php
+++ b/app/Support/Dashboard/FinancialDashboardData.php
@@ -4,6 +4,7 @@ namespace App\Support\Dashboard;
 
 use App\Enums\TipoLacamento;
 use App\Models\Lancamento;
+use App\Models\LancamentoItem;
 use Carbon\Carbon;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Support\Collection;
@@ -14,6 +15,7 @@ class FinancialDashboardData
     {
         return new FinancialDashboardDataSet(
             records: $this->records($filters),
+            categoryIds: FinancialDashboardFilters::categoryIds($filters),
         );
     }
 
@@ -27,12 +29,12 @@ class FinancialDashboardData
         $paymentMethods = FinancialDashboardFilters::paymentMethodValues($filters);
 
         return Lancamento::query()
-            ->with('categoria')
+            ->with('items.categoria')
             ->when($startDate !== null, fn (Builder $query): Builder => $query->where('data', '>=', $startDate))
             ->when($endDate !== null, fn (Builder $query): Builder => $query->where('data', '<=', $endDate))
             ->when($statuses !== [], fn (Builder $query): Builder => $query->whereIn('status', $statuses))
             ->when($types !== [], fn (Builder $query): Builder => $query->whereIn('tipo', $types))
-            ->when($categoryIds !== [], fn (Builder $query): Builder => $query->whereIn('categoria_lancamento_id', $categoryIds))
+            ->when($categoryIds !== [], fn (Builder $query): Builder => $query->whereHas('items', fn (Builder $query): Builder => $query->whereIn('categoria_lancamento_id', $categoryIds)))
             ->when($paymentMethods !== [], fn (Builder $query): Builder => $query->whereIn('forma_pagamento', $paymentMethods));
     }
 
@@ -49,6 +51,7 @@ class FinancialDashboardDataSet
 {
     public function __construct(
         private readonly Collection $records,
+        private readonly array $categoryIds = [],
     ) {}
 
     public function summary(): array
@@ -80,8 +83,9 @@ class FinancialDashboardDataSet
     public function categoryTotals(int $limit = 10): array
     {
         return $this->records
-            ->groupBy(fn (Lancamento $lancamento): string => $lancamento->categoria?->nome ?: 'Sem categoria')
-            ->map(fn (Collection $records): int => $records->sum(fn (Lancamento $lancamento): int => $this->amount($lancamento)))
+            ->flatMap(fn (Lancamento $lancamento): Collection => $this->categoryItems($lancamento))
+            ->groupBy(fn (LancamentoItem $item): string => $item->categoria?->nome ?: 'Sem categoria')
+            ->map(fn (Collection $items): int => $items->sum(fn (LancamentoItem $item): int => abs((int) $item->valor)))
             ->sortDesc()
             ->take($limit)
             ->all();
@@ -122,7 +126,27 @@ class FinancialDashboardDataSet
 
     private function amount(Lancamento $lancamento): int
     {
+        if ($this->categoryIds !== []) {
+            return $this->categoryItems($lancamento)
+                ->sum(fn (LancamentoItem $item): int => abs((int) $item->valor));
+        }
+
         return abs((int) $lancamento->valor);
+    }
+
+    private function categoryItems(Lancamento $lancamento): Collection
+    {
+        $items = $lancamento->relationLoaded('items')
+            ? $lancamento->items
+            : $lancamento->items()->with('categoria')->get();
+
+        if ($this->categoryIds === []) {
+            return $items;
+        }
+
+        return $items
+            ->filter(fn (LancamentoItem $item): bool => in_array((int) $item->categoria_lancamento_id, $this->categoryIds, true))
+            ->values();
     }
 
     private function dateKey(Lancamento $lancamento): string

--- a/app/Support/FilamentUploadState.php
+++ b/app/Support/FilamentUploadState.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace App\Support;
+
+use Illuminate\Http\UploadedFile;
+
+final class FilamentUploadState
+{
+    public static function storedPath(mixed $state, string $directory, string $disk = 'public'): ?string
+    {
+        $file = self::firstValue($state);
+
+        if (is_string($file)) {
+            return $file;
+        }
+
+        if ($file instanceof UploadedFile || (is_object($file) && method_exists($file, 'store'))) {
+            $path = $file->store($directory, $disk);
+
+            return is_string($path) ? $path : null;
+        }
+
+        return null;
+    }
+
+    private static function firstValue(mixed $state): mixed
+    {
+        if (! is_array($state)) {
+            return $state;
+        }
+
+        if ($state === []) {
+            return null;
+        }
+
+        return $state[array_key_first($state)];
+    }
+}

--- a/app/Support/Financeiro/LancamentoBatchCreator.php
+++ b/app/Support/Financeiro/LancamentoBatchCreator.php
@@ -1,0 +1,285 @@
+<?php
+
+namespace App\Support\Financeiro;
+
+use App\Enums\FormaPagamento;
+use App\Enums\StatusLacamento;
+use App\Enums\TipoLacamento;
+use App\Models\Campista;
+use App\Models\CategoriaLancamento;
+use App\Models\EquipeTrabalho;
+use App\Models\Lancamento;
+use App\Settings\GeneralSettings;
+use Carbon\CarbonInterface;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Validation\ValidationException;
+
+class LancamentoBatchCreator
+{
+    public const MODE_REGISTRATIONS = 'registrations';
+
+    public const MODE_MANUAL = 'manual';
+
+    public function __construct(
+        private readonly RegistrationPaymentAllocator $allocator,
+    ) {}
+
+    public function nextBatchCode(?CarbonInterface $date = null): string
+    {
+        $prefix = 'LOTE-'.($date ?? now())->format('Ymd');
+
+        $lastSequence = Lancamento::query()
+            ->where('batch_code', 'like', $prefix.'-%')
+            ->pluck('batch_code')
+            ->map(fn (?string $code): int => (int) substr((string) $code, -3))
+            ->max() ?? 0;
+
+        return sprintf('%s-%03d', $prefix, $lastSequence + 1);
+    }
+
+    /**
+     * @return array<int, string>
+     */
+    public function registrationOptions(?string $registrationType, ?string $search = null): array
+    {
+        return filled($search)
+            ? $this->allocator->registrationSearchResults($registrationType, $search)
+            : $this->allocator->registrationOptions($registrationType);
+    }
+
+    /**
+     * @return Collection<int, Lancamento>
+     */
+    public function create(array $data): Collection
+    {
+        return DB::transaction(function () use ($data): Collection {
+            $mode = $data['mode'] ?? self::MODE_REGISTRATIONS;
+            $batchCode = $this->nextBatchCode();
+
+            return match ($mode) {
+                self::MODE_MANUAL => $this->createManualBatch($data, $batchCode),
+                default => $this->createRegistrationBatch($data, $batchCode),
+            };
+        });
+    }
+
+    /**
+     * @return Collection<int, Lancamento>
+     */
+    private function createRegistrationBatch(array $data, string $batchCode): Collection
+    {
+        $registrationType = $data['registration_type'] ?? Campista::class;
+
+        if (! array_key_exists($registrationType, RegistrationPaymentAllocator::registrationTypeOptions())) {
+            throw ValidationException::withMessages([
+                'registration_type' => 'Selecione um tipo de inscrição válido.',
+            ]);
+        }
+
+        /** @var class-string<Model> $registrationType */
+        $rows = $this->registrationRows($data, $registrationType);
+
+        if ($rows === []) {
+            throw ValidationException::withMessages([
+                'registration_ids' => 'Selecione pelo menos uma inscrição para o lote.',
+            ]);
+        }
+
+        $category = $this->allocator->categoryForRegistrationType($registrationType);
+
+        if (! $category) {
+            throw ValidationException::withMessages([
+                'registration_type' => 'A categoria padrão desse tipo de inscrição não foi encontrada.',
+            ]);
+        }
+
+        $availableIds = array_keys($this->registrationOptions($registrationType));
+        $selectedIds = collect($rows)->pluck('registration_id')->unique()->values()->all();
+        $invalidIds = array_values(array_diff($selectedIds, $availableIds));
+
+        if ($invalidIds !== []) {
+            throw ValidationException::withMessages([
+                'registration_ids' => 'Remova inscrições canceladas ou já vinculadas antes de criar o lote.',
+            ]);
+        }
+
+        return collect($rows)->map(function (array $row) use ($registrationType, $category, $data, $batchCode): Lancamento {
+            $registration = $registrationType::query()->findOrFail($row['registration_id']);
+            $name = $this->rowName($row, $registration);
+
+            $lancamento = Lancamento::query()->create([
+                'nome' => $this->registrationLaunchName($registration, $name),
+                'descricao' => $this->nullableText($row['descricao'] ?? $data['descricao'] ?? null),
+                'comprador' => null,
+                'data' => $data['data'] ?? now()->toDateString(),
+                'valor' => 0,
+                'tipo' => TipoLacamento::Receita,
+                'status' => StatusLacamento::Pendente,
+                'forma_pagamento' => FormaPagamento::NaoPago,
+                'comprovante' => [],
+                'batch_code' => $batchCode,
+                'user_id' => auth()->id(),
+            ]);
+
+            $this->allocator->syncItems($lancamento, [[
+                'nome' => $name,
+                'descricao' => $this->nullableText($row['descricao'] ?? null),
+                'valor' => $this->amount($row['valor'] ?? $data['default_value'] ?? $this->defaultRegistrationAmount()),
+                'categoria_lancamento_id' => $category->id,
+                'registration_type' => $registrationType,
+                'registration_id' => $registration->getKey(),
+            ]]);
+
+            return $lancamento->fresh(['items']);
+        });
+    }
+
+    /**
+     * @return Collection<int, Lancamento>
+     */
+    private function createManualBatch(array $data, string $batchCode): Collection
+    {
+        $type = TipoLacamento::from((int) ($data['tipo'] ?? TipoLacamento::Receita->value));
+        $items = $this->manualRows($data);
+
+        if ($items === []) {
+            throw ValidationException::withMessages([
+                'manual_items' => 'Informe pelo menos um item avulso para o lote.',
+            ]);
+        }
+
+        return collect($items)->map(function (array $item) use ($type, $data, $batchCode): Lancamento {
+            $lancamento = Lancamento::query()->create([
+                'nome' => $this->nullableText($item['nome'] ?? null) ?? 'Lançamento avulso',
+                'descricao' => $this->nullableText($item['descricao'] ?? $data['descricao'] ?? null),
+                'comprador' => $type === TipoLacamento::Despesa ? $this->nullableText($item['comprador'] ?? $data['comprador'] ?? 'Lote financeiro') : null,
+                'data' => $data['data'] ?? now()->toDateString(),
+                'valor' => 0,
+                'tipo' => $type,
+                'status' => StatusLacamento::Pendente,
+                'forma_pagamento' => FormaPagamento::NaoPago,
+                'comprovante' => [],
+                'batch_code' => $batchCode,
+                'user_id' => auth()->id(),
+            ]);
+
+            $this->allocator->syncItems($lancamento, [[
+                'nome' => $lancamento->nome,
+                'descricao' => $this->nullableText($item['descricao'] ?? null),
+                'valor' => $this->amount($item['valor'] ?? $data['default_value'] ?? 0),
+                'categoria_lancamento_id' => (int) ($item['categoria_lancamento_id'] ?? $data['categoria_lancamento_id'] ?? 0),
+                'registration_type' => null,
+                'registration_id' => null,
+            ]]);
+
+            return $lancamento->fresh(['items']);
+        });
+    }
+
+    /**
+     * @param  class-string<Model>  $registrationType
+     * @return array<int, array{registration_id: int, nome: ?string, valor: int, descricao: ?string}>
+     */
+    private function registrationRows(array $data, string $registrationType): array
+    {
+        $selectedIds = collect($data['registration_ids'] ?? [])
+            ->map(fn (mixed $id): int => (int) $id)
+            ->filter()
+            ->unique()
+            ->values();
+
+        $rows = collect($data['registration_items'] ?? [])
+            ->map(function (array $row) use ($data): array {
+                return [
+                    'registration_id' => (int) ($row['registration_id'] ?? 0),
+                    'nome' => $this->nullableText($row['nome'] ?? null),
+                    'valor' => $this->amount($row['valor'] ?? $data['default_value'] ?? $this->defaultRegistrationAmount()),
+                    'descricao' => $this->nullableText($row['descricao'] ?? null),
+                ];
+            })
+            ->filter(fn (array $row): bool => $row['registration_id'] > 0)
+            ->values();
+
+        if ($rows->isEmpty()) {
+            $rows = $selectedIds->map(fn (int $id): array => [
+                'registration_id' => $id,
+                'nome' => null,
+                'valor' => $this->amount($data['default_value'] ?? $this->defaultRegistrationAmount()),
+                'descricao' => null,
+            ]);
+        }
+
+        $duplicates = $rows
+            ->pluck('registration_id')
+            ->duplicates()
+            ->all();
+
+        if ($duplicates !== []) {
+            throw ValidationException::withMessages([
+                'registration_ids' => 'A mesma inscrição não pode aparecer duas vezes no lote.',
+            ]);
+        }
+
+        if ($selectedIds->isNotEmpty()) {
+            $rows = $rows->filter(fn (array $row): bool => $selectedIds->contains($row['registration_id']));
+        }
+
+        return $rows->values()->all();
+    }
+
+    /**
+     * @return array<int, array<string, mixed>>
+     */
+    private function manualRows(array $data): array
+    {
+        return collect($data['manual_items'] ?? [])
+            ->map(fn (array $row): array => [
+                'nome' => $this->nullableText($row['nome'] ?? null),
+                'valor' => $this->amount($row['valor'] ?? $data['default_value'] ?? 0),
+                'categoria_lancamento_id' => (int) ($row['categoria_lancamento_id'] ?? $data['categoria_lancamento_id'] ?? 0),
+                'descricao' => $this->nullableText($row['descricao'] ?? null),
+                'comprador' => $this->nullableText($row['comprador'] ?? null),
+            ])
+            ->filter(fn (array $row): bool => filled($row['nome']) || $row['valor'] > 0 || $row['categoria_lancamento_id'] > 0)
+            ->values()
+            ->all();
+    }
+
+    private function rowName(array $row, Model $registration): string
+    {
+        return $this->nullableText($row['nome'] ?? null)
+            ?? (string) ($registration->getAttribute('nome') ?? 'Inscrição #'.$registration->getKey());
+    }
+
+    private function registrationLaunchName(Model $registration, string $name): string
+    {
+        $prefix = $registration instanceof EquipeTrabalho
+            ? 'Contribuição equipe'
+            : 'Inscrição';
+
+        return $prefix.' - '.$name;
+    }
+
+    private function defaultRegistrationAmount(): int
+    {
+        return (int) (app(GeneralSettings::class)->valor_acampamento ?? 0);
+    }
+
+    private function amount(mixed $value): int
+    {
+        if (is_string($value)) {
+            $value = str_replace(['R$', '.', ',', ' '], ['', '', '.', ''], $value);
+        }
+
+        return abs((int) round(((float) $value)));
+    }
+
+    private function nullableText(mixed $value): ?string
+    {
+        $value = trim((string) $value);
+
+        return $value === '' ? null : $value;
+    }
+}

--- a/app/Support/Financeiro/RegistrationPaymentAllocator.php
+++ b/app/Support/Financeiro/RegistrationPaymentAllocator.php
@@ -5,10 +5,12 @@ namespace App\Support\Financeiro;
 use App\Enums\StatusInscricao;
 use App\Enums\StatusInscricaoEquipeTrabalho;
 use App\Enums\StatusLacamento;
+use App\Enums\TipoLacamento;
 use App\Models\Campista;
+use App\Models\CategoriaLancamento;
 use App\Models\EquipeTrabalho;
-use App\Models\FinancialEntryRegistration;
 use App\Models\Lancamento;
+use App\Models\LancamentoItem;
 use App\Settings\GeneralSettings;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Facades\DB;
@@ -66,28 +68,57 @@ class RegistrationPaymentAllocator
     }
 
     /**
-     * @param  array<int, array<string, mixed>>  $allocations
-     * @return array<int, array{registration_type: class-string<Model>, registration_id: int, amount: int}>
+     * @param  array<int, array<string, mixed>>  $items
+     * @return array<int, array{nome: string, descricao: ?string, valor: int, categoria_lancamento_id: int, registration_type: class-string<Model>|null, registration_id: int|null}>
      */
-    public function validateAllocations(Lancamento $lancamento, array $allocations): array
+    public function validateItems(Lancamento $lancamento, array $items): array
     {
-        $normalized = $this->normalizeAllocations($allocations);
-        $totalAllocated = array_sum(array_column($normalized, 'amount'));
-        $entryAmount = abs((int) $lancamento->valor);
+        $normalized = $this->normalizeItems($items);
 
-        if ($totalAllocated > $entryAmount) {
+        if ($normalized === []) {
             throw ValidationException::withMessages([
-                'registration_payments' => 'A soma dos valores vinculados às inscrições não pode ultrapassar o valor do lançamento.',
+                'items' => 'Informe pelo menos um item do lançamento.',
             ]);
         }
 
-        foreach ($normalized as $allocation) {
-            $registration = $this->registrationFromAllocation($allocation);
-            $remaining = $this->remainingAmountFor($registration, $lancamento->exists ? (int) $lancamento->getKey() : null);
+        $seenRegistrations = [];
 
-            if ($allocation['amount'] > $remaining) {
+        foreach ($normalized as $item) {
+            $category = CategoriaLancamento::query()->find($item['categoria_lancamento_id']);
+
+            if (! $category || ! $this->categoryMatchesLaunchType($category, $lancamento->tipo)) {
                 throw ValidationException::withMessages([
-                    'registration_payments' => sprintf(
+                    'items' => 'A categoria do item precisa acompanhar o tipo do lançamento.',
+                ]);
+            }
+
+            if ($item['registration_type'] === null || $item['registration_id'] === null) {
+                continue;
+            }
+
+            $key = $item['registration_type'].'#'.$item['registration_id'];
+
+            if (array_key_exists($key, $seenRegistrations)) {
+                throw ValidationException::withMessages([
+                    'items' => 'A mesma inscrição não pode ser vinculada duas vezes ao mesmo lançamento.',
+                ]);
+            }
+
+            $seenRegistrations[$key] = true;
+            $registration = $this->registrationFromItem($item);
+            $excludingLancamentoId = $lancamento->exists ? (int) $lancamento->getKey() : null;
+
+            if ($this->registrationHasLinkedItem($registration, $excludingLancamentoId)) {
+                throw ValidationException::withMessages([
+                    'items' => sprintf('%s já possui lançamento vinculado.', $this->registrationName($registration)),
+                ]);
+            }
+
+            $remaining = $this->remainingAmountFor($registration, $excludingLancamentoId);
+
+            if ($item['valor'] > $remaining) {
+                throw ValidationException::withMessages([
+                    'items' => sprintf(
                         'O valor aplicado em %s não pode ultrapassar o saldo restante da inscrição.',
                         $this->registrationName($registration),
                     ),
@@ -99,27 +130,32 @@ class RegistrationPaymentAllocator
     }
 
     /**
-     * @param  array<int, array<string, mixed>>  $allocations
+     * @param  array<int, array<string, mixed>>  $items
      */
-    public function sync(Lancamento $lancamento, array $allocations): void
+    public function syncItems(Lancamento $lancamento, array $items): void
     {
-        $normalized = $this->validateAllocations($lancamento, $allocations);
+        $normalized = $this->validateItems($lancamento, $items);
 
         DB::transaction(function () use ($lancamento, $normalized): void {
-            $previousRegistrations = $lancamento->registrationPayments()
+            $previousRegistrations = $lancamento->items()
                 ->with('registration')
                 ->get()
-                ->map(fn (FinancialEntryRegistration $payment): ?Model => $payment->registration)
+                ->map(fn (LancamentoItem $item): ?Model => $item->registration)
                 ->filter();
 
-            $lancamento->registrationPayments()->delete();
+            $lancamento->items()->delete();
 
-            foreach ($normalized as $allocation) {
-                $lancamento->registrationPayments()->create($allocation);
+            foreach ($normalized as $item) {
+                $lancamento->items()->create($item);
             }
 
             $currentRegistrations = collect($normalized)
-                ->map(fn (array $allocation): Model => $this->registrationFromAllocation($allocation));
+                ->filter(fn (array $item): bool => $item['registration_type'] !== null && $item['registration_id'] !== null)
+                ->map(fn (array $item): Model => $this->registrationFromItem($item));
+
+            $lancamento->forceFill([
+                'valor' => $this->signedTotalForItems($lancamento->tipo, $normalized),
+            ])->save();
 
             $previousRegistrations
                 ->merge($currentRegistrations)
@@ -128,9 +164,47 @@ class RegistrationPaymentAllocator
         });
     }
 
+    /**
+     * Compatibility wrapper for older call sites while forms move to item-based payloads.
+     *
+     * @param  array<int, array<string, mixed>>  $allocations
+     */
+    public function sync(Lancamento $lancamento, array $allocations): void
+    {
+        CategoriaLancamento::ensureSystemDefaults();
+
+        $items = collect($this->normalizeAllocations($allocations))
+            ->map(function (array $allocation): array {
+                $registration = $this->registrationFromAllocation($allocation);
+
+                return [
+                    'nome' => $this->registrationName($registration),
+                    'descricao' => null,
+                    'valor' => $allocation['amount'],
+                    'categoria_lancamento_id' => $this->categoryForRegistrationType($allocation['registration_type'])?->id,
+                    'registration_type' => $allocation['registration_type'],
+                    'registration_id' => $allocation['registration_id'],
+                ];
+            })
+            ->all();
+
+        $this->syncItems($lancamento, $items);
+    }
+
+    /**
+     * @param  array<int, array<string, mixed>>  $items
+     */
+    public function signedTotalForItems(mixed $type, array $items): int
+    {
+        $total = collect($items)
+            ->sum(fn (array $item): int => abs((int) ($item['valor'] ?? $item['amount'] ?? 0)));
+
+        return $this->isExpenseType($type) ? $total * -1 : $total;
+    }
+
     public function paidAmountFor(Model $registration, ?int $excludingLancamentoId = null): int
     {
-        $query = FinancialEntryRegistration::query()
+        $query = LancamentoItem::query()
             ->where('registration_type', $registration::class)
             ->where('registration_id', $registration->getKey())
             ->whereHas('lancamento', fn ($query) => $query->where('status', StatusLacamento::Pago->value));
@@ -139,7 +213,7 @@ class RegistrationPaymentAllocator
             $query->where('lancamento_id', '<>', $excludingLancamentoId);
         }
 
-        return (int) $query->sum('amount');
+        return (int) $query->sum('valor');
     }
 
     public function remainingAmountFor(Model $registration, ?int $excludingLancamentoId = null): int
@@ -162,6 +236,56 @@ class RegistrationPaymentAllocator
         $amount = (int) (app(GeneralSettings::class)->valor_acampamento ?? 0);
 
         return $amount > 0 ? $amount : null;
+    }
+
+    /**
+     * @param  array<int, array<string, mixed>>  $items
+     * @return array<int, array{nome: string, descricao: ?string, valor: int, categoria_lancamento_id: int, registration_type: class-string<Model>|null, registration_id: int|null}>
+     */
+    private function normalizeItems(array $items): array
+    {
+        $normalized = [];
+
+        foreach ($items as $item) {
+            $name = trim((string) ($item['nome'] ?? ''));
+            $description = $item['descricao'] ?? null;
+            $amount = abs((int) ($item['valor'] ?? $item['amount'] ?? 0));
+            $categoryId = (int) ($item['categoria_lancamento_id'] ?? 0);
+            $registrationType = $item['registration_type'] ?? null;
+            $registrationId = filled($item['registration_id'] ?? null) ? (int) $item['registration_id'] : null;
+
+            if ($name === '' && $amount === 0 && $categoryId === 0 && blank($registrationType) && $registrationId === null) {
+                continue;
+            }
+
+            if ($name === '' || $amount <= 0 || $categoryId <= 0) {
+                throw ValidationException::withMessages([
+                    'items' => 'Informe nome, valor e categoria em todos os itens.',
+                ]);
+            }
+
+            if (filled($registrationType) || $registrationId !== null) {
+                if (! $this->isSupportedRegistrationType($registrationType) || $registrationId === null || $registrationId <= 0) {
+                    throw ValidationException::withMessages([
+                        'items' => 'Informe tipo e inscrição válidos para itens vinculados.',
+                    ]);
+                }
+            } else {
+                $registrationType = null;
+                $registrationId = null;
+            }
+
+            $normalized[] = [
+                'nome' => $name,
+                'descricao' => is_string($description) && trim($description) !== '' ? trim($description) : null,
+                'valor' => $amount,
+                'categoria_lancamento_id' => $categoryId,
+                'registration_type' => $registrationType,
+                'registration_id' => $registrationId,
+            ];
+        }
+
+        return $normalized;
     }
 
     /**
@@ -218,6 +342,17 @@ class RegistrationPaymentAllocator
         return $registrationType::query()->findOrFail($allocation['registration_id']);
     }
 
+    /**
+     * @param  array{registration_type: class-string<Model>|null, registration_id: int|null}  $item
+     */
+    private function registrationFromItem(array $item): Model
+    {
+        /** @var class-string<Model> $registrationType */
+        $registrationType = $item['registration_type'];
+
+        return $registrationType::query()->findOrFail($item['registration_id']);
+    }
+
     private function syncRegistrationStatus(Model $registration): void
     {
         $expected = $this->expectedAmountFor($registration);
@@ -262,7 +397,7 @@ class RegistrationPaymentAllocator
     private function latestPaidLancamentoFor(Model $registration): ?Lancamento
     {
         return Lancamento::query()
-            ->whereHas('registrationPayments', fn ($query) => $query
+            ->whereHas('items', fn ($query) => $query
                 ->where('registration_type', $registration::class)
                 ->where('registration_id', $registration->getKey()))
             ->where('status', StatusLacamento::Pago->value)
@@ -321,8 +456,58 @@ class RegistrationPaymentAllocator
             return false;
         }
 
-        return $registration->getKey() === $currentRegistrationId
-            || $this->remainingAmountFor($registration, $excludingLancamentoId) > 0;
+        if ($registration->getKey() === $currentRegistrationId) {
+            return true;
+        }
+
+        return ! $this->registrationHasLinkedItem($registration, $excludingLancamentoId)
+            && $this->remainingAmountFor($registration, $excludingLancamentoId) > 0;
+    }
+
+    private function registrationHasLinkedItem(Model $registration, ?int $excludingLancamentoId = null): bool
+    {
+        return LancamentoItem::query()
+            ->where('registration_type', $registration::class)
+            ->where('registration_id', $registration->getKey())
+            ->when($excludingLancamentoId !== null, fn ($query) => $query->where('lancamento_id', '<>', $excludingLancamentoId))
+            ->exists();
+    }
+
+    public function categoryForRegistrationType(string $registrationType): ?CategoriaLancamento
+    {
+        $systemKey = match ($registrationType) {
+            Campista::class => CategoriaLancamento::SYSTEM_CATEGORY_INSCRICAO,
+            EquipeTrabalho::class => CategoriaLancamento::SYSTEM_CATEGORY_CONTRIBUICAO_EQUIPE_TRABALHO,
+            default => null,
+        };
+
+        if ($systemKey === null) {
+            return null;
+        }
+
+        CategoriaLancamento::ensureSystemDefaults();
+
+        return CategoriaLancamento::query()
+            ->where('system_key', $systemKey)
+            ->first();
+    }
+
+    private function categoryMatchesLaunchType(CategoriaLancamento $category, mixed $type): bool
+    {
+        if ($type instanceof TipoLacamento) {
+            return $category->tipo === $type;
+        }
+
+        return ! blank($type) && (int) $category->tipo->value === (int) $type;
+    }
+
+    private function isExpenseType(mixed $type): bool
+    {
+        if ($type instanceof TipoLacamento) {
+            return $type === TipoLacamento::Despesa;
+        }
+
+        return ! blank($type) && (int) $type === TipoLacamento::Despesa->value;
     }
 
     private function registrationName(Model $registration): string

--- a/app/Support/Livewire/FilamentNotificationsWireableSynth.php
+++ b/app/Support/Livewire/FilamentNotificationsWireableSynth.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace App\Support\Livewire;
+
+use Filament\Notifications\Collection as FilamentNotificationCollection;
+use Livewire\Features\SupportWireables\WireableSynth;
+
+class FilamentNotificationsWireableSynth extends WireableSynth
+{
+    public function hydrate($value, $meta, $hydrateChild): mixed
+    {
+        if (($meta['class'] ?? null) === FilamentNotificationCollection::class && ! is_array($value)) {
+            $value = [];
+        }
+
+        if (($meta['class'] ?? null) === FilamentNotificationCollection::class) {
+            $value = collect($value)
+                ->filter(fn (mixed $notification): bool => is_array($notification))
+                ->map(fn (array $notification): array => $this->sanitizeNotificationPayload($notification))
+                ->all();
+        }
+
+        return parent::hydrate($value, $meta, $hydrateChild);
+    }
+
+    /**
+     * @param  array<string, mixed>  $notification
+     * @return array<string, mixed>
+     */
+    private function sanitizeNotificationPayload(array $notification): array
+    {
+        if (isset($notification['actions']) && is_array($notification['actions'])) {
+            $notification['actions'] = array_values(array_filter(
+                $notification['actions'],
+                fn (mixed $action): bool => is_array($action),
+            ));
+        }
+
+        return $notification;
+    }
+}

--- a/database/factories/LancamentoFactory.php
+++ b/database/factories/LancamentoFactory.php
@@ -25,12 +25,12 @@ class LancamentoFactory extends Factory
             'descricao' => $this->faker->sentence(),
             'comprador' => $this->faker->name(),
             'data' => $this->faker->dateTime(),
-            'valor' => $this->faker->randomFloat(2, 0, 1000),
+            'valor' => $this->faker->numberBetween(0, 100000),
             'tipo' => $this->faker->randomElement([TipoLacamento::Receita->value,TipoLacamento::Doacao->value,TipoLacamento::Despesa->value]),
-            'categoria_lancamento_id' => null,
             'status' => $this->faker->randomElement([StatusLacamento::Pago->value,StatusLacamento::Cancelado->value,StatusLacamento::Pendente->value,]),
             'forma_pagamento' => $this->faker->randomElement([FormaPagamento::Dinheiro->value, FormaPagamento::Pix->value]),
-            'comprovante' => $this->faker->imageUrl(640, 480),
+            'comprovante' => [],
+            'batch_code' => null,
             'user_id' => $this->faker->numberBetween(User::count(), 10),
 
         ];

--- a/database/migrations/2026_06_08_010000_create_lancamento_items_and_migrate_financial_links.php
+++ b/database/migrations/2026_06_08_010000_create_lancamento_items_and_migrate_financial_links.php
@@ -1,0 +1,223 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('lancamentos', function (Blueprint $table): void {
+            $table->string('batch_code', 20)
+                ->nullable()
+                ->after('comprovante')
+                ->index();
+        });
+
+        Schema::create('lancamento_items', function (Blueprint $table): void {
+            $table->id();
+            $table->foreignId('lancamento_id')
+                ->constrained('lancamentos')
+                ->cascadeOnDelete();
+            $table->string('nome');
+            $table->text('descricao')->nullable();
+            $table->unsignedInteger('valor');
+            $table->foreignId('categoria_lancamento_id')
+                ->constrained('categorias_lancamento')
+                ->restrictOnDelete();
+            $table->string('registration_type')->nullable();
+            $table->unsignedBigInteger('registration_id')->nullable();
+            $table->timestamps();
+
+            $table->index([
+                'registration_type',
+                'registration_id',
+            ], 'lancamento_items_registration_index');
+            $table->unique([
+                'lancamento_id',
+                'registration_type',
+                'registration_id',
+            ], 'lancamento_items_registration_unique');
+        });
+
+        $this->migrateExistingRowsToItems();
+
+        Schema::dropIfExists('financial_entry_registrations');
+
+        if (Schema::hasColumn('lancamentos', 'categoria_lancamento_id')) {
+            Schema::table('lancamentos', function (Blueprint $table): void {
+                $table->dropConstrainedForeignId('categoria_lancamento_id');
+            });
+        }
+    }
+
+    public function down(): void
+    {
+        Schema::table('lancamentos', function (Blueprint $table): void {
+            $table->foreignId('categoria_lancamento_id')
+                ->nullable()
+                ->constrained('categorias_lancamento')
+                ->restrictOnDelete();
+        });
+
+        Schema::create('financial_entry_registrations', function (Blueprint $table): void {
+            $table->id();
+            $table->foreignId('lancamento_id')
+                ->constrained('lancamentos')
+                ->cascadeOnDelete();
+            $table->string('registration_type');
+            $table->unsignedBigInteger('registration_id');
+            $table->unsignedInteger('amount');
+            $table->timestamps();
+
+            $table->index([
+                'registration_type',
+                'registration_id',
+            ], 'fer_registration_index');
+            $table->unique([
+                'lancamento_id',
+                'registration_type',
+                'registration_id',
+            ], 'financial_entry_registration_unique');
+        });
+
+        $now = now();
+
+        DB::table('lancamentos')
+            ->orderBy('id')
+            ->each(function (object $lancamento) use ($now): void {
+                $firstItem = DB::table('lancamento_items')
+                    ->where('lancamento_id', $lancamento->id)
+                    ->orderBy('id')
+                    ->first();
+
+                if ($firstItem !== null) {
+                    DB::table('lancamentos')
+                        ->where('id', $lancamento->id)
+                        ->update(['categoria_lancamento_id' => $firstItem->categoria_lancamento_id]);
+                }
+
+                DB::table('lancamento_items')
+                    ->where('lancamento_id', $lancamento->id)
+                    ->whereNotNull('registration_type')
+                    ->whereNotNull('registration_id')
+                    ->orderBy('id')
+                    ->each(function (object $item) use ($now): void {
+                        DB::table('financial_entry_registrations')->insert([
+                            'lancamento_id' => $item->lancamento_id,
+                            'registration_type' => $item->registration_type,
+                            'registration_id' => $item->registration_id,
+                            'amount' => $item->valor,
+                            'created_at' => $now,
+                            'updated_at' => $now,
+                        ]);
+                    });
+            });
+
+        Schema::dropIfExists('lancamento_items');
+
+        Schema::table('lancamentos', function (Blueprint $table): void {
+            $table->dropColumn('batch_code');
+        });
+    }
+
+    private function migrateExistingRowsToItems(): void
+    {
+        $now = now();
+        $hasFinancialLinks = Schema::hasTable('financial_entry_registrations');
+
+        DB::table('lancamentos')
+            ->orderBy('id')
+            ->each(function (object $lancamento) use ($hasFinancialLinks, $now): void {
+                $categoryId = $lancamento->categoria_lancamento_id ?? $this->fallbackCategoryId((int) $lancamento->tipo);
+
+                if ($categoryId === null) {
+                    return;
+                }
+
+                $total = abs((int) $lancamento->valor);
+                $allocated = 0;
+
+                $links = $hasFinancialLinks
+                    ? DB::table('financial_entry_registrations')
+                        ->where('lancamento_id', $lancamento->id)
+                        ->orderBy('id')
+                        ->get()
+                    : collect();
+
+                foreach ($links as $link) {
+                    $amount = abs((int) $link->amount);
+                    $allocated += $amount;
+
+                    DB::table('lancamento_items')->insert([
+                        'lancamento_id' => $lancamento->id,
+                        'nome' => $this->registrationName($link->registration_type, (int) $link->registration_id),
+                        'descricao' => null,
+                        'valor' => $amount,
+                        'categoria_lancamento_id' => $categoryId,
+                        'registration_type' => $link->registration_type,
+                        'registration_id' => $link->registration_id,
+                        'created_at' => $now,
+                        'updated_at' => $now,
+                    ]);
+                }
+
+                $residual = $total - $allocated;
+
+                if ($links->isEmpty()) {
+                    DB::table('lancamento_items')->insert([
+                        'lancamento_id' => $lancamento->id,
+                        'nome' => (string) $lancamento->nome,
+                        'descricao' => $lancamento->descricao,
+                        'valor' => $total,
+                        'categoria_lancamento_id' => $categoryId,
+                        'registration_type' => null,
+                        'registration_id' => null,
+                        'created_at' => $now,
+                        'updated_at' => $now,
+                    ]);
+
+                    return;
+                }
+
+                if ($residual > 0) {
+                    DB::table('lancamento_items')->insert([
+                        'lancamento_id' => $lancamento->id,
+                        'nome' => 'Saldo não vinculado',
+                        'descricao' => $lancamento->descricao,
+                        'valor' => $residual,
+                        'categoria_lancamento_id' => $categoryId,
+                        'registration_type' => null,
+                        'registration_id' => null,
+                        'created_at' => $now,
+                        'updated_at' => $now,
+                    ]);
+                }
+            });
+    }
+
+    private function registrationName(?string $registrationType, int $registrationId): string
+    {
+        $table = match ($registrationType) {
+            App\Models\Campista::class => 'campistas',
+            App\Models\EquipeTrabalho::class => 'equipe_trabalho',
+            default => null,
+        };
+
+        if ($table === null) {
+            return 'Inscrição removida';
+        }
+
+        return (string) (DB::table($table)->where('id', $registrationId)->value('nome') ?? 'Inscrição removida');
+    }
+
+    private function fallbackCategoryId(int $type): ?int
+    {
+        return DB::table('categorias_lancamento')
+            ->where('tipo', $type)
+            ->orderBy('id')
+            ->value('id');
+    }
+};

--- a/resources/views/filament/resources/lancamento-resource/pages/batch-lancamentos.blade.php
+++ b/resources/views/filament/resources/lancamento-resource/pages/batch-lancamentos.blade.php
@@ -1,0 +1,5 @@
+<x-filament-panels::page>
+    <div class="space-y-6">
+        {{ $this->form }}
+    </div>
+</x-filament-panels::page>

--- a/tests/Feature/CampistaResourceActionsTest.php
+++ b/tests/Feature/CampistaResourceActionsTest.php
@@ -8,6 +8,7 @@ use App\Filament\Resources\CampistaResource\CampistaForm;
 use App\Filament\Resources\CampistaResource\Pages\EditCampista;
 use App\Filament\Resources\CampistaResource\Pages\ListCampistas;
 use App\Models\Campista;
+use App\Models\CategoriaLancamento;
 use App\Models\Lancamento;
 use App\Models\User;
 use Database\Seeders\ShieldSeeder;
@@ -61,9 +62,12 @@ it('renders campista payment information only from linked financial entries', fu
         'user_id' => null,
     ]);
 
-    $campista->financialEntryRegistrations()->create([
-        'lancamento_id' => $lancamento->id,
-        'amount' => 25000,
+    $lancamento->items()->create([
+        'nome' => $campista->nome,
+        'valor' => 25000,
+        'categoria_lancamento_id' => campistaActionsInscricaoCategory()->id,
+        'registration_type' => $campista::class,
+        'registration_id' => $campista->id,
     ]);
 
     expect((string) CampistaForm::paymentSummaryHtml($campista))
@@ -101,9 +105,12 @@ it('renders the linked payment summary on the campista edit form', function () {
         'user_id' => null,
     ]);
 
-    $campista->financialEntryRegistrations()->create([
-        'lancamento_id' => $lancamento->id,
-        'amount' => 25000,
+    $lancamento->items()->create([
+        'nome' => $campista->nome,
+        'valor' => 25000,
+        'categoria_lancamento_id' => campistaActionsInscricaoCategory()->id,
+        'registration_type' => $campista::class,
+        'registration_id' => $campista->id,
     ]);
 
     Livewire::test(EditCampista::class, ['record' => $campista->getKey()])
@@ -113,3 +120,12 @@ it('renders the linked payment summary on the campista edit form', function () {
         ->assertDontSee('Nome Comprovante')
         ->assertDontSee('Data de Pagamento');
 });
+
+function campistaActionsInscricaoCategory(): CategoriaLancamento
+{
+    CategoriaLancamento::ensureSystemDefaults();
+
+    return CategoriaLancamento::query()
+        ->where('system_key', CategoriaLancamento::SYSTEM_CATEGORY_INSCRICAO)
+        ->firstOrFail();
+}

--- a/tests/Feature/CategoriaLancamentoResourceTest.php
+++ b/tests/Feature/CategoriaLancamentoResourceTest.php
@@ -242,7 +242,9 @@ it('renders category tiles in launch tables and select options', function () {
         ->toContain('use App\Support\IconBadge;')
         ->toContain('IconBadge::tileIcon')
         ->toContain('->html()')
-        ->toContain('->tooltip(fn (?string $state): string => $state ?? \'Sem categoria\')')
+        ->toContain('->tooltip(fn (Lancamento $record): string => $record->categories_summary)')
+        ->toContain('$extra = $categories->count() - 2')
+        ->toContain('$extraBadge = $extra > 0')
         ->not->toContain("->badge()\n                    ->sortable(),\n\n                TextColumn::make('status')");
 
     expect(file_get_contents(app_path('Filament/Resources/LancamentoResource/Forms/LancamentoForm.php')))
@@ -262,11 +264,16 @@ it('links a financial entry to a launch category', function () {
 
     $lancamento = Lancamento::factory()->create([
         'tipo' => TipoLacamento::Despesa,
-        'categoria_lancamento_id' => $category->id,
         'user_id' => null,
     ]);
 
-    expect($lancamento->fresh()->categoria)
+    $lancamento->items()->create([
+        'nome' => 'Alimentação da equipe',
+        'valor' => 5579,
+        'categoria_lancamento_id' => $category->id,
+    ]);
+
+    expect($lancamento->fresh()->categories->first())
         ->toBeInstanceOf(CategoriaLancamento::class)
         ->nome->toBe('Alimentação');
 });
@@ -278,7 +285,8 @@ it('exposes the category field on the financial entry form and table', function 
         ->toContain("->where('tipo', (int) \$type)");
 
     expect(file_get_contents(app_path('Filament/Resources/LancamentoResource.php')))
-        ->toContain("TextColumn::make('categoria.nome')")
+        ->toContain("TextColumn::make('categories_summary')")
         ->toContain("SelectFilter::make('categoria_lancamento_id')")
-        ->toContain("Group::make('categoria.nome')");
+        ->toContain("whereHas('items'")
+        ->toContain("Group::make('batch_code')");
 });

--- a/tests/Feature/FilamentNotificationsHydrationTest.php
+++ b/tests/Feature/FilamentNotificationsHydrationTest.php
@@ -1,0 +1,60 @@
+<?php
+
+use App\Support\Livewire\FilamentNotificationsWireableSynth;
+use Filament\Notifications\Collection as FilamentNotificationCollection;
+use Filament\Notifications\Notification;
+use Livewire\Component;
+use Livewire\Mechanisms\HandleComponents\ComponentContext;
+use Livewire\Mechanisms\HandleComponents\HandleComponents;
+
+it('sanitizes malformed filament notification payloads during Livewire hydration', function () {
+    $synth = new FilamentNotificationsWireableSynth(
+        new ComponentContext(new class extends Component {}),
+        'notifications',
+    );
+
+    $collection = $synth->hydrate(
+        [
+            0,
+            'valid-notification' => Notification::make('valid-notification')
+                ->title('Inscrição recebida')
+                ->success()
+                ->toArray(),
+        ],
+        ['class' => FilamentNotificationCollection::class],
+        fn (string|int $key, mixed $child): mixed => $child,
+    );
+
+    expect($collection)
+        ->toBeInstanceOf(FilamentNotificationCollection::class)
+        ->toHaveCount(1)
+        ->and($collection->first())
+        ->toBeInstanceOf(Notification::class)
+        ->getTitle()->toBe('Inscrição recebida');
+});
+
+it('hydrates an empty notification collection when the whole notification payload is malformed', function () {
+    $synth = new FilamentNotificationsWireableSynth(
+        new ComponentContext(new class extends Component {}),
+        'notifications',
+    );
+
+    $collection = $synth->hydrate(
+        0,
+        ['class' => FilamentNotificationCollection::class],
+        fn (string|int $key, mixed $child): mixed => $child,
+    );
+
+    expect($collection)
+        ->toBeInstanceOf(FilamentNotificationCollection::class)
+        ->toBeEmpty();
+});
+
+it('registers the safe wireable synthesizer before Livewire hydrates Filament notifications', function () {
+    $synth = app(HandleComponents::class)->findSynth(
+        new FilamentNotificationCollection,
+        new class extends Component {},
+    );
+
+    expect($synth)->toBeInstanceOf(FilamentNotificationsWireableSynth::class);
+});

--- a/tests/Feature/FilamentUploadStateTest.php
+++ b/tests/Feature/FilamentUploadStateTest.php
@@ -1,0 +1,27 @@
+<?php
+
+use App\Support\FilamentUploadState;
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\Storage;
+
+it('keeps already stored Filament upload paths without storing them again', function () {
+    Storage::fake('public');
+
+    Storage::disk('public')->put('foto-formulario/avatar-processado.jpg', 'conteudo');
+
+    expect(FilamentUploadState::storedPath([
+        'upload-key' => 'foto-formulario/avatar-processado.jpg',
+    ], 'foto-formulario'))
+        ->toBe('foto-formulario/avatar-processado.jpg');
+});
+
+it('stores temporary uploaded files when Filament upload state still contains a file object', function () {
+    Storage::fake('public');
+
+    $path = FilamentUploadState::storedPath([
+        'upload-key' => UploadedFile::fake()->image('avatar.jpg', 500, 500),
+    ], 'foto-formulario');
+
+    expect($path)->toStartWith('foto-formulario/')
+        ->and(Storage::disk('public')->exists($path))->toBeTrue();
+});

--- a/tests/Feature/FinancialDashboardDataTest.php
+++ b/tests/Feature/FinancialDashboardDataTest.php
@@ -27,7 +27,10 @@ function makeFinancialDashboardCategory(string $name, TipoLacamento $type): Cate
 
 function makeFinancialDashboardEntry(array $attributes = []): Lancamento
 {
-    return Lancamento::query()->create(array_merge([
+    $category = $attributes['categoria_lancamento_id'] ?? null;
+    unset($attributes['categoria_lancamento_id']);
+
+    $lancamento = Lancamento::query()->create(array_merge([
         'nome' => 'Lançamento financeiro',
         'descricao' => null,
         'comprador' => null,
@@ -37,9 +40,19 @@ function makeFinancialDashboardEntry(array $attributes = []): Lancamento
         'status' => StatusLacamento::Pago->value,
         'forma_pagamento' => FormaPagamento::Pix->value,
         'comprovante' => [],
-        'categoria_lancamento_id' => null,
         'user_id' => null,
     ], $attributes));
+
+    if ($category !== null) {
+        $lancamento->items()->create([
+            'nome' => $lancamento->nome,
+            'descricao' => $lancamento->descricao,
+            'valor' => abs((int) $lancamento->valor),
+            'categoria_lancamento_id' => $category,
+        ]);
+    }
+
+    return $lancamento;
 }
 
 it('summarizes paid financial entries as revenue donations expenses and balance by default', function () {

--- a/tests/Feature/FinancialDashboardWidgetsTest.php
+++ b/tests/Feature/FinancialDashboardWidgetsTest.php
@@ -33,7 +33,10 @@ function financialDashboardChartExtraJs(string $chart): string
 
 function makeFinancialDashboardWidgetEntry(array $attributes = []): Lancamento
 {
-    return Lancamento::query()->create(array_merge([
+    $category = $attributes['categoria_lancamento_id'] ?? null;
+    unset($attributes['categoria_lancamento_id']);
+
+    $lancamento = Lancamento::query()->create(array_merge([
         'nome' => 'Lançamento financeiro',
         'descricao' => null,
         'comprador' => null,
@@ -43,9 +46,19 @@ function makeFinancialDashboardWidgetEntry(array $attributes = []): Lancamento
         'status' => StatusLacamento::Pago->value,
         'forma_pagamento' => 1,
         'comprovante' => [],
-        'categoria_lancamento_id' => null,
         'user_id' => null,
     ], $attributes));
+
+    if ($category !== null) {
+        $lancamento->items()->create([
+            'nome' => $lancamento->nome,
+            'descricao' => $lancamento->descricao,
+            'valor' => abs((int) $lancamento->valor),
+            'categoria_lancamento_id' => $category,
+        ]);
+    }
+
+    return $lancamento;
 }
 
 it('registers a financial dashboard page in the finance navigation group with global filters', function () {
@@ -109,16 +122,11 @@ it('renders financial category values as pie chart slices', function () {
         'categoria_lancamento_id' => $market->id,
     ]);
 
-    makeFinancialDashboardWidgetEntry([
-        'valor' => 347,
-        'categoria_lancamento_id' => null,
-    ]);
-
     $options = financialDashboardChartOptions(FinancialCategoryChart::class);
 
     expect($options['chart']['type'])->toBe('pie')
-        ->and($options['labels'])->toBe(['Mercado', 'Sem categoria'])
-        ->and($options['series'])->toBe([560, 347]);
+        ->and($options['labels'])->toBe(['Mercado'])
+        ->and($options['series'])->toBe([560]);
 });
 
 it('keeps the daily financial flow y axis able to show negative balances', function () {

--- a/tests/Feature/FinancialEntryItemsTest.php
+++ b/tests/Feature/FinancialEntryItemsTest.php
@@ -9,9 +9,10 @@ use App\Filament\Resources\LancamentoResource\Forms\LancamentoForm;
 use App\Filament\Resources\LancamentoResource\Pages\CreateLancamento;
 use App\Filament\Resources\LancamentoResource\Pages\EditLancamento;
 use App\Models\Campista;
+use App\Models\CategoriaLancamento;
 use App\Models\EquipeTrabalho;
-use App\Models\FinancialEntryRegistration;
 use App\Models\Lancamento;
+use App\Models\LancamentoItem;
 use App\Models\User;
 use App\Support\EnumOptionBadge;
 use App\Support\Financeiro\RegistrationPaymentAllocator;
@@ -44,10 +45,6 @@ it('defaults financial entry date to the application current date', function () 
 });
 
 it('renders financial status and payment select options with enum icons and colors', function () {
-    if (! class_exists(EnumOptionBadge::class)) {
-        $this->fail('Financial enum select options must be rendered by EnumOptionBadge.');
-    }
-
     expect((string) EnumOptionBadge::option(StatusLacamento::Pago))
         ->toContain('Pago')
         ->toContain('polaris-payment-icon')
@@ -65,43 +62,23 @@ it('renders financial status and payment select options with enum icons and colo
         ->toContain('->enum(FormaPagamento::class)');
 });
 
-it('links one paid financial entry to multiple campista registrations and marks them paid', function () {
-    seedFinancialRegistrationSettings(25000);
+it('links one paid financial entry to multiple registration items and marks them paid', function () {
+    seedFinancialItemSettings(25000);
+    CategoriaLancamento::ensureSystemDefaults();
 
-    $joao = Campista::factory()->create([
-        'nome' => 'João Campista',
-        'status' => StatusInscricao::Pendente->value,
-        'forma_pagamento' => FormaPagamento::NaoPago->value,
-        'dia_pagamento' => null,
-        'tribo_id' => null,
-        'user_id' => null,
-    ]);
-    $maria = Campista::factory()->create([
-        'nome' => 'Maria Campista',
-        'status' => StatusInscricao::Pendente->value,
-        'forma_pagamento' => FormaPagamento::NaoPago->value,
-        'dia_pagamento' => null,
-        'tribo_id' => null,
-        'user_id' => null,
-    ]);
-    $lancamento = paidFinancialEntry(50000);
+    $category = financialItemRegistrationCategory(Campista::class);
+    $joao = financialItemCampista('João Campista');
+    $maria = financialItemCampista('Maria Campista');
+    $lancamento = financialItemEntry(['status' => StatusLacamento::Pago->value]);
 
-    app(RegistrationPaymentAllocator::class)->sync($lancamento, [
-        [
-            'registration_type' => Campista::class,
-            'registration_id' => $joao->id,
-            'amount' => 25000,
-        ],
-        [
-            'registration_type' => Campista::class,
-            'registration_id' => $maria->id,
-            'amount' => 25000,
-        ],
+    app(RegistrationPaymentAllocator::class)->syncItems($lancamento, [
+        financialItemPayload($category, $joao),
+        financialItemPayload($category, $maria),
     ]);
 
-    expect($lancamento->fresh()->registrationPayments)
+    expect($lancamento->fresh()->items)
         ->toHaveCount(2)
-        ->each->toBeInstanceOf(FinancialEntryRegistration::class)
+        ->each->toBeInstanceOf(LancamentoItem::class)
         ->and($joao->fresh()->status)->toBe(StatusInscricao::Pago)
         ->and($joao->fresh()->forma_pagamento)->toBe(FormaPagamento::Pix)
         ->and($joao->fresh()->dia_pagamento?->format('Y-m-d'))->toBe('2026-07-01')
@@ -110,139 +87,75 @@ it('links one paid financial entry to multiple campista registrations and marks 
         ->and(app(RegistrationPaymentAllocator::class)->remainingAmountFor($maria->fresh()))->toBe(0);
 });
 
-it('keeps a campista pending until multiple partial financial entries complete the expected amount', function () {
-    seedFinancialRegistrationSettings(25000);
+it('supports team work registrations through the same financial item link', function () {
+    seedFinancialItemSettings(25000);
+    CategoriaLancamento::ensureSystemDefaults();
 
-    $campista = Campista::factory()->create([
-        'nome' => 'Campista Parcial',
-        'status' => StatusInscricao::Pendente->value,
-        'forma_pagamento' => FormaPagamento::NaoPago->value,
-        'dia_pagamento' => null,
-        'tribo_id' => null,
-        'user_id' => null,
-    ]);
-
-    app(RegistrationPaymentAllocator::class)->sync(paidFinancialEntry(10000), [
-        [
-            'registration_type' => Campista::class,
-            'registration_id' => $campista->id,
-            'amount' => 10000,
-        ],
-    ]);
-
-    expect($campista->fresh()->status)
-        ->toBe(StatusInscricao::Pendente)
-        ->and(app(RegistrationPaymentAllocator::class)->paidAmountFor($campista->fresh()))->toBe(10000)
-        ->and(app(RegistrationPaymentAllocator::class)->remainingAmountFor($campista->fresh()))->toBe(15000);
-
-    app(RegistrationPaymentAllocator::class)->sync(paidFinancialEntry(15000), [
-        [
-            'registration_type' => Campista::class,
-            'registration_id' => $campista->id,
-            'amount' => 15000,
-        ],
-    ]);
-
-    expect($campista->fresh()->status)
-        ->toBe(StatusInscricao::Pago)
-        ->and(app(RegistrationPaymentAllocator::class)->paidAmountFor($campista->fresh()))->toBe(25000)
-        ->and(app(RegistrationPaymentAllocator::class)->remainingAmountFor($campista->fresh()))->toBe(0);
-});
-
-it('supports team work registrations through the same financial entry registration link', function () {
-    seedFinancialRegistrationSettings(25000);
-
+    $category = financialItemRegistrationCategory(EquipeTrabalho::class);
     $equipe = EquipeTrabalho::factory()->create([
         'nome' => 'Voluntário Equipe',
         'status' => StatusInscricaoEquipeTrabalho::Pendente->value,
     ]);
-    $lancamento = paidFinancialEntry(25000);
+    $lancamento = financialItemEntry(['status' => StatusLacamento::Pago->value]);
 
-    app(RegistrationPaymentAllocator::class)->sync($lancamento, [
-        [
-            'registration_type' => EquipeTrabalho::class,
-            'registration_id' => $equipe->id,
-            'amount' => 25000,
-        ],
+    app(RegistrationPaymentAllocator::class)->syncItems($lancamento, [
+        financialItemPayload($category, $equipe),
     ]);
 
-    expect($lancamento->fresh()->registrationPayments)
+    expect($lancamento->fresh()->items)
         ->toHaveCount(1)
-        ->and($lancamento->fresh()->registrationPayments->first()->registration)
+        ->and($lancamento->fresh()->items->first()->registration)
         ->toBeInstanceOf(EquipeTrabalho::class)
         ->and($equipe->fresh()->status)
         ->toBe(StatusInscricaoEquipeTrabalho::Aprovado);
 });
 
-it('searches registration payment options by registration name', function () {
-    seedFinancialRegistrationSettings(25000);
+it('searches registration item options by registration name and hides already linked registrations', function () {
+    seedFinancialItemSettings(25000);
+    CategoriaLancamento::ensureSystemDefaults();
 
-    $lucas = Campista::factory()->create([
-        'nome' => 'Lucas da Silva',
-        'status' => StatusInscricao::Pendente->value,
-        'tribo_id' => null,
-        'user_id' => null,
-    ]);
+    $category = financialItemRegistrationCategory(Campista::class);
+    $lucas = financialItemCampista('Lucas da Silva');
+    $maria = financialItemCampista('Maria Souza');
 
-    Campista::factory()->create([
-        'nome' => 'Maria Souza',
-        'status' => StatusInscricao::Pendente->value,
-        'tribo_id' => null,
-        'user_id' => null,
+    app(RegistrationPaymentAllocator::class)->syncItems(financialItemEntry(), [
+        financialItemPayload($category, $maria),
     ]);
 
     $results = app(RegistrationPaymentAllocator::class)
-        ->registrationSearchResults(Campista::class, 'Lucas');
+        ->registrationSearchResults(Campista::class, 'a');
 
     expect($results)
         ->toHaveKey($lucas->id)
         ->and(implode(' ', $results))->toContain('Lucas da Silva')
-        ->and(implode(' ', $results))->not->toContain('Maria Souza');
+        ->and($results)->not->toHaveKey($maria->id);
 });
 
-it('creates a financial entry with multiple registration links from the Filament create page', function () {
+it('creates a financial entry with multiple items from the Filament create page', function () {
     $this->seed(ShieldSeeder::class);
-    seedFinancialRegistrationSettings(25000);
+    seedFinancialItemSettings(25000);
+    CategoriaLancamento::ensureSystemDefaults();
 
     $user = User::factory()->create();
     $user->assignRole('Super Administrador');
     $this->actingAs($user);
 
-    $joao = Campista::factory()->create([
-        'nome' => 'João Tela',
-        'status' => StatusInscricao::Pendente->value,
-        'tribo_id' => null,
-        'user_id' => null,
-    ]);
-    $maria = Campista::factory()->create([
-        'nome' => 'Maria Tela',
-        'status' => StatusInscricao::Pendente->value,
-        'tribo_id' => null,
-        'user_id' => null,
-    ]);
+    $category = financialItemRegistrationCategory(Campista::class);
+    $joao = financialItemCampista('João Tela');
+    $maria = financialItemCampista('Maria Tela');
 
     Livewire::test(CreateLancamento::class)
         ->fillForm([
             'nome' => 'PIX João e Maria',
-            'valor' => 50000,
             'tipo' => TipoLacamento::Receita->value,
-            'categoria_lancamento_id' => null,
             'data' => '2026-07-01',
             'status' => StatusLacamento::Pago->value,
             'forma_pagamento' => FormaPagamento::Pix->value,
             'comprador' => 'Família',
             'descricao' => 'Pagamento agrupado de inscrições',
-            'registration_payments' => [
-                [
-                    'registration_type' => Campista::class,
-                    'registration_id' => $joao->id,
-                    'amount' => 25000,
-                ],
-                [
-                    'registration_type' => Campista::class,
-                    'registration_id' => $maria->id,
-                    'amount' => 25000,
-                ],
+            'items' => [
+                financialItemPayload($category, $joao),
+                financialItemPayload($category, $maria),
             ],
             'comprovante' => [
                 [
@@ -261,7 +174,7 @@ it('creates a financial entry with multiple registration links from the Filament
         ->and($lancamento->comprador)->toBeNull()
         ->and(data_get($lancamento->comprovante, '0.data.observacao'))->toBe('PIX recebido para João e Maria')
         ->and(data_get($lancamento->comprovante, '0.data'))->not->toHaveKey('comprovante_nome')
-        ->and($lancamento->registrationPayments)->toHaveCount(2)
+        ->and($lancamento->items)->toHaveCount(2)
         ->and($joao->fresh()->status)->toBe(StatusInscricao::Pago)
         ->and($maria->fresh()->status)->toBe(StatusInscricao::Pago);
 });
@@ -273,7 +186,7 @@ it('allows cash revenue financial entries without receipt attachments', function
     $user->assignRole('Super Administrador');
     $this->actingAs($user);
 
-    $payload = financialEntryFormPayload([
+    $payload = financialItemFormPayload([
         'nome' => 'Receita em dinheiro sem comprovante',
         'tipo' => TipoLacamento::Receita->value,
         'forma_pagamento' => FormaPagamento::Dinheiro->value,
@@ -287,7 +200,8 @@ it('allows cash revenue financial entries without receipt attachments', function
 
     $lancamento = Lancamento::query()->where('nome', 'Receita em dinheiro sem comprovante')->firstOrFail();
 
-    expect($lancamento->comprovante)->toBe([]);
+    expect($lancamento->comprovante)->toBe([])
+        ->and($lancamento->items)->toHaveCount(1);
 });
 
 it('requires receipt attachments outside cash revenue financial entries', function () {
@@ -312,7 +226,7 @@ it('requires receipt attachments outside cash revenue financial entries', functi
         ],
     ] as $payload) {
         Livewire::test(CreateLancamento::class)
-            ->fillForm(financialEntryFormPayload([
+            ->fillForm(financialItemFormPayload([
                 ...$payload,
                 'comprovante' => [],
             ]))
@@ -321,58 +235,36 @@ it('requires receipt attachments outside cash revenue financial entries', functi
     }
 });
 
-it('updates registration links from the Filament edit page without duplicating the financial entry', function () {
+it('updates financial items from the Filament edit page without duplicating the financial entry', function () {
     $this->seed(ShieldSeeder::class);
-    seedFinancialRegistrationSettings(25000);
+    seedFinancialItemSettings(25000);
+    CategoriaLancamento::ensureSystemDefaults();
 
     $user = User::factory()->create();
     $user->assignRole('Super Administrador');
     $this->actingAs($user);
 
-    $joao = Campista::factory()->create([
-        'nome' => 'João Editado',
-        'status' => StatusInscricao::Pendente->value,
-        'tribo_id' => null,
-        'user_id' => null,
-    ]);
-    $maria = Campista::factory()->create([
-        'nome' => 'Maria Editada',
-        'status' => StatusInscricao::Pendente->value,
-        'tribo_id' => null,
-        'user_id' => null,
-    ]);
-    $lancamento = paidFinancialEntry(50000);
+    $category = financialItemRegistrationCategory(Campista::class);
+    $joao = financialItemCampista('João Editado');
+    $maria = financialItemCampista('Maria Editada');
+    $lancamento = financialItemEntry(['status' => StatusLacamento::Pago->value]);
 
-    app(RegistrationPaymentAllocator::class)->sync($lancamento, [
-        [
-            'registration_type' => Campista::class,
-            'registration_id' => $joao->id,
-            'amount' => 25000,
-        ],
+    app(RegistrationPaymentAllocator::class)->syncItems($lancamento, [
+        financialItemPayload($category, $joao),
     ]);
 
     Livewire::test(EditLancamento::class, ['record' => $lancamento->getKey()])
         ->fillForm([
             'nome' => 'PIX editado',
-            'valor' => 50000,
             'tipo' => TipoLacamento::Receita->value,
-            'categoria_lancamento_id' => null,
             'data' => '2026-07-01',
             'status' => StatusLacamento::Pago->value,
             'forma_pagamento' => FormaPagamento::Pix->value,
             'comprador' => 'Família',
             'descricao' => 'Pagamento editado',
-            'registration_payments' => [
-                [
-                    'registration_type' => Campista::class,
-                    'registration_id' => $joao->id,
-                    'amount' => 25000,
-                ],
-                [
-                    'registration_type' => Campista::class,
-                    'registration_id' => $maria->id,
-                    'amount' => 25000,
-                ],
+            'items' => [
+                financialItemPayload($category, $joao),
+                financialItemPayload($category, $maria),
             ],
             'comprovante' => [
                 [
@@ -386,66 +278,52 @@ it('updates registration links from the Filament edit page without duplicating t
 
     expect(Lancamento::query()->count())
         ->toBe(1)
+        ->and($lancamento->fresh()->valor)->toBe(50000)
         ->and($lancamento->fresh()->comprador)->toBeNull()
         ->and(data_get($lancamento->fresh()->comprovante, '0.data.observacao'))->toBe('Comprovante substituído na edição')
-        ->and(data_get($lancamento->fresh()->comprovante, '0.data'))->not->toHaveKey('comprovante_nome')
-        ->and($lancamento->fresh()->registrationPayments)->toHaveCount(2)
+        ->and($lancamento->fresh()->items)->toHaveCount(2)
         ->and($joao->fresh()->status)->toBe(StatusInscricao::Pago)
         ->and($maria->fresh()->status)->toBe(StatusInscricao::Pago);
 });
 
-it('rejects financial entry registration amounts above the entry total or remaining registration balance', function () {
-    seedFinancialRegistrationSettings(25000);
+it('rejects item values above the remaining registration balance and duplicate linked registrations', function () {
+    seedFinancialItemSettings(25000);
+    CategoriaLancamento::ensureSystemDefaults();
 
-    $joao = Campista::factory()->create(['nome' => 'João', 'tribo_id' => null, 'user_id' => null]);
-    $maria = Campista::factory()->create(['nome' => 'Maria', 'tribo_id' => null, 'user_id' => null]);
+    $category = financialItemRegistrationCategory(Campista::class);
+    $joao = financialItemCampista('João');
 
-    expect(fn () => app(RegistrationPaymentAllocator::class)->sync(paidFinancialEntry(25000), [
-        [
-            'registration_type' => Campista::class,
-            'registration_id' => $joao->id,
-            'amount' => 20000,
-        ],
-        [
-            'registration_type' => Campista::class,
-            'registration_id' => $maria->id,
-            'amount' => 10000,
-        ],
+    expect(fn () => app(RegistrationPaymentAllocator::class)->syncItems(financialItemEntry(), [
+        financialItemPayload($category, $joao, ['valor' => 30000]),
     ]))->toThrow(ValidationException::class);
 
-    app(RegistrationPaymentAllocator::class)->sync(paidFinancialEntry(20000), [
-        [
-            'registration_type' => Campista::class,
-            'registration_id' => $joao->id,
-            'amount' => 20000,
-        ],
+    app(RegistrationPaymentAllocator::class)->syncItems(financialItemEntry(), [
+        financialItemPayload($category, $joao, ['valor' => 10000]),
     ]);
 
-    expect(fn () => app(RegistrationPaymentAllocator::class)->sync(paidFinancialEntry(10000), [
-        [
-            'registration_type' => Campista::class,
-            'registration_id' => $joao->id,
-            'amount' => 10000,
-        ],
+    expect(fn () => app(RegistrationPaymentAllocator::class)->syncItems(financialItemEntry(), [
+        financialItemPayload($category, $joao, ['valor' => 10000]),
     ]))->toThrow(ValidationException::class);
 });
 
-it('exposes registration payment links in the financial entry form and table', function () {
+it('exposes item links in the financial entry form and table', function () {
     $form = file_get_contents(app_path('Filament/Resources/LancamentoResource/Forms/LancamentoForm.php'));
     $resource = file_get_contents(app_path('Filament/Resources/LancamentoResource.php'));
     $createPage = file_get_contents(app_path('Filament/Resources/LancamentoResource/Pages/CreateLancamento.php'));
     $editPage = file_get_contents(app_path('Filament/Resources/LancamentoResource/Pages/EditLancamento.php'));
 
     expect($form)
-        ->toContain("Repeater::make('registration_payments')")
+        ->toContain("Repeater::make('items')")
         ->toContain("Repeater::make('comprovante')")
+        ->toContain("Select::make('categoria_lancamento_id')")
         ->toContain("Select::make('registration_type')")
         ->toContain("Select::make('registration_id')")
         ->toContain('getSearchResultsUsing')
-        ->toContain("Money::make('amount')")
+        ->toContain("Money::make('valor')")
         ->toContain("RichEditor::make('descricao')")
-        ->toContain("->toolbarButtons([['bold', 'italic', 'underline'], ['bulletList', 'orderedList'], ['link', 'clearFormatting']])")
-        ->not->toContain("Textarea::make('descricao')")
+        ->not->toContain("Repeater::make('registration_payments')")
+        ->not->toContain("Money::make('amount')")
+        ->not->toContain("Textarea::make('descricao')\n                                ->toolbarButtons")
         ->toContain('RegistrationPaymentAllocator::registrationTypeOptions')
         ->toContain('registrationOptions')
         ->toContain('registrationSearchResults')
@@ -456,13 +334,14 @@ it('exposes registration payment links in the financial entry form and table', f
         ->not->toContain("TextInput::make('comprovante_nome')")
         ->and($resource)
         ->toContain("TextColumn::make('registration_payments_summary')")
-        ->toContain("->with(['categoria', 'registrationPayments.registration'])")
+        ->toContain("->with(['items.categoria', 'items.registration'])")
+        ->toContain("TextColumn::make('batch_code')")
         ->and($createPage)
         ->toContain('RegistrationPaymentAllocator::class')
-        ->toContain('registrationPaymentData')
+        ->toContain('itemData')
         ->and($editPage)
         ->toContain('RegistrationPaymentAllocator::class')
-        ->toContain('registrationPaymentsFormState');
+        ->toContain('itemsFormState');
 
     expect(Schema::getColumnType('lancamentos', 'descricao'))->toBe('text');
 });
@@ -500,7 +379,7 @@ it('keeps comprador only for expense financial entries', function () {
         ]))->toHaveKey('comprador', 'Comprador Despesa');
 });
 
-function seedFinancialRegistrationSettings(int $amount): void
+function seedFinancialItemSettings(int $amount): void
 {
     DB::table('settings')->updateOrInsert(
         [
@@ -513,35 +392,86 @@ function seedFinancialRegistrationSettings(int $amount): void
     );
 }
 
-function financialEntryFormPayload(array $overrides = []): array
+function financialItemCampista(string $name): Campista
+{
+    return Campista::factory()->create([
+        'nome' => $name,
+        'status' => StatusInscricao::Pendente->value,
+        'forma_pagamento' => FormaPagamento::NaoPago->value,
+        'dia_pagamento' => null,
+        'tribo_id' => null,
+        'user_id' => null,
+    ]);
+}
+
+function financialItemRegistrationCategory(string $registrationType): CategoriaLancamento
+{
+    return app(RegistrationPaymentAllocator::class)->categoryForRegistrationType($registrationType);
+}
+
+function financialItemPayload(CategoriaLancamento $category, Campista|EquipeTrabalho $registration, array $overrides = []): array
 {
     return array_replace([
+        'nome' => $registration->nome,
+        'valor' => 25000,
+        'categoria_lancamento_id' => $category->id,
+        'registration_type' => $registration::class,
+        'registration_id' => $registration->id,
+        'descricao' => null,
+    ], $overrides);
+}
+
+function financialItemFormPayload(array $overrides = []): array
+{
+    CategoriaLancamento::ensureSystemDefaults();
+
+    $type = $overrides['tipo'] ?? TipoLacamento::Receita->value;
+    $category = CategoriaLancamento::query()
+        ->where('tipo', $type instanceof TipoLacamento ? $type->value : (int) $type)
+        ->orderBy('id')
+        ->first()
+        ?? CategoriaLancamento::query()->create([
+            'nome' => 'Categoria financeira',
+            'tipo' => $type instanceof TipoLacamento ? $type : TipoLacamento::from((int) $type),
+            'cor' => '#f46b12',
+            'icone' => 'heroicon-o-banknotes',
+            'ativo' => true,
+        ]);
+
+    return array_replace([
         'nome' => 'Lançamento financeiro',
-        'valor' => 12500,
         'tipo' => TipoLacamento::Receita->value,
-        'categoria_lancamento_id' => null,
         'data' => '2026-07-01',
         'status' => StatusLacamento::Pago->value,
         'forma_pagamento' => FormaPagamento::Pix->value,
         'comprador' => null,
         'descricao' => null,
-        'registration_payments' => [],
+        'items' => [
+            [
+                'nome' => 'Item financeiro',
+                'valor' => 12500,
+                'categoria_lancamento_id' => $category->id,
+                'registration_type' => null,
+                'registration_id' => null,
+                'descricao' => null,
+            ],
+        ],
         'comprovante' => [],
     ], $overrides);
 }
 
-function paidFinancialEntry(int $amount): Lancamento
+function financialItemEntry(array $overrides = []): Lancamento
 {
-    return Lancamento::factory()->create([
+    return Lancamento::factory()->create(array_replace([
         'nome' => 'PIX inscrições',
         'descricao' => 'Pagamento de inscrições',
         'comprador' => 'Responsável',
         'data' => '2026-07-01',
-        'valor' => $amount,
+        'valor' => 0,
         'tipo' => TipoLacamento::Receita->value,
-        'status' => StatusLacamento::Pago->value,
+        'status' => StatusLacamento::Pendente->value,
         'forma_pagamento' => FormaPagamento::Pix->value,
         'comprovante' => [],
         'user_id' => null,
-    ]);
+    ], $overrides));
 }

--- a/tests/Feature/LancamentoBatchPageTest.php
+++ b/tests/Feature/LancamentoBatchPageTest.php
@@ -1,0 +1,310 @@
+<?php
+
+use App\Enums\FormaPagamento;
+use App\Enums\StatusInscricao;
+use App\Enums\StatusInscricaoEquipeTrabalho;
+use App\Enums\StatusLacamento;
+use App\Enums\TipoLacamento;
+use App\Filament\Resources\LancamentoResource;
+use App\Filament\Resources\LancamentoResource\Pages\BatchLancamentos;
+use App\Models\Campista;
+use App\Models\CategoriaLancamento;
+use App\Models\EquipeTrabalho;
+use App\Models\Lancamento;
+use App\Models\User;
+use App\Support\Financeiro\LancamentoBatchCreator;
+use Carbon\Carbon;
+use Database\Seeders\ShieldSeeder;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Validation\ValidationException;
+use Livewire\Livewire;
+
+uses(RefreshDatabase::class);
+
+it('registers a dedicated batch launch page and list action', function () {
+    $pages = LancamentoResource::getPages();
+    $listPage = file_get_contents(app_path('Filament/Resources/LancamentoResource/Pages/ListLancamentos.php'));
+    $batchPage = file_get_contents(app_path('Filament/Resources/LancamentoResource/Pages/BatchLancamentos.php'));
+    $view = file_get_contents(resource_path('views/filament/resources/lancamento-resource/pages/batch-lancamentos.blade.php'));
+
+    expect($pages)
+        ->toHaveKey('batch')
+        ->and($listPage)
+        ->toContain('batch')
+        ->toContain('Lançamento em lote')
+        ->and($batchPage)
+        ->toContain("ModalTableSelect::make('registration_ids')")
+        ->toContain('LancamentoBatchCampistasTable::class')
+        ->toContain('LancamentoBatchEquipeTrabalhoTable::class')
+        ->not->toContain('->getSearchResultsUsing(fn (Get $get, string $search): array => app(LancamentoBatchCreator::class)')
+        ->toContain("Repeater::make('manual_items')")
+        ->toContain("Action::make('createBatch')")
+        ->and(file_get_contents(app_path('Filament/Resources/LancamentoResource/Tables/LancamentoBatchCampistasTable.php')))
+        ->toContain('CampistaTable::getListTableColumns()')
+        ->toContain('LancamentoBatchCreator::class')
+        ->and($view)
+        ->toContain('{{ $this->form }}');
+});
+
+it('shows a visual warning when the configured camp amount is zero on batch registration mode', function () {
+    $this->seed(ShieldSeeder::class);
+    seedLancamentoBatchSettings(0);
+
+    $user = User::factory()->create();
+    $user->assignRole('Super Administrador');
+    $this->actingAs($user);
+
+    Livewire::test(BatchLancamentos::class)
+        ->assertSee('Valor do acampamento não configurado')
+        ->assertSee('O campo de inscrições pode ficar sem opções enquanto o valor estiver zerado nas configurações.');
+});
+
+it('creates one pending launch per selected campista registration using the default inscription category', function () {
+    Carbon::setTestNow('2026-06-08 09:00:00');
+    seedLancamentoBatchSettings(35000);
+    CategoriaLancamento::ensureSystemDefaults();
+
+    $joao = lancamentoBatchCampista('João Lote');
+    $maria = lancamentoBatchCampista('Maria Lote');
+
+    $created = app(LancamentoBatchCreator::class)->create([
+        'mode' => 'registrations',
+        'registration_type' => Campista::class,
+        'registration_ids' => [$joao->id, $maria->id],
+        'data' => '2026-07-01',
+        'descricao' => 'Lote de inscrições',
+    ]);
+
+    $category = lancamentoBatchSystemCategory(CategoriaLancamento::SYSTEM_CATEGORY_INSCRICAO);
+
+    expect($created)
+        ->toHaveCount(2)
+        ->and(Lancamento::query()->pluck('batch_code')->unique()->values()->all())
+        ->toBe(['LOTE-20260608-001'])
+        ->and(Lancamento::query()->pluck('status')->unique()->values()->all())
+        ->toBe([StatusLacamento::Pendente])
+        ->and(Lancamento::query()->pluck('forma_pagamento')->unique()->values()->all())
+        ->toBe([FormaPagamento::NaoPago])
+        ->and(Lancamento::query()->pluck('valor')->all())
+        ->toBe([35000, 35000])
+        ->and(Lancamento::query()->with('items')->get()->flatMap->items->pluck('categoria_lancamento_id')->all())
+        ->toBe([$category->id, $category->id])
+        ->and($joao->fresh()->status)->toBe(StatusInscricao::Pendente)
+        ->and($maria->fresh()->status)->toBe(StatusInscricao::Pendente);
+
+    Carbon::setTestNow();
+});
+
+it('creates team work contribution batches with the team contribution category', function () {
+    Carbon::setTestNow('2026-06-08 09:00:00');
+    seedLancamentoBatchSettings(12000);
+    CategoriaLancamento::ensureSystemDefaults();
+
+    $member = EquipeTrabalho::factory()->create([
+        'nome' => 'Equipe Lote',
+        'status' => StatusInscricaoEquipeTrabalho::Pendente->value,
+    ]);
+
+    app(LancamentoBatchCreator::class)->create([
+        'mode' => 'registrations',
+        'registration_type' => EquipeTrabalho::class,
+        'registration_ids' => [$member->id],
+        'data' => '2026-07-01',
+    ]);
+
+    $category = lancamentoBatchSystemCategory(CategoriaLancamento::SYSTEM_CATEGORY_CONTRIBUICAO_EQUIPE_TRABALHO);
+
+    expect(Lancamento::query()->firstOrFail()->items()->firstOrFail())
+        ->categoria_lancamento_id->toBe($category->id)
+        ->registration_type->toBe(EquipeTrabalho::class)
+        ->registration_id->toBe($member->id);
+
+    Carbon::setTestNow();
+});
+
+it('excludes cancelled and already linked registrations from batch options and validation', function () {
+    seedLancamentoBatchSettings(35000);
+    CategoriaLancamento::ensureSystemDefaults();
+
+    $available = lancamentoBatchCampista('Disponível Lote');
+    $cancelled = lancamentoBatchCampista('Cancelado Lote', [
+        'status' => StatusInscricao::Cancelado->value,
+    ]);
+    $linked = lancamentoBatchCampista('Vinculado Lote');
+    $category = lancamentoBatchSystemCategory(CategoriaLancamento::SYSTEM_CATEGORY_INSCRICAO);
+
+    $launch = Lancamento::factory()->create([
+        'status' => StatusLacamento::Pendente->value,
+        'tipo' => TipoLacamento::Receita->value,
+        'forma_pagamento' => FormaPagamento::NaoPago->value,
+        'valor' => 35000,
+        'user_id' => null,
+    ]);
+    $launch->items()->create([
+        'nome' => $linked->nome,
+        'valor' => 35000,
+        'categoria_lancamento_id' => $category->id,
+        'registration_type' => $linked::class,
+        'registration_id' => $linked->id,
+    ]);
+
+    $options = app(LancamentoBatchCreator::class)->registrationOptions(Campista::class);
+
+    expect($options)
+        ->toHaveKey($available->id)
+        ->not->toHaveKey($cancelled->id)
+        ->not->toHaveKey($linked->id);
+
+    expect(fn () => app(LancamentoBatchCreator::class)->create([
+        'mode' => 'registrations',
+        'registration_type' => Campista::class,
+        'registration_ids' => [$available->id, $cancelled->id],
+        'data' => '2026-07-01',
+    ]))->toThrow(ValidationException::class);
+});
+
+it('creates one pending manual launch per free item with editable categories', function () {
+    Carbon::setTestNow('2026-06-08 09:00:00');
+
+    $donation = CategoriaLancamento::query()->create([
+        'nome' => 'Doação avulsa',
+        'tipo' => TipoLacamento::Doacao,
+        'cor' => '#0ea5e9',
+        'icone' => 'iconoir-donate',
+        'ativo' => true,
+    ]);
+
+    $created = app(LancamentoBatchCreator::class)->create([
+        'mode' => 'manual',
+        'tipo' => TipoLacamento::Doacao->value,
+        'data' => '2026-07-02',
+        'manual_items' => [
+            [
+                'nome' => 'Doação comunidade',
+                'valor' => 10000,
+                'categoria_lancamento_id' => $donation->id,
+                'descricao' => 'Entrada avulsa',
+            ],
+            [
+                'nome' => 'Doação visitante',
+                'valor' => 5000,
+                'categoria_lancamento_id' => $donation->id,
+                'descricao' => null,
+            ],
+        ],
+    ]);
+
+    expect($created)
+        ->toHaveCount(2)
+        ->and(Lancamento::query()->pluck('nome')->all())
+        ->toBe(['Doação comunidade', 'Doação visitante'])
+        ->and(Lancamento::query()->pluck('batch_code')->unique()->values()->all())
+        ->toBe(['LOTE-20260608-001'])
+        ->and(Lancamento::query()->pluck('status')->unique()->values()->all())
+        ->toBe([StatusLacamento::Pendente])
+        ->and(Lancamento::query()->with('items')->get()->flatMap->items->pluck('categoria_lancamento_id')->unique()->values()->all())
+        ->toBe([$donation->id]);
+
+    Carbon::setTestNow();
+});
+
+it('increments the daily batch code and does not keep partial launches when validation fails', function () {
+    Carbon::setTestNow('2026-06-08 09:00:00');
+
+    Lancamento::factory()->create([
+        'batch_code' => 'LOTE-20260608-001',
+        'user_id' => null,
+    ]);
+
+    $expense = CategoriaLancamento::query()->create([
+        'nome' => 'Despesa avulsa',
+        'tipo' => TipoLacamento::Despesa,
+        'cor' => '#ef4444',
+        'icone' => 'heroicon-o-shopping-cart',
+        'ativo' => true,
+    ]);
+
+    expect(app(LancamentoBatchCreator::class)->nextBatchCode())->toBe('LOTE-20260608-002');
+
+    try {
+        app(LancamentoBatchCreator::class)->create([
+            'mode' => 'manual',
+            'tipo' => TipoLacamento::Receita->value,
+            'data' => '2026-07-02',
+            'manual_items' => [
+                [
+                    'nome' => 'Categoria incompatível',
+                    'valor' => 10000,
+                    'categoria_lancamento_id' => $expense->id,
+                ],
+            ],
+        ]);
+    } catch (ValidationException) {
+        //
+    }
+
+    expect(Lancamento::query()->count())->toBe(1);
+
+    Carbon::setTestNow();
+});
+
+it('creates registration batches from the Filament page', function () {
+    $this->seed(ShieldSeeder::class);
+    seedLancamentoBatchSettings(35000);
+    CategoriaLancamento::ensureSystemDefaults();
+
+    $user = User::factory()->create();
+    $user->assignRole('Super Administrador');
+    $this->actingAs($user);
+
+    $campista = lancamentoBatchCampista('Campista Pela Tela');
+
+    Livewire::test(BatchLancamentos::class)
+        ->fillForm([
+            'mode' => 'registrations',
+            'registration_type' => Campista::class,
+            'registration_ids' => [$campista->id],
+            'data' => '2026-07-01',
+            'descricao' => 'Criado pela página de lote',
+        ])
+        ->call('createBatch')
+        ->assertHasNoFormErrors();
+
+    expect(Lancamento::query()->where('batch_code', 'like', 'LOTE-%')->count())
+        ->toBe(1)
+        ->and(Lancamento::query()->firstOrFail()->items()->firstOrFail()->registration_id)
+        ->toBe($campista->id);
+});
+
+function seedLancamentoBatchSettings(int $amount): void
+{
+    DB::table('settings')->updateOrInsert(
+        [
+            'group' => 'general',
+            'name' => 'valor_acampamento',
+        ],
+        [
+            'payload' => json_encode($amount),
+        ],
+    );
+}
+
+function lancamentoBatchCampista(string $name, array $overrides = []): Campista
+{
+    return Campista::factory()->create(array_replace([
+        'nome' => $name,
+        'status' => StatusInscricao::Pendente->value,
+        'forma_pagamento' => FormaPagamento::NaoPago->value,
+        'dia_pagamento' => null,
+        'tribo_id' => null,
+        'user_id' => null,
+    ], $overrides));
+}
+
+function lancamentoBatchSystemCategory(string $systemKey): CategoriaLancamento
+{
+    return CategoriaLancamento::query()
+        ->where('system_key', $systemKey)
+        ->firstOrFail();
+}

--- a/tests/Feature/LancamentoItemsTest.php
+++ b/tests/Feature/LancamentoItemsTest.php
@@ -1,0 +1,120 @@
+<?php
+
+use App\Enums\FormaPagamento;
+use App\Enums\StatusInscricao;
+use App\Enums\StatusLacamento;
+use App\Enums\TipoLacamento;
+use App\Models\Campista;
+use App\Models\CategoriaLancamento;
+use App\Models\Lancamento;
+use App\Support\Financeiro\RegistrationPaymentAllocator;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Validation\ValidationException;
+
+uses(RefreshDatabase::class);
+
+it('moves financial classification from lancamentos to lancamento items', function () {
+    expect(Schema::hasTable('lancamento_items'))->toBeTrue()
+        ->and(Schema::hasColumn('lancamento_items', 'categoria_lancamento_id'))->toBeTrue()
+        ->and(Schema::hasColumn('lancamento_items', 'registration_type'))->toBeTrue()
+        ->and(Schema::hasColumn('lancamento_items', 'registration_id'))->toBeTrue()
+        ->and(Schema::hasColumn('lancamentos', 'batch_code'))->toBeTrue()
+        ->and(Schema::hasColumn('lancamentos', 'categoria_lancamento_id'))->toBeFalse()
+        ->and(Schema::hasTable('financial_entry_registrations'))->toBeFalse();
+});
+
+it('syncs launch totals from items and marks paid registrations from paid item values', function () {
+    seedLancamentoItemSettings(25000);
+    CategoriaLancamento::ensureSystemDefaults();
+
+    $category = CategoriaLancamento::query()
+        ->where('system_key', CategoriaLancamento::SYSTEM_CATEGORY_INSCRICAO)
+        ->firstOrFail();
+
+    $campista = Campista::factory()->create([
+        'nome' => 'João Item',
+        'status' => StatusInscricao::Pendente->value,
+        'forma_pagamento' => FormaPagamento::NaoPago->value,
+        'dia_pagamento' => null,
+        'tribo_id' => null,
+        'user_id' => null,
+    ]);
+
+    $lancamento = lancamentoItemEntry([
+        'valor' => 0,
+        'status' => StatusLacamento::Pago->value,
+    ]);
+
+    app(RegistrationPaymentAllocator::class)->syncItems($lancamento, [
+        [
+            'nome' => 'João Item',
+            'valor' => 25000,
+            'categoria_lancamento_id' => $category->id,
+            'registration_type' => Campista::class,
+            'registration_id' => $campista->id,
+        ],
+    ]);
+
+    expect($lancamento->fresh()->valor)->toBe(25000)
+        ->and($lancamento->fresh()->items)->toHaveCount(1)
+        ->and($lancamento->fresh()->items->first()->categoria_lancamento_id)->toBe($category->id)
+        ->and(app(RegistrationPaymentAllocator::class)->paidAmountFor($campista->fresh()))->toBe(25000)
+        ->and(app(RegistrationPaymentAllocator::class)->remainingAmountFor($campista->fresh()))->toBe(0)
+        ->and($campista->fresh()->status)->toBe(StatusInscricao::Pago)
+        ->and($campista->fresh()->forma_pagamento)->toBe(FormaPagamento::Pix)
+        ->and($campista->fresh()->dia_pagamento?->format('Y-m-d'))->toBe('2026-07-01');
+});
+
+it('validates item category compatibility with launch type', function () {
+    $expenseCategory = CategoriaLancamento::query()->create([
+        'nome' => 'Mercado',
+        'tipo' => TipoLacamento::Despesa,
+        'cor' => '#ef4444',
+        'icone' => 'heroicon-o-shopping-cart',
+        'ativo' => true,
+    ]);
+
+    $lancamento = lancamentoItemEntry([
+        'tipo' => TipoLacamento::Receita->value,
+        'valor' => 0,
+    ]);
+
+    expect(fn () => app(RegistrationPaymentAllocator::class)->syncItems($lancamento, [
+        [
+            'nome' => 'Item incompatível',
+            'valor' => 1000,
+            'categoria_lancamento_id' => $expenseCategory->id,
+        ],
+    ]))->toThrow(ValidationException::class);
+});
+
+function seedLancamentoItemSettings(int $amount): void
+{
+    DB::table('settings')->updateOrInsert(
+        [
+            'group' => 'general',
+            'name' => 'valor_acampamento',
+        ],
+        [
+            'payload' => json_encode($amount),
+        ],
+    );
+}
+
+function lancamentoItemEntry(array $overrides = []): Lancamento
+{
+    return Lancamento::factory()->create(array_replace([
+        'nome' => 'Lançamento por item',
+        'descricao' => 'Pagamento por item',
+        'comprador' => null,
+        'data' => '2026-07-01',
+        'valor' => 0,
+        'tipo' => TipoLacamento::Receita->value,
+        'status' => StatusLacamento::Pendente->value,
+        'forma_pagamento' => FormaPagamento::Pix->value,
+        'comprovante' => [],
+        'user_id' => null,
+    ], $overrides));
+}

--- a/tests/Feature/PublicFilamentAssetsTest.php
+++ b/tests/Feature/PublicFilamentAssetsTest.php
@@ -121,6 +121,7 @@ it('stores registration photo uploads on the public disk so previews can load sa
     $campistaTable = file_get_contents(app_path('Filament/Resources/CampistaResource/CampistaTable.php'));
     $equipeTable = file_get_contents(app_path('Filament/Resources/EquipeTrabalhoResource/EquipeTrabalhoTable.php'));
     $campistaView = file_get_contents(app_path('Filament/Resources/CampistaResource/Pages/ViewCampista.php'));
+    $publicCampistaForm = file_get_contents(app_path('Livewire/CampistaForm.php'));
     $publicEquipeForm = file_get_contents(app_path('Livewire/EquipeTrabalhoForm.php'));
 
     expect($campistaForm)
@@ -141,8 +142,10 @@ it('stores registration photo uploads on the public disk so previews can load sa
         ->toContain("->disk('public')")
         ->and($campistaView)
         ->toContain('Storage::disk(\'public\')->url($avatar)')
+        ->and($publicCampistaForm)
+        ->toContain('FilamentUploadState::storedPath($this->data[\'avatar_url\'] ?? null, \'foto-formulario\')')
         ->and($publicEquipeForm)
-        ->toContain("->store('foto-formulario-equipe-trabalho', 'public')");
+        ->toContain('FilamentUploadState::storedPath($this->data[\'avatar_url\'] ?? null, \'foto-formulario-equipe-trabalho\')');
 });
 
 it('keeps parish community fields visible for zero-valued parish options', function () {


### PR DESCRIPTION
- Move financial categories and registration links into lancamento items so entries can hold multiple classified values.
- Add a batch lancamento page for pending registration and manual launches.
- Harden Filament upload and notification hydration handling with tests.