### PR TITLE
Normalize masked financial batch amounts as cents

### DIFF
--- a/.claude/napkin.md
+++ b/.claude/napkin.md
@@ -21,8 +21,8 @@
    Do instead: wait for `window.Alpine && window.Livewire`, then interact with `.fi-dropdown-trigger` for mousedown-driven dropdowns.
 
 ## Shell & Command Reliability
-1. **[2026-06-06] No repo-specific shell rule yet**
-   Do instead: prefer repo-native commands discovered from Composer, npm, and docs.
+1. **[2026-06-08] SQLite test DB cannot handle parallel test commands**
+   Do instead: run `php artisan test` commands sequentially because `.env.testing` points to the shared `database/database.sqlite`; if locks corrupt schema state, back up and recreate that untracked file before rerunning.
 
 ## Domain Behavior Guardrails
 1. **[2026-06-07] Filament dropdowns need an explicit layer scale**

--- a/app/Filament/Resources/LancamentoResource/Forms/LancamentoForm.php
+++ b/app/Filament/Resources/LancamentoResource/Forms/LancamentoForm.php
@@ -151,7 +151,8 @@ abstract class LancamentoForm
                                         ->maxLength(255)
                                         ->columnSpan([
                                             'default' => 'full',
-                                            'lg' => 4,
+                                            'md' => 1,
+                                            'xl' => 5,
                                         ]),
 
                                     Money::make('valor')
@@ -161,7 +162,8 @@ abstract class LancamentoForm
                                         ->required()
                                         ->columnSpan([
                                             'default' => 'full',
-                                            'lg' => 2,
+                                            'md' => 1,
+                                            'xl' => 2,
                                         ]),
 
                                     Select::make('categoria_lancamento_id')
@@ -174,7 +176,8 @@ abstract class LancamentoForm
                                         ->disabled(fn (Get $get): bool => blank($get('../../tipo')))
                                         ->columnSpan([
                                             'default' => 'full',
-                                            'lg' => 3,
+                                            'md' => 1,
+                                            'xl' => 5,
                                         ]),
 
                                     Select::make('registration_type')
@@ -188,7 +191,8 @@ abstract class LancamentoForm
                                         ->placeholder('Sem vínculo')
                                         ->columnSpan([
                                             'default' => 'full',
-                                            'lg' => 3,
+                                            'md' => 1,
+                                            'xl' => 3,
                                         ]),
 
                                     Select::make('registration_id')
@@ -204,8 +208,8 @@ abstract class LancamentoForm
                                                 $get('registration_type'),
                                                 $search,
                                                 $record?->id,
-                                            filled($get('registration_id')) ? (int) $get('registration_id') : null,
-                                        ))
+                                                filled($get('registration_id')) ? (int) $get('registration_id') : null,
+                                            ))
                                         ->searchable()
                                         ->preload()
                                         ->live()
@@ -219,7 +223,8 @@ abstract class LancamentoForm
                                         ->disabled(fn (Get $get): bool => blank($get('registration_type')))
                                         ->columnSpan([
                                             'default' => 'full',
-                                            'lg' => 6,
+                                            'md' => 2,
+                                            'xl' => 9,
                                         ]),
 
                                     Textarea::make('descricao')
@@ -227,7 +232,11 @@ abstract class LancamentoForm
                                         ->rows(2)
                                         ->columnSpanFull(),
                                 ])
-                                ->columns(12)
+                                ->columns([
+                                    'default' => 1,
+                                    'md' => 2,
+                                    'xl' => 12,
+                                ])
                                 ->defaultItems(1)
                                 ->minItems(1)
                                 ->addActionLabel('Adicionar item')
@@ -245,8 +254,8 @@ abstract class LancamentoForm
                         ->schema([
                             Repeater::make('comprovante')
                                 ->label('Comprovantes')
-                                ->required(fn (Get $get): bool => self::requiresComprovante($get('tipo'), $get('forma_pagamento')))
-                                ->minItems(fn (Get $get): int => self::requiresComprovante($get('tipo'), $get('forma_pagamento')) ? 1 : 0)
+                                ->required(fn (Get $get): bool => self::requiresComprovante($get('status'), $get('tipo'), $get('forma_pagamento')))
+                                ->minItems(fn (Get $get): int => self::requiresComprovante($get('status'), $get('tipo'), $get('forma_pagamento')) ? 1 : 0)
                                 ->afterStateHydrated(static function (Repeater $component): void {
                                     $component->rawState(self::comprovanteRepeaterFormState($component->getRawState()));
                                     $component->hydrateItems();
@@ -258,7 +267,7 @@ abstract class LancamentoForm
                                         ->placeholder('Tamanho max.: 2MB')
                                         ->hint('Tamanho máximo: 2MB')
                                         ->label('Documento')
-                                        ->required(fn (Get $get): bool => self::requiresComprovante($get('../../tipo'), $get('../../forma_pagamento')))
+                                        ->required(fn (Get $get): bool => self::requiresComprovante($get('../../status'), $get('../../tipo'), $get('../../forma_pagamento')))
                                         ->downloadable()
                                         ->openable()
                                         ->multiple()
@@ -473,9 +482,26 @@ abstract class LancamentoForm
         return (int) $type === TipoLacamento::Despesa->value;
     }
 
-    private static function requiresComprovante(mixed $type, mixed $paymentMethod): bool
+    private static function requiresComprovante(mixed $status, mixed $type, mixed $paymentMethod): bool
     {
+        if (! self::isPaidStatus($status)) {
+            return false;
+        }
+
         return ! (self::isRevenueType($type) && self::isCashPayment($paymentMethod));
+    }
+
+    private static function isPaidStatus(mixed $status): bool
+    {
+        if ($status instanceof StatusLacamento) {
+            return $status === StatusLacamento::Pago;
+        }
+
+        if (blank($status)) {
+            return false;
+        }
+
+        return (int) $status === StatusLacamento::Pago->value;
     }
 
     private static function isRevenueType(mixed $type): bool

--- a/app/Filament/Resources/LancamentoResource/Pages/BatchLancamentos.php
+++ b/app/Filament/Resources/LancamentoResource/Pages/BatchLancamentos.php
@@ -11,6 +11,7 @@ use App\Models\Campista;
 use App\Models\EquipeTrabalho;
 use App\Settings\GeneralSettings;
 use App\Support\Financeiro\LancamentoBatchCreator;
+use App\Support\Financeiro\MoneyAmount;
 use App\Support\Financeiro\RegistrationPaymentAllocator;
 use Filament\Actions\Action;
 use Filament\Forms\Components\DatePicker;
@@ -147,10 +148,11 @@ class BatchLancamentos extends Page
                             ->prefix(RawJs::make('R$'))
                             ->live(onBlur: true)
                             ->afterStateUpdated(function (Get $get, Set $set): void {
+                                $amount = MoneyAmount::toCents($get('default_value'));
                                 $items = collect($get('registration_items') ?? [])
                                     ->map(fn (array $item): array => [
                                         ...$item,
-                                        'valor' => $get('default_value'),
+                                        'valor' => $amount,
                                     ])
                                     ->all();
 
@@ -183,7 +185,7 @@ class BatchLancamentos extends Page
                                 $set('registration_items', $this->registrationItemState(
                                     $get('registration_type'),
                                     is_array($state) ? $state : [],
-                                    (int) ($get('default_value') ?? $this->defaultRegistrationAmount()),
+                                    $get('default_value') ?? $this->defaultRegistrationAmount(),
                                 ));
                             })
                             ->columnSpan([
@@ -295,10 +297,11 @@ class BatchLancamentos extends Page
                             ->prefix(RawJs::make('R$'))
                             ->live(onBlur: true)
                             ->afterStateUpdated(function (Get $get, Set $set): void {
+                                $amount = MoneyAmount::toCents($get('manual_default_value'));
                                 $items = collect($get('manual_items') ?? [])
                                     ->map(fn (array $item): array => [
                                         ...$item,
-                                        'valor' => $get('manual_default_value'),
+                                        'valor' => $amount,
                                     ])
                                     ->all();
 
@@ -433,11 +436,13 @@ class BatchLancamentos extends Page
      * @param  array<int, mixed>  $ids
      * @return array<int, array<string, mixed>>
      */
-    private function registrationItemState(?string $registrationType, array $ids, int $amount): array
+    private function registrationItemState(?string $registrationType, array $ids, mixed $amount): array
     {
         if (! is_string($registrationType) || ! array_key_exists($registrationType, RegistrationPaymentAllocator::registrationTypeOptions())) {
             return [];
         }
+
+        $amount = MoneyAmount::toCents($amount);
 
         /** @var class-string<Model> $registrationType */
         return collect($ids)

--- a/app/Support/Financeiro/LancamentoBatchCreator.php
+++ b/app/Support/Financeiro/LancamentoBatchCreator.php
@@ -269,11 +269,7 @@ class LancamentoBatchCreator
 
     private function amount(mixed $value): int
     {
-        if (is_string($value)) {
-            $value = str_replace(['R$', '.', ',', ' '], ['', '', '.', ''], $value);
-        }
-
-        return abs((int) round(((float) $value)));
+        return MoneyAmount::toCents($value);
     }
 
     private function nullableText(mixed $value): ?string

--- a/app/Support/Financeiro/MoneyAmount.php
+++ b/app/Support/Financeiro/MoneyAmount.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace App\Support\Financeiro;
+
+final class MoneyAmount
+{
+    public static function toCents(mixed $value): int
+    {
+        if ($value === null || $value === '') {
+            return 0;
+        }
+
+        if (is_int($value)) {
+            return abs($value);
+        }
+
+        if (is_float($value)) {
+            return abs((int) round($value));
+        }
+
+        $value = trim((string) $value);
+
+        if ($value === '') {
+            return 0;
+        }
+
+        $value = str_replace(['R$', ' '], '', $value);
+
+        if (str_contains($value, ',')) {
+            $decimal = str_replace(',', '.', str_replace('.', '', $value));
+
+            return abs((int) round(((float) $decimal) * 100));
+        }
+
+        if (preg_match('/^-?\d+\.\d{1,2}$/', $value) === 1) {
+            return abs((int) round(((float) $value) * 100));
+        }
+
+        return abs((int) preg_replace('/[^\d]/', '', $value));
+    }
+}

--- a/tests/Feature/FinancialEntryItemsTest.php
+++ b/tests/Feature/FinancialEntryItemsTest.php
@@ -204,6 +204,31 @@ it('allows cash revenue financial entries without receipt attachments', function
         ->and($lancamento->items)->toHaveCount(1);
 });
 
+it('allows pending financial entries without receipt attachments', function () {
+    $this->seed(ShieldSeeder::class);
+
+    $user = User::factory()->create();
+    $user->assignRole('Super Administrador');
+    $this->actingAs($user);
+
+    Livewire::test(CreateLancamento::class)
+        ->fillForm(financialItemFormPayload([
+            'nome' => 'PIX pendente sem comprovante',
+            'status' => StatusLacamento::Pendente->value,
+            'tipo' => TipoLacamento::Receita->value,
+            'forma_pagamento' => FormaPagamento::Pix->value,
+            'comprovante' => [],
+        ]))
+        ->call('create')
+        ->assertHasNoFormErrors();
+
+    $lancamento = Lancamento::query()->where('nome', 'PIX pendente sem comprovante')->firstOrFail();
+
+    expect($lancamento->comprovante)
+        ->toBe([])
+        ->and($lancamento->status)->toBe(StatusLacamento::Pendente);
+});
+
 it('requires receipt attachments outside cash revenue financial entries', function () {
     $this->seed(ShieldSeeder::class);
 
@@ -344,6 +369,16 @@ it('exposes item links in the financial entry form and table', function () {
         ->toContain('itemsFormState');
 
     expect(Schema::getColumnType('lancamentos', 'descricao'))->toBe('text');
+});
+
+it('uses a spacious responsive layout for financial item fields', function () {
+    $form = file_get_contents(app_path('Filament/Resources/LancamentoResource/Forms/LancamentoForm.php'));
+
+    expect($form)
+        ->toContain("Repeater::make('items')")
+        ->toContain("->columns([\n                                    'default' => 1,\n                                    'md' => 2,\n                                    'xl' => 12,\n                                ])")
+        ->toContain("'xl' => 5")
+        ->toContain("'xl' => 9");
 });
 
 it('normalizes legacy receipt names into optional observations', function () {

--- a/tests/Feature/LancamentoBatchPageTest.php
+++ b/tests/Feature/LancamentoBatchPageTest.php
@@ -60,6 +60,22 @@ it('shows a visual warning when the configured camp amount is zero on batch regi
         ->assertSee('O campo de inscrições pode ficar sem opções enquanto o valor estiver zerado nas configurações.');
 });
 
+it('keeps registration item values in cents when propagating a masked default amount', function () {
+    $this->seed(ShieldSeeder::class);
+    seedLancamentoBatchSettings(35000);
+
+    $user = User::factory()->create();
+    $user->assignRole('Super Administrador');
+    $this->actingAs($user);
+
+    $campista = lancamentoBatchCampista('Ana Souza 001');
+
+    Livewire::test(BatchLancamentos::class)
+        ->set('data.default_value', '350,00')
+        ->set('data.registration_ids', [$campista->id])
+        ->assertSet('data.registration_items.0.valor', 35000);
+});
+
 it('creates one pending launch per selected campista registration using the default inscription category', function () {
     Carbon::setTestNow('2026-06-08 09:00:00');
     seedLancamentoBatchSettings(35000);
@@ -94,6 +110,32 @@ it('creates one pending launch per selected campista registration using the defa
         ->and($maria->fresh()->status)->toBe(StatusInscricao::Pendente);
 
     Carbon::setTestNow();
+});
+
+it('stores Brazilian masked registration item amounts as cents when creating a batch', function () {
+    seedLancamentoBatchSettings(35000);
+    CategoriaLancamento::ensureSystemDefaults();
+
+    $campista = lancamentoBatchCampista('Ana Souza 001');
+
+    app(LancamentoBatchCreator::class)->create([
+        'mode' => 'registrations',
+        'registration_type' => Campista::class,
+        'registration_ids' => [$campista->id],
+        'data' => '2026-07-01',
+        'registration_items' => [
+            [
+                'registration_id' => $campista->id,
+                'nome' => 'Ana Souza 001',
+                'valor' => '350,00',
+                'descricao' => null,
+            ],
+        ],
+    ]);
+
+    expect(Lancamento::query()->firstOrFail())
+        ->valor->toBe(35000)
+        ->items()->firstOrFail()->valor->toBe(35000);
 });
 
 it('creates team work contribution batches with the team contribution category', function () {


### PR DESCRIPTION
- Share money parsing across batch creation and Livewire propagation
- Allow pending entries without receipt attachments
- Improve financial item repeater responsiveness and test coverage