### PR TITLE
Improve report preview workflow and payment privacy

### DIFF
--- a/.claude/napkin.md
+++ b/.claude/napkin.md
@@ -7,17 +7,19 @@
 - Each item includes date + "Do instead".
 
 ## Execution & Validation (Highest Priority)
-1. **[2026-06-06] Public Livewire registration pages need settings rows in tests**
+1. **[2026-06-09] Large report previews need a real web request check**
+   Do instead: after admin report preview changes, test the unfiltered route through `juvenil.test` or Playwright and confirm the expected response type; focused small-record tests can miss web runtime failures.
+2. **[2026-06-06] Public Livewire registration pages need settings rows in tests**
    Do instead: use `RefreshDatabase`, disable Vite, and seed/update `general` settings before asserting route rendering.
-2. **[2026-06-07] Filament package translations use Laravel vendor overrides**
+3. **[2026-06-07] Filament package translations use Laravel vendor overrides**
    Do instead: add package keys under `lang/vendor/{package}/pt_BR/*.php` and validate with `php artisan tinker --execute='app()->setLocale("pt_BR"); echo __("package::file.key");'`.
-3. **[2026-06-07] Filament admin table theming is global CSS**
+4. **[2026-06-07] Filament admin table theming is global CSS**
    Do instead: style `.fi-ta-*` selectors in `resources/css/filament/admin/theme.css`, then validate with `npm run build`, focused PHP tests, and `tests/Browser/admin-panel-layout.spec.js`.
-4. **[2026-06-06] Browser checks may run through Vite dev assets**
+5. **[2026-06-06] Browser checks may run through Vite dev assets**
    Do instead: check `public/hot` and the loaded script URLs before trusting production-build screenshots.
-5. **[2026-06-07] Authenticated Filament layout needs real-login browser checks**
+6. **[2026-06-07] Authenticated Filament layout needs real-login browser checks**
    Do instead: use Playwright to log in, assert admin cookie consent is hidden, verify document/table overflow, and capture dashboard/list screenshots.
-6. **[2026-06-07] Filament dropdown tests need client readiness**
+7. **[2026-06-07] Filament dropdown tests need client readiness**
    Do instead: wait for `window.Alpine && window.Livewire`, then interact with `.fi-dropdown-trigger` for mousedown-driven dropdowns.
 
 ## Shell & Command Reliability

--- a/app/Filament/Pages/ReportsPage.php
+++ b/app/Filament/Pages/ReportsPage.php
@@ -19,6 +19,7 @@ use Filament\Schemas\Components\Utilities\Get;
 use Filament\Schemas\Components\Utilities\Set;
 use Filament\Schemas\Schema;
 use Filament\Support\Enums\Alignment;
+use Filament\Support\Enums\Width;
 use Illuminate\Support\HtmlString;
 
 class ReportsPage extends Page
@@ -50,6 +51,7 @@ class ReportsPage extends Page
         'search' => null,
         'show_sensitive_health' => false,
         'confirm_sensitive_health' => false,
+        'show_payment_data' => false,
     ];
 
     public static function getRoutePath(Panel $panel): string
@@ -59,6 +61,7 @@ class ReportsPage extends Page
 
     public function mount(): void
     {
+        $this->filters = $this->filtersFromQuery(request()->query());
         $this->filters['type'] ??= $this->defaultReportType();
 
         $this->form->fill($this->filters);
@@ -71,8 +74,23 @@ class ReportsPage extends Page
             ->columns(1)
             ->components([
                 Section::make('Montar relatório')
-                    ->description('Escolha o tipo e refine a prévia antes de imprimir.')
+                    ->description('Escolha o tipo, aplique os filtros e gere a prévia no mesmo navegador.')
                     ->icon('heroicon-o-adjustments-horizontal')
+                    ->headerActions([
+                        Action::make('reportHelp')
+                            ->label('Dúvidas')
+                            ->icon('heroicon-o-question-mark-circle')
+                            ->color('gray')
+                            ->slideOver()
+                            ->modalWidth(Width::Large)
+                            ->modalHeading('Dúvidas da central de relatórios')
+                            ->modalDescription('Use esta referência para escolher o relatório certo antes de abrir a prévia.')
+                            ->modalSubmitAction(false)
+                            ->modalCancelActionLabel('Fechar')
+                            ->modalContent(fn () => view('filament.pages.partials.reports-help', [
+                                'types' => $this->reportTypes(),
+                            ])),
+                    ])
                     ->schema([
                         Grid::make([
                             'default' => 1,
@@ -90,8 +108,19 @@ class ReportsPage extends Page
                                     ->selectablePlaceholder(false)
                                     ->columnSpan([
                                         'default' => 'full',
-                                        'md' => 1,
-                                        'xl' => 3,
+                                        'md' => 2,
+                                        'xl' => 4,
+                                    ]),
+
+                                TextInput::make('search')
+                                    ->label('Busca')
+                                    ->placeholder('Nome, responsável, bairro ou cidade')
+                                    ->prefixIcon('heroicon-o-magnifying-glass')
+                                    ->live(debounce: 500)
+                                    ->columnSpan([
+                                        'default' => 'full',
+                                        'md' => 2,
+                                        'xl' => 8,
                                     ]),
 
                                 Select::make('status')
@@ -104,7 +133,7 @@ class ReportsPage extends Page
                                     ->columnSpan([
                                         'default' => 'full',
                                         'md' => 1,
-                                        'xl' => 3,
+                                        'xl' => 4,
                                     ]),
 
                                 Select::make('tribo_id')
@@ -119,7 +148,7 @@ class ReportsPage extends Page
                                     ->columnSpan([
                                         'default' => 'full',
                                         'md' => 1,
-                                        'xl' => 3,
+                                        'xl' => 4,
                                     ]),
 
                                 Select::make('presenca')
@@ -134,17 +163,7 @@ class ReportsPage extends Page
                                     ->columnSpan([
                                         'default' => 'full',
                                         'md' => 1,
-                                        'xl' => 3,
-                                    ]),
-
-                                TextInput::make('search')
-                                    ->label('Busca')
-                                    ->placeholder('Nome, responsável, bairro ou cidade')
-                                    ->prefixIcon('heroicon-o-magnifying-glass')
-                                    ->live(debounce: 500)
-                                    ->columnSpan([
-                                        'default' => 'full',
-                                        'xl' => 9,
+                                        'xl' => 4,
                                     ]),
 
                                 Toggle::make('show_sensitive_health')
@@ -159,7 +178,19 @@ class ReportsPage extends Page
                                     ->visible(fn (): bool => $this->canUseSensitiveHealthFilter())
                                     ->columnSpan([
                                         'default' => 'full',
-                                        'xl' => 3,
+                                        'md' => 1,
+                                        'xl' => 6,
+                                    ]),
+
+                                Toggle::make('show_payment_data')
+                                    ->label('Exibir dados de pagamento')
+                                    ->helperText('Por padrão, dados de pagamento permanecem ocultos nos relatórios.')
+                                    ->live()
+                                    ->visible(fn (): bool => $this->canUsePaymentDataFilter())
+                                    ->columnSpan([
+                                        'default' => 'full',
+                                        'md' => 1,
+                                        'xl' => 6,
                                     ]),
 
                                 Html::make(new HtmlString(
@@ -185,7 +216,7 @@ class ReportsPage extends Page
                             ->icon('heroicon-o-printer')
                             ->color('primary')
                             ->url(fn (): string => route('admin.reports.print', $this->previewQuery()))
-                            ->openUrlInNewTab()
+                            ->extraAttributes(['data-report-preview-link' => 'true'])
                             ->disabled(fn (): bool => blank($this->filters['type'] ?? null) || $this->missingSensitiveHealthConfirmation()),
                     ])
                     ->footerActionsAlignment(Alignment::End),
@@ -209,14 +240,28 @@ class ReportsPage extends Page
 
     public function previewQuery(): array
     {
-        return collect($this->filters)
+        $query = collect($this->filters)
             ->filter(fn (mixed $value): bool => $value !== null && $value !== '' && $value !== [] && $value !== false)
             ->all();
+
+        return [
+            ...$query,
+            'return' => route('filament.admin.pages.reports-page', $query),
+        ];
     }
 
     private function canUseSensitiveHealthFilter(): bool
     {
         return auth()->user()?->can('view_sensitive_health_campista') ?? false;
+    }
+
+    private function canUsePaymentDataFilter(): bool
+    {
+        $user = auth()->user();
+
+        return $user !== null
+            && $user->can('view_any_lancamento')
+            && $user->can('view_lancamento');
     }
 
     private function missingSensitiveHealthConfirmation(): bool
@@ -229,5 +274,56 @@ class ReportsPage extends Page
     private function defaultReportType(): ?string
     {
         return data_get($this->reportTypes(), '0.value');
+    }
+
+    private function filtersFromQuery(array $query): array
+    {
+        $filters = $this->filters;
+
+        if (array_key_exists('type', $query)) {
+            $filters['type'] = filled($query['type']) ? (string) $query['type'] : null;
+        }
+
+        if (array_key_exists('status', $query)) {
+            $filters['status'] = $this->integerList($query['status']);
+        }
+
+        if (array_key_exists('tribo_id', $query)) {
+            $filters['tribo_id'] = $this->integerList($query['tribo_id']);
+        }
+
+        if (array_key_exists('presenca', $query)) {
+            $filters['presenca'] = $query['presenca'] === '' || $query['presenca'] === null
+                ? null
+                : (string) (int) $query['presenca'];
+        }
+
+        if (array_key_exists('search', $query)) {
+            $filters['search'] = filled($query['search']) ? (string) $query['search'] : null;
+        }
+
+        foreach (['show_sensitive_health', 'confirm_sensitive_health', 'show_payment_data'] as $key) {
+            if (array_key_exists($key, $query)) {
+                $filters[$key] = $this->truthy($query[$key]);
+            }
+        }
+
+        return $filters;
+    }
+
+    private function integerList(mixed $values): array
+    {
+        $values = is_array($values) ? $values : [$values];
+
+        return collect($values)
+            ->filter(fn (mixed $value): bool => $value !== null && $value !== '')
+            ->map(fn (mixed $value): int => (int) $value)
+            ->values()
+            ->all();
+    }
+
+    private function truthy(mixed $value): bool
+    {
+        return filter_var($value, FILTER_VALIDATE_BOOLEAN);
     }
 }

--- a/app/Http/Controllers/Admin/PrintableReportController.php
+++ b/app/Http/Controllers/Admin/PrintableReportController.php
@@ -5,6 +5,7 @@ namespace App\Http\Controllers\Admin;
 use App\Support\Reports\CampistaReportData;
 use App\Support\Reports\CampistaReportType;
 use Illuminate\Http\Request;
+use Illuminate\Support\Str;
 
 class PrintableReportController
 {
@@ -17,8 +18,25 @@ class PrintableReportController
         abort_unless($type instanceof CampistaReportType, 404);
         abort_unless($type->canBeAccessedBy($user), 403);
 
+        $report = $reports->payload($type, $request->query(), $user);
+
         return view('admin.reports.print', [
-            'report' => $reports->payload($type, $request->query(), $user),
+            'report' => $report,
+            'returnUrl' => $this->returnUrl($request->query('return')),
+            'logoSrc' => asset('img/logo.png'),
         ]);
+    }
+
+    private function returnUrl(mixed $value): string
+    {
+        $fallback = route('filament.admin.pages.reports-page');
+
+        if (! is_string($value) || blank($value)) {
+            return $fallback;
+        }
+
+        return Str::startsWith($value, route('filament.admin.pages.reports-page'))
+            ? $value
+            : $fallback;
     }
 }

--- a/app/Support/Reports/CampistaReportData.php
+++ b/app/Support/Reports/CampistaReportData.php
@@ -40,6 +40,7 @@ class CampistaReportData
         $records = $this->records($filters);
         $canUseSensitiveHealth = $user->can('view_sensitive_health_campista');
         $showSensitiveHealth = $this->canExposeSensitiveHealth($filters, $user);
+        $showPaymentData = $this->canExposePaymentData($filters, $user);
 
         if ($type === CampistaReportType::SensitiveHealth) {
             $records = $records->filter(fn (Campista $campista): bool => $this->hasSensitiveHealthFlag($campista))->values();
@@ -55,7 +56,7 @@ class CampistaReportData
             'showSensitiveHealth' => $showSensitiveHealth,
             'recordsCount' => $records->count(),
             'fichas' => $type === CampistaReportType::RegistrationFichas
-                ? $records->map(fn (Campista $campista): array => $this->ficha($campista, $showSensitiveHealth, $user))->all()
+                ? $records->map(fn (Campista $campista): array => $this->ficha($campista, $showSensitiveHealth, $showPaymentData))->all()
                 : [],
             'tribes' => $type === CampistaReportType::TribeQuadrant
                 ? $this->tribeGroups($records)
@@ -113,7 +114,7 @@ class CampistaReportData
             ->get();
     }
 
-    private function ficha(Campista $campista, bool $showSensitiveHealth, User $user): array
+    private function ficha(Campista $campista, bool $showSensitiveHealth, bool $showPaymentData): array
     {
         $formData = $campista->form_data ?? [];
         $status = $this->statusEnum($campista);
@@ -174,6 +175,7 @@ class CampistaReportData
             'sections' => [
                 [
                     'title' => 'Dados pessoais',
+                    'area' => 'personal',
                     'fields' => [
                         ['label' => 'Nome completo', 'value' => $campista->nome],
                         ['label' => 'Nascimento', 'value' => data_get($formData, 'data_nacimento')],
@@ -187,6 +189,7 @@ class CampistaReportData
                 ],
                 [
                     'title' => 'Contato e responsável',
+                    'area' => 'contact',
                     'fields' => [
                         ['label' => 'Responsável', 'value' => $this->responsibleName($campista)],
                         ['label' => 'Telefone do responsável', 'value' => $this->responsiblePhone($campista)],
@@ -194,6 +197,7 @@ class CampistaReportData
                 ],
                 [
                     'title' => 'Endereço',
+                    'area' => 'address',
                     'fields' => [
                         ['label' => 'CEP', 'value' => data_get($formData, 'cep')],
                         ['label' => 'Rua', 'value' => data_get($formData, 'rua')],
@@ -206,6 +210,7 @@ class CampistaReportData
                 ],
                 [
                     'title' => 'Comunidade e experiência',
+                    'area' => 'community',
                     'fields' => [
                         ['label' => 'Paróquia', 'value' => $this->parishLabel(data_get($formData, 'paroquia'))],
                         ['label' => 'Comunidade', 'value' => $this->communityLabel(data_get($formData, 'paroquia'), data_get($formData, 'comunidade'))],
@@ -218,6 +223,7 @@ class CampistaReportData
                 ],
                 [
                     'title' => 'Saúde e cuidados',
+                    'area' => 'health',
                     'fields' => [
                         ['label' => 'Toma remédio?', 'value' => $this->sensitiveBooleanLabel($takesMedicine, $showSensitiveHealth), 'tone' => $takesMedicine ? 'warning' : 'success'],
                         ['label' => 'Detalhes do remédio', 'value' => $this->sensitiveValue(data_get($formData, 'remedio'), $takesMedicine, $showSensitiveHealth)],
@@ -225,30 +231,17 @@ class CampistaReportData
                         ['label' => 'Recomendação de cuidado', 'value' => $this->sensitiveValue(data_get($formData, 'recomendacao'), $hasRecommendation, $showSensitiveHealth)],
                     ],
                 ],
-                [
-                    'title' => 'Controle da inscrição',
-                    'fields' => [
-                        ['label' => 'Data de inscrição', 'value' => $campista->created_at?->format('d/m/Y H:i')],
-                        ['label' => 'Data de pagamento', 'value' => $campista->dia_pagamento?->format('d/m/Y')],
-                        ['label' => 'Forma de pagamento', 'value' => $payment?->getLabel()],
-                        ['label' => 'Observações', 'value' => $campista->observacoes, 'wide' => true],
-                    ],
-                ],
             ],
-            'can_view_payments' => $this->canViewLinkedPayments($user),
-            'payments' => $this->linkedPaymentsData($campista, $user),
+            'can_view_payments' => $showPaymentData,
+            'payments' => $showPaymentData ? $this->linkedPaymentsData($campista) : [],
         ];
     }
 
     /**
      * @return array<int, array{name: string, amount: string, date: string, method: array{label: string, icon: string, color: string, accent: string}, status: array{label: string, icon: string, color: string, accent: string}, url: ?string}>
      */
-    private function linkedPaymentsData(Campista $campista, User $user): array
+    private function linkedPaymentsData(Campista $campista): array
     {
-        if (! $this->canViewLinkedPayments($user)) {
-            return [];
-        }
-
         $items = $campista->relationLoaded('lancamentoItems')
             ? $campista->lancamentoItems
             : $campista->lancamentoItems()->with('lancamento')->get();
@@ -287,12 +280,6 @@ class CampistaReportData
             ],
             'url' => $lancamento ? route('filament.admin.resources.lancamentos.view', ['record' => $lancamento]) : null,
         ];
-    }
-
-    private function canViewLinkedPayments(User $user): bool
-    {
-        return $user->can('view_any_lancamento')
-            && $user->can('view_lancamento');
     }
 
     private function money(int $amount): string
@@ -462,6 +449,13 @@ class CampistaReportData
         return $user->can('view_sensitive_health_campista')
             && $this->truthy($filters['show_sensitive_health'] ?? false)
             && $this->truthy($filters['confirm_sensitive_health'] ?? false);
+    }
+
+    private function canExposePaymentData(array $filters, User $user): bool
+    {
+        return $user->can('view_any_lancamento')
+            && $user->can('view_lancamento')
+            && $this->truthy($filters['show_payment_data'] ?? false);
     }
 
     private function integerList(mixed $values): array

--- a/resources/css/filament/admin/theme.css
+++ b/resources/css/filament/admin/theme.css
@@ -1516,6 +1516,10 @@ body.fi-panel-admin:not(.juvenil-admin-auth-body) .juvenil-report-page {
 
 body.fi-panel-admin:not(.juvenil-admin-auth-body) .juvenil-report-brief {
     position: relative;
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) minmax(9rem, auto);
+    align-items: end;
+    gap: clamp(1rem, 2vw, 1.6rem);
     overflow: hidden;
     border: 1px solid rgba(157, 219, 239, 0.24);
     background:
@@ -1534,7 +1538,8 @@ body.fi-panel-admin:not(.juvenil-admin-auth-body) .juvenil-report-brief::after {
 }
 
 body.fi-panel-admin:not(.juvenil-admin-auth-body) .juvenil-report-brief__eyebrow,
-body.fi-panel-admin:not(.juvenil-admin-auth-body) .juvenil-report-card span {
+body.fi-panel-admin:not(.juvenil-admin-auth-body) .juvenil-report-empty span,
+body.fi-panel-admin:not(.juvenil-admin-auth-body) .juvenil-report-help__item span {
     color: #9ddbef;
     font-size: 0.74rem;
     font-weight: 800;
@@ -1552,60 +1557,48 @@ body.fi-panel-admin:not(.juvenil-admin-auth-body) .juvenil-report-brief h2 {
 }
 
 body.fi-panel-admin:not(.juvenil-admin-auth-body) .juvenil-report-brief p,
-body.fi-panel-admin:not(.juvenil-admin-auth-body) .juvenil-report-card p {
+body.fi-panel-admin:not(.juvenil-admin-auth-body) .juvenil-report-empty p,
+body.fi-panel-admin:not(.juvenil-admin-auth-body) .juvenil-report-help__item p {
     color: rgba(216, 242, 250, 0.78);
     margin: 0;
 }
 
-body.fi-panel-admin:not(.juvenil-admin-auth-body) .juvenil-report-grid {
+body.fi-panel-admin:not(.juvenil-admin-auth-body) .juvenil-report-brief__meter {
     display: grid;
-    gap: clamp(0.85rem, 1.4vw, 1.15rem);
-    grid-template-columns: repeat(auto-fit, minmax(min(100%, 16rem), 1fr));
+    justify-items: end;
+    gap: 0.25rem;
+    border-left: 1px solid rgba(157, 219, 239, 0.22);
+    padding-left: clamp(1rem, 2vw, 1.5rem);
+    text-align: right;
 }
 
-body.fi-panel-admin:not(.juvenil-admin-auth-body) .juvenil-report-card {
-    position: relative;
-    min-height: 9.25rem;
-    overflow: hidden;
-    border: 1px solid rgba(157, 219, 239, 0.2);
+body.fi-panel-admin:not(.juvenil-admin-auth-body) .juvenil-report-brief__meter span {
+    color: #f3fbff;
+    font-family: var(--display-font), var(--font-family), sans-serif;
+    font-size: clamp(2rem, 4vw, 3rem);
+    line-height: 0.9;
+}
+
+body.fi-panel-admin:not(.juvenil-admin-auth-body) .juvenil-report-brief__meter strong {
+    color: rgba(216, 242, 250, 0.74);
+    font-size: 0.72rem;
+    font-weight: 900;
+    letter-spacing: 0.12em;
+    line-height: 1rem;
+    text-transform: uppercase;
+}
+
+body.fi-panel-admin:not(.juvenil-admin-auth-body) .juvenil-report-empty {
+    border: 1px dashed rgba(157, 219, 239, 0.3);
     background:
         linear-gradient(180deg, rgba(7, 61, 69, 0.62), rgba(4, 31, 35, 0.78)),
         var(--juvenil-camp-panel-deep);
-    padding: 1rem;
-    transition:
-        border-color 180ms ease,
-        transform 180ms ease,
-        background 180ms ease;
+    padding: 1.1rem;
 }
 
-body.fi-panel-admin:not(.juvenil-admin-auth-body) .juvenil-report-card:hover {
-    border-color: rgba(244, 107, 18, 0.48);
-    background:
-        linear-gradient(180deg, rgba(7, 61, 69, 0.76), rgba(4, 31, 35, 0.86)),
-        var(--juvenil-camp-panel-deep);
-    transform: translateY(-1px);
-}
-
-body.fi-panel-admin:not(.juvenil-admin-auth-body) .juvenil-report-card::after {
-    position: absolute;
-    inset: auto 0 0;
-    height: 2px;
-    background: rgba(157, 219, 239, 0.36);
-    content: '';
-}
-
-body.fi-panel-admin:not(.juvenil-admin-auth-body) .juvenil-report-card--sensitive {
-    border-color: rgba(244, 107, 18, 0.5);
-    background:
-        linear-gradient(135deg, rgba(244, 107, 18, 0.17), rgba(4, 31, 35, 0.8)),
-        var(--juvenil-camp-panel-deep);
-}
-
-body.fi-panel-admin:not(.juvenil-admin-auth-body) .juvenil-report-card--sensitive::after {
-    background: var(--juvenil-camp-orange);
-}
-
-body.fi-panel-admin:not(.juvenil-admin-auth-body) .juvenil-report-card h3 {
+body.fi-panel-admin:not(.juvenil-admin-auth-body) .juvenil-report-empty h3,
+body.fi-panel-admin:not(.juvenil-admin-auth-body) .juvenil-report-help__item strong {
+    display: block;
     color: #f3fbff;
     font-size: 1rem;
     font-weight: 800;
@@ -1631,6 +1624,10 @@ body.fi-panel-admin:not(.juvenil-admin-auth-body) .juvenil-report-form .fi-secti
         rgba(3, 24, 28, 0.34);
 }
 
+body.fi-panel-admin:not(.juvenil-admin-auth-body) .juvenil-report-form .fi-section-header .fi-ac {
+    flex-wrap: nowrap;
+}
+
 body.fi-panel-admin:not(.juvenil-admin-auth-body) .juvenil-report-form .fi-section-content-ctn {
     background: rgba(3, 24, 28, 0.16);
 }
@@ -1648,6 +1645,79 @@ body.fi-panel-admin:not(.juvenil-admin-auth-body) .juvenil-report-form .fi-fo-fi
 body.fi-panel-admin:not(.juvenil-admin-auth-body) .juvenil-report-form :is(.fi-input-wrp, .fi-select-input) {
     min-height: 2.8rem;
     background: rgba(3, 24, 28, 0.66);
+}
+
+body.fi-panel-admin:not(.juvenil-admin-auth-body) .juvenil-report-help__list {
+    display: grid;
+    gap: 0.75rem;
+    margin: 0;
+    padding: 0;
+}
+
+body.fi-panel-admin:not(.juvenil-admin-auth-body) .juvenil-report-help__item {
+    display: grid;
+    gap: 0.34rem;
+    border: 1px solid rgba(157, 219, 239, 0.18);
+    background: rgba(3, 24, 28, 0.38);
+    padding: 0.95rem;
+}
+
+body.fi-panel-admin:not(.juvenil-admin-auth-body) .juvenil-report-help__item--restricted {
+    border-color: rgba(244, 107, 18, 0.44);
+    background: linear-gradient(135deg, rgba(244, 107, 18, 0.13), rgba(3, 24, 28, 0.48));
+}
+
+body.fi-panel-admin:not(.juvenil-admin-auth-body) .juvenil-report-help__item--restricted span {
+    color: #ffd7bd;
+}
+
+body.fi-panel-admin:not(.juvenil-admin-auth-body) .juvenil-report-loading[hidden] {
+    display: none;
+}
+
+body.fi-panel-admin:not(.juvenil-admin-auth-body) .juvenil-report-loading {
+    position: fixed;
+    inset: 0;
+    z-index: 999;
+    display: grid;
+    place-items: center;
+    background: rgba(3, 24, 28, 0.62);
+    backdrop-filter: blur(10px);
+}
+
+body.fi-panel-admin:not(.juvenil-admin-auth-body) .juvenil-report-loading__panel {
+    display: grid;
+    justify-items: center;
+    gap: 0.55rem;
+    width: min(24rem, calc(100vw - 2rem));
+    border: 1px solid rgba(157, 219, 239, 0.28);
+    background:
+        linear-gradient(180deg, rgba(7, 61, 69, 0.92), rgba(4, 31, 35, 0.94)),
+        var(--juvenil-camp-panel-deep);
+    color: #f3fbff;
+    padding: 1.4rem;
+    text-align: center;
+}
+
+body.fi-panel-admin:not(.juvenil-admin-auth-body) .juvenil-report-loading__panel p {
+    margin: 0;
+    color: rgba(216, 242, 250, 0.72);
+    font-size: 0.86rem;
+}
+
+body.fi-panel-admin:not(.juvenil-admin-auth-body) .juvenil-report-loading__spinner {
+    width: 2.2rem;
+    height: 2.2rem;
+    border: 3px solid rgba(157, 219, 239, 0.24);
+    border-top-color: var(--juvenil-camp-orange);
+    border-radius: 999px;
+    animation: juvenil-report-spin 800ms linear infinite;
+}
+
+@keyframes juvenil-report-spin {
+    to {
+        transform: rotate(360deg);
+    }
 }
 
 @media (max-width: 1023px) {
@@ -1690,8 +1760,17 @@ body.fi-panel-admin:not(.juvenil-admin-auth-body) .juvenil-report-form :is(.fi-i
         grid-template-columns: 1fr;
     }
 
-    body.fi-panel-admin:not(.juvenil-admin-auth-body) .juvenil-report-grid {
+    body.fi-panel-admin:not(.juvenil-admin-auth-body) .juvenil-report-brief {
         grid-template-columns: 1fr;
+    }
+
+    body.fi-panel-admin:not(.juvenil-admin-auth-body) .juvenil-report-brief__meter {
+        justify-items: start;
+        border-top: 1px solid rgba(157, 219, 239, 0.18);
+        border-left: 0;
+        padding-top: 1rem;
+        padding-left: 0;
+        text-align: left;
     }
 
     body.fi-panel-admin:not(.juvenil-admin-auth-body) .juvenil-registration-card__field {

--- a/resources/views/admin/reports/partials/registration-fichas.blade.php
+++ b/resources/views/admin/reports/partials/registration-fichas.blade.php
@@ -14,7 +14,7 @@
                     @endif
                 </div>
 
-                <div>
+                <div class="report-registration-ficha__name">
                     <span class="report-badge">Ficha oficial</span>
                     <h2>{{ $ficha['name'] }}</h2>
                     <p class="report-registration-ficha__meta">
@@ -59,87 +59,132 @@
             @endforeach
         </section>
 
-        <div class="report-two-col report-registration-ficha__sections">
+        <div @class([
+            'report-registration-ficha__bento',
+            'report-registration-ficha__bento--with-payments' => $ficha['can_view_payments'],
+        ])>
             @foreach ($ficha['sections'] as $section)
-                <section class="report-card">
+                <section class="report-card report-card--{{ $section['area'] }}">
                     <h3>{{ $section['title'] }}</h3>
-                    <dl class="report-fields">
-                        @foreach ($section['fields'] as $field)
-                            <div @class([
-                                'report-field',
-                                'report-field--wide' => $field['wide'] ?? false,
-                                'report-field--tone-' . ($field['tone'] ?? '') => isset($field['tone']),
-                            ])>
-                                <dt>{{ $field['label'] }}</dt>
-                                <dd>{{ filled($field['value'] ?? null) ? $field['value'] : 'Não informado' }}</dd>
-                            </div>
+                    @php
+                        $fieldRows = [];
+                        $pendingFields = [];
+
+                        foreach ($section['fields'] as $field) {
+                            if ($field['wide'] ?? false) {
+                                if ($pendingFields !== []) {
+                                    $fieldRows[] = $pendingFields;
+                                    $pendingFields = [];
+                                }
+
+                                $fieldRows[] = [$field];
+
+                                continue;
+                            }
+
+                            $pendingFields[] = $field;
+
+                            if (count($pendingFields) === 2) {
+                                $fieldRows[] = $pendingFields;
+                                $pendingFields = [];
+                            }
+                        }
+
+                        if ($pendingFields !== []) {
+                            $fieldRows[] = $pendingFields;
+                        }
+                    @endphp
+
+                    <table class="report-fields-table">
+                        <tbody>
+                        @foreach ($fieldRows as $row)
+                            <tr>
+                                @foreach ($row as $field)
+                                    <td
+                                        @class([
+                                            'report-field',
+                                            'report-field--wide' => $field['wide'] ?? false,
+                                            'report-field--tone-' . ($field['tone'] ?? '') => isset($field['tone']),
+                                        ])
+                                        @if (count($row) === 1) colspan="2" @endif
+                                    >
+                                        <span class="report-field__label">{{ $field['label'] }}</span>
+                                        <strong class="report-field__value">{{ filled($field['value'] ?? null) ? $field['value'] : 'Não informado' }}</strong>
+                                    </td>
+                                @endforeach
+
+                                @if (count($row) === 1 && ! ($row[0]['wide'] ?? false))
+                                    <td class="report-field report-field--empty"></td>
+                                @endif
+                            </tr>
                         @endforeach
-                    </dl>
+                        </tbody>
+                    </table>
                 </section>
             @endforeach
+
+            @if ($ficha['can_view_payments'])
+                <section class="report-card report-card--payments report-registration-payment-section">
+                    <h3>Pagamentos vinculados</h3>
+
+                    @if (count($ficha['payments']))
+                        <div class="report-registration-payments">
+                            @foreach ($ficha['payments'] as $payment)
+                                <article class="report-registration-payment">
+                                    <header>
+                                        <div>
+                                            <span>Lançamento financeiro</span>
+                                            <strong>{{ $payment['name'] }}</strong>
+                                        </div>
+
+                                        @if ($payment['url'])
+                                            <a href="{{ $payment['url'] }}">Visualizar lançamento</a>
+                                        @endif
+                                    </header>
+
+                                    <dl>
+                                        <div>
+                                            <dt>Valor aplicado</dt>
+                                            <dd>{{ $payment['amount'] }}</dd>
+                                        </div>
+                                        <div>
+                                            <dt>Data</dt>
+                                            <dd>{{ $payment['date'] }}</dd>
+                                        </div>
+                                        <div
+                                            class="report-registration-payment__token"
+                                            data-report-payment-icon="{{ $payment['method']['icon'] }}"
+                                            data-report-payment-color="{{ $payment['method']['color'] }}"
+                                            style="--report-accent: {{ $payment['method']['accent'] }};"
+                                        >
+                                            <dt>Forma</dt>
+                                            <dd>
+                                                @svg($payment['method']['icon'], 'report-registration-payment__icon', ['aria-hidden' => 'true'])
+                                                {{ $payment['method']['label'] }}
+                                            </dd>
+                                        </div>
+                                        <div
+                                            class="report-registration-payment__token"
+                                            data-report-payment-icon="{{ $payment['status']['icon'] }}"
+                                            data-report-payment-color="{{ $payment['status']['color'] }}"
+                                            style="--report-accent: {{ $payment['status']['accent'] }};"
+                                        >
+                                            <dt>Status</dt>
+                                            <dd>
+                                                @svg($payment['status']['icon'], 'report-registration-payment__icon', ['aria-hidden' => 'true'])
+                                                {{ $payment['status']['label'] }}
+                                            </dd>
+                                        </div>
+                                    </dl>
+                                </article>
+                            @endforeach
+                        </div>
+                    @else
+                        <p class="report-empty report-registration-payment-section__empty">Nenhum lançamento financeiro vinculado a esta inscrição.</p>
+                    @endif
+                </section>
+            @endif
         </div>
-
-        @if ($ficha['can_view_payments'])
-            <section class="report-card report-registration-payment-section">
-                <h3>Pagamentos vinculados</h3>
-
-                @if (count($ficha['payments']))
-                    <div class="report-registration-payments">
-                        @foreach ($ficha['payments'] as $payment)
-                            <article class="report-registration-payment">
-                                <header>
-                                    <div>
-                                        <span>Lançamento financeiro</span>
-                                        <strong>{{ $payment['name'] }}</strong>
-                                    </div>
-
-                                    @if ($payment['url'])
-                                        <a href="{{ $payment['url'] }}">Visualizar lançamento</a>
-                                    @endif
-                                </header>
-
-                                <dl>
-                                    <div>
-                                        <dt>Valor aplicado</dt>
-                                        <dd>{{ $payment['amount'] }}</dd>
-                                    </div>
-                                    <div>
-                                        <dt>Data</dt>
-                                        <dd>{{ $payment['date'] }}</dd>
-                                    </div>
-                                    <div
-                                        class="report-registration-payment__token"
-                                        data-report-payment-icon="{{ $payment['method']['icon'] }}"
-                                        data-report-payment-color="{{ $payment['method']['color'] }}"
-                                        style="--report-accent: {{ $payment['method']['accent'] }};"
-                                    >
-                                        <dt>Forma</dt>
-                                        <dd>
-                                            @svg($payment['method']['icon'], 'report-registration-payment__icon', ['aria-hidden' => 'true'])
-                                            {{ $payment['method']['label'] }}
-                                        </dd>
-                                    </div>
-                                    <div
-                                        class="report-registration-payment__token"
-                                        data-report-payment-icon="{{ $payment['status']['icon'] }}"
-                                        data-report-payment-color="{{ $payment['status']['color'] }}"
-                                        style="--report-accent: {{ $payment['status']['accent'] }};"
-                                    >
-                                        <dt>Status</dt>
-                                        <dd>
-                                            @svg($payment['status']['icon'], 'report-registration-payment__icon', ['aria-hidden' => 'true'])
-                                            {{ $payment['status']['label'] }}
-                                        </dd>
-                                    </div>
-                                </dl>
-                            </article>
-                        @endforeach
-                    </div>
-                @else
-                    <p class="report-empty report-registration-payment-section__empty">Nenhum lançamento financeiro vinculado a esta inscrição.</p>
-                @endif
-            </section>
-        @endif
     </article>
 @empty
     <p class="report-empty">Nenhuma ficha encontrada com os filtros informados.</p>

--- a/resources/views/admin/reports/print.blade.php
+++ b/resources/views/admin/reports/print.blade.php
@@ -12,16 +12,29 @@
             --panel: #ffffff;
             --accent: #f46b12;
             --soft: #f3f8f9;
+            --report-screen-bg: #03181c;
+            --report-screen-base: #052f35;
+            --report-screen-surface: #073d45;
+            --report-screen-panel: #041f23;
+            --report-screen-line: rgba(157, 219, 239, .22);
+            --report-screen-line-strong: rgba(157, 219, 239, .36);
+            --report-screen-sky: #9ddbef;
+            --report-screen-text: #f4fbfd;
+            --report-screen-muted: #d8f2fa;
         }
 
-        * {
+        *,
+        *::before,
+        *::after {
             box-sizing: border-box;
+            -webkit-print-color-adjust: exact;
+            print-color-adjust: exact;
         }
 
         body {
             margin: 0;
-            background: var(--soft);
-            color: var(--ink);
+            background: var(--report-screen-bg);
+            color: var(--report-screen-text);
             font-family: Arial, Helvetica, sans-serif;
             font-size: 13px;
             line-height: 1.45;
@@ -35,9 +48,10 @@
             align-items: center;
             justify-content: space-between;
             gap: 1rem;
-            border-bottom: 1px solid var(--line);
-            background: rgba(255, 255, 255, 0.94);
+            border-bottom: 1px solid var(--report-screen-line);
+            background: rgba(3, 24, 28, .96);
             padding: 1rem 1.25rem;
+            color: var(--report-screen-text);
         }
 
         .report-toolbar strong {
@@ -46,19 +60,46 @@
         }
 
         .report-toolbar span {
-            color: var(--muted);
+            color: var(--report-screen-muted);
         }
 
+        .report-print-toolbar__eyebrow {
+            display: block;
+            color: var(--report-screen-sky);
+            font-size: .68rem;
+            font-weight: 900;
+            letter-spacing: .14em;
+            text-transform: uppercase;
+        }
+
+        .report-print-toolbar__actions {
+            display: flex;
+            flex-wrap: wrap;
+            justify-content: flex-end;
+            gap: .5rem;
+        }
+
+        .report-print-action,
         .report-toolbar button {
+            display: inline-flex;
             min-height: 2.75rem;
-            border: 0;
+            align-items: center;
+            justify-content: center;
+            border: 1px solid rgba(244, 107, 18, .72);
             background: var(--accent);
-            color: #082529;
+            color: var(--ink);
             cursor: pointer;
             font-weight: 800;
             letter-spacing: .08em;
             padding: .75rem 1.1rem;
+            text-decoration: none;
             text-transform: uppercase;
+        }
+
+        .report-print-action--secondary {
+            border-color: var(--report-screen-line-strong);
+            background: rgba(7, 61, 69, .74);
+            color: var(--report-screen-text);
         }
 
         .report-shell {
@@ -67,11 +108,11 @@
             padding: 1.5rem;
         }
 
-        .report-heading,
         .report-section,
         .report-page {
             border: 1px solid var(--line);
             background: var(--panel);
+            color: var(--ink);
         }
 
         .report-heading {
@@ -79,6 +120,9 @@
             grid-template-columns: minmax(0, 1fr) auto;
             align-items: center;
             gap: 1rem;
+            border: 1px solid var(--report-screen-line);
+            background: rgba(7, 61, 69, .82);
+            color: var(--report-screen-text);
             margin-bottom: 1rem;
             padding: 1.25rem;
         }
@@ -100,9 +144,14 @@
 
         .report-heading h1 {
             margin: 0 0 .35rem;
+            color: var(--report-screen-text);
             font-size: 1.7rem;
             line-height: 1.1;
             text-transform: uppercase;
+        }
+
+        .report-heading p {
+            color: var(--report-screen-muted);
         }
 
         .report-heading p,
@@ -112,7 +161,7 @@
         }
 
         .report-heading dt {
-            color: var(--muted);
+            color: var(--report-screen-sky);
             font-size: .72rem;
             font-weight: 800;
             letter-spacing: .08em;
@@ -120,6 +169,7 @@
         }
 
         .report-heading dd {
+            color: var(--report-screen-text);
             font-weight: 700;
         }
 
@@ -131,14 +181,15 @@
         }
 
         .report-filter {
-            border: 1px solid var(--line);
-            background: #fff;
+            border: 1px solid var(--report-screen-line);
+            background: rgba(4, 31, 35, .72);
+            color: var(--report-screen-text);
             padding: .75rem;
         }
 
         .report-filter span {
             display: block;
-            color: var(--muted);
+            color: var(--report-screen-sky);
             font-size: .7rem;
             font-weight: 800;
             letter-spacing: .08em;
@@ -148,6 +199,7 @@
         .report-filter strong {
             display: block;
             margin-top: .2rem;
+            color: var(--report-screen-text);
         }
 
         .report-section {
@@ -338,6 +390,13 @@
             align-items: start;
         }
 
+        .report-registration-ficha__bento {
+            display: grid;
+            grid-template-columns: repeat(2, minmax(0, 1fr));
+            gap: .55rem;
+            align-items: start;
+        }
+
         .report-registration-ficha .report-card {
             page-break-inside: avoid;
         }
@@ -388,6 +447,26 @@
             gap: .45rem .75rem;
         }
 
+        .report-fields-table {
+            width: 100%;
+            border-collapse: collapse;
+            table-layout: fixed;
+        }
+
+        .report-fields-table .report-field {
+            padding: .12rem .55rem .32rem 0;
+            vertical-align: top;
+        }
+
+        .report-fields-table .report-field:last-child {
+            padding-right: 0;
+        }
+
+        .report-field--empty {
+            padding: 0;
+        }
+
+        .report-field__label,
         .report-fields dt,
         .report-table th {
             color: var(--muted);
@@ -397,9 +476,12 @@
             text-transform: uppercase;
         }
 
+        .report-field__value,
         .report-fields dd {
+            display: block;
             margin: .12rem 0 0;
             font-weight: 700;
+            line-height: 1.24;
             word-break: break-word;
         }
 
@@ -407,10 +489,12 @@
             grid-column: 1 / -1;
         }
 
+        .report-field--tone-warning .report-field__value,
         .report-field--tone-warning dd {
             color: #8a5a00;
         }
 
+        .report-field--tone-success .report-field__value,
         .report-field--tone-success dd {
             color: #0f6b38;
         }
@@ -418,6 +502,11 @@
         .report-registration-payment-section {
             margin-top: .75rem;
             page-break-inside: avoid;
+        }
+
+        .report-card--payments {
+            grid-column: 1 / -1;
+            margin-top: 0;
         }
 
         .report-registration-payments {
@@ -521,7 +610,7 @@
         .report-sensitive-alert {
             border: 1px solid rgba(244, 107, 18, .55);
             background: rgba(244, 107, 18, .12);
-            color: var(--ink);
+            color: var(--report-screen-text);
             margin-bottom: 1rem;
             padding: .85rem 1rem;
         }
@@ -543,10 +632,12 @@
 
             body {
                 background: #fff;
+                color: var(--ink);
                 font-size: 11px;
             }
 
-            .report-toolbar {
+            .report-toolbar,
+            .report-print-toolbar {
                 display: none;
             }
 
@@ -568,25 +659,49 @@
                 border-color: #b7c6c9;
             }
 
+            .report-heading,
+            .report-filter,
+            .report-sensitive-alert {
+                background: #fff;
+                color: var(--ink);
+            }
+
+            .report-heading h1,
+            .report-heading dd,
+            .report-filter strong {
+                color: var(--ink);
+            }
+
+            .report-heading p,
+            .report-heading dt,
+            .report-filter span {
+                color: var(--muted);
+            }
+
             .report-registration-payment a {
                 display: none;
             }
         }
     </style>
 </head>
-<body>
-    <div class="report-toolbar">
+<body class="report-print-document">
+    <div class="report-toolbar report-print-toolbar">
         <div>
+            <span class="report-print-toolbar__eyebrow">Prévia para impressão</span>
             <strong>{{ $report['title'] }}</strong>
             <span>{{ $report['recordsCount'] }} registros - gerado em {{ $report['generatedAt'] }}</span>
         </div>
-        <button type="button" onclick="window.print()">Imprimir</button>
+        <div class="report-print-toolbar__actions">
+            <a class="report-print-action report-print-action--secondary" href="{{ $returnUrl }}">Voltar para a central</a>
+            <button type="button" data-report-save-pdf onclick="window.print()">Salvar PDF</button>
+            <button type="button" data-report-print onclick="window.print()">Imprimir</button>
+        </div>
     </div>
 
     <main class="report-shell">
-        <header class="report-heading">
+        <header class="report-heading report-print-panel">
             <div class="report-heading__brand">
-                <img class="report-heading__logo" src="{{ asset('img/logo.png') }}" alt="Logo do acampamento">
+                <img class="report-heading__logo" src="{{ $logoSrc ?? asset('img/logo.png') }}" alt="Logo do acampamento">
                 <div>
                     <h1>{{ $report['title'] }}</h1>
                     <p>{{ $report['description'] }}</p>
@@ -602,7 +717,7 @@
 
         <section class="report-filters" aria-label="Filtros aplicados">
             @foreach ($report['filters'] as $label => $value)
-                <div class="report-filter">
+                <div class="report-filter report-print-filter">
                     <span>{{ $label }}</span>
                     <strong>{{ $value ?: 'Não informado' }}</strong>
                 </div>

--- a/resources/views/filament/pages/partials/reports-help.blade.php
+++ b/resources/views/filament/pages/partials/reports-help.blade.php
@@ -1,0 +1,47 @@
+@php
+    $availableValues = collect($types)->pluck('value')->all();
+
+    $reportHelp = collect([
+        'usage' => [
+            'title' => 'Como usar a central de relatórios',
+            'tone' => 'operacional',
+            'description' => 'Escolha o tipo de relatório, aplique status, tribo, presença e busca, revise os controles sensíveis quando aparecerem e abra a prévia. A tela de prévia mantém um link de volta para a central com os mesmos filtros.',
+        ],
+        'registration_fichas' => [
+            'title' => 'Fichas de inscrição',
+            'tone' => 'operacional',
+            'description' => 'Use para imprimir uma ficha consolidada por campista, com dados pessoais, contato, endereço, comunidade, controle da inscrição e campos médicos ocultos por padrão.',
+        ],
+        'tribe_quadrant' => [
+            'title' => 'Quadrante das inscrições por tribo',
+            'tone' => 'operacional',
+            'description' => 'Use para conferir a distribuição dos campistas por tribo, validar agrupamentos e apoiar organização de equipes e espaços.',
+        ],
+        'sensitive_health' => [
+            'title' => 'Lista médica da enfermaria',
+            'tone' => 'restrito',
+            'description' => 'Use somente para triagem e cuidado da enfermaria. Os detalhes médicos aparecem apenas para perfis autorizados e após confirmação explícita.',
+        ],
+        'mission_contacts' => [
+            'title' => 'Contatos e endereços para missão',
+            'tone' => 'operacional',
+            'description' => 'Use para preparar visitas missionárias com responsável, telefone, endereço, bairro, cidade e ponto de referência.',
+        ],
+    ])
+        ->filter(fn (array $item, string $key): bool => $key === 'usage' || in_array($key, $availableValues, true));
+@endphp
+
+<div class="juvenil-report-help">
+    <ul class="juvenil-report-help__list">
+        @foreach ($reportHelp as $key => $item)
+            <li @class([
+                'juvenil-report-help__item',
+                'juvenil-report-help__item--restricted' => $item['tone'] === 'restrito',
+            ])>
+                <span>{{ $item['tone'] }}</span>
+                <strong>{{ $item['title'] }}</strong>
+                <p>{{ $item['description'] }}</p>
+            </li>
+        @endforeach
+    </ul>
+</div>

--- a/resources/views/filament/pages/reports-page.blade.php
+++ b/resources/views/filament/pages/reports-page.blade.php
@@ -5,35 +5,51 @@
                 <p class="juvenil-report-brief__eyebrow">Prévia segura para impressão</p>
                 <h2>Central de impressão</h2>
                 <p>
-                    Gere fichas, quadrantes e listas operacionais com filtros por status, tribo,
-                    presença e busca. Relatórios sensíveis só aparecem para perfis autorizados.
+                    Gere fichas, quadrantes e listas operacionais com filtros por status, tribo, presença e busca.
+                    A prévia abre na mesma aba e mantém o retorno para esta central.
                 </p>
             </div>
-        </section>
 
-        <section class="juvenil-report-grid" aria-label="Tipos de relatório disponíveis">
-            @forelse ($this->reportTypes() as $type)
-                <article @class([
-                    'juvenil-report-card',
-                    'juvenil-report-card--sensitive' => $type['sensitive'],
-                ])>
-                    <span>{{ $type['sensitive'] ? 'Restrito' : 'Operacional' }}</span>
-                    <h3>{{ $type['title'] }}</h3>
-                    <p>{{ $type['description'] }}</p>
-                </article>
-            @empty
-                <article class="juvenil-report-card">
-                    <span>Sem acesso</span>
-                    <h3>Nenhum relatório disponível</h3>
-                    <p>Seu perfil ainda não possui permissão para gerar relatórios.</p>
-                </article>
-            @endforelse
+            <div class="juvenil-report-brief__meter" aria-hidden="true">
+                <span>{{ count($this->reportTypes()) }}</span>
+                <strong>modelos disponíveis</strong>
+            </div>
         </section>
 
         @if (count($this->reportTypes()))
             <div class="juvenil-report-form">
                 {{ $this->form }}
             </div>
+        @else
+            <section class="juvenil-report-empty" aria-label="Nenhum relatório disponível">
+                <span>Sem acesso</span>
+                <h3>Nenhum relatório disponível</h3>
+                <p>Seu perfil ainda não possui permissão para gerar relatórios.</p>
+            </section>
         @endif
+
+        <div class="juvenil-report-loading" data-report-preview-loading role="status" aria-live="polite" hidden>
+            <div class="juvenil-report-loading__panel">
+                <span class="juvenil-report-loading__spinner" aria-hidden="true"></span>
+                <strong>Abrindo prévia para impressão</strong>
+                <p>Se houver muitos dados, mantenha esta aba aberta até o relatório carregar.</p>
+            </div>
+        </div>
     </div>
+
+    <script>
+        document.addEventListener('click', function (event) {
+            const previewLink = event.target.closest('[data-report-preview-link]');
+
+            if (! previewLink || previewLink.getAttribute('aria-disabled') === 'true' || ! previewLink.href) {
+                return;
+            }
+
+            const loading = document.querySelector('[data-report-preview-loading]');
+
+            if (loading) {
+                loading.hidden = false;
+            }
+        });
+    </script>
 </x-filament-panels::page>

--- a/tests/Browser/admin-panel-layout.spec.js
+++ b/tests/Browser/admin-panel-layout.spec.js
@@ -707,7 +707,9 @@ test('authenticated Filament select dropdowns open above sibling sections', asyn
     });
 });
 
-test('authenticated reports page uses native Filament filters in a balanced layout', async ({ page }) => {
+test('authenticated reports page uses native Filament filters with help and same-tab preview', async ({ page }) => {
+    test.setTimeout(120000);
+
     await mkdir('storage/app/screenshots', { recursive: true });
 
     await signIn(page);
@@ -718,42 +720,61 @@ test('authenticated reports page uses native Filament filters in a balanced layo
 
     await expect(page.locator('h1')).toContainText('Relatórios dinâmicos');
     await expect(page.getByRole('link', { name: /abrir prévia/i })).toBeVisible();
+    await expect(page.getByRole('button', { name: /dúvidas/i })).toBeVisible();
     await expect(page.locator('.juvenil-report-form select')).toHaveCount(0);
+    await expect(page.locator('.juvenil-report-card')).toHaveCount(0);
     await expectNoDocumentHorizontalOverflow(page);
 
     const layoutState = await page.evaluate(() => {
         const pageElement = document.querySelector('.fi-page');
         const brief = document.querySelector('.juvenil-report-brief');
-        const cards = [...document.querySelectorAll('.juvenil-report-card')]
-            .map((card) => card.getBoundingClientRect())
-            .filter((rect) => rect.width > 0 && rect.height > 0);
+        const meter = document.querySelector('.juvenil-report-brief__meter');
         const form = document.querySelector('.juvenil-report-form .fi-section');
+        const loading = document.querySelector('[data-report-preview-loading]');
 
-        if (! pageElement || ! brief || ! form || cards.length === 0) {
+        if (! pageElement || ! brief || ! form || ! meter || ! loading) {
             return null;
         }
 
         const pageRect = pageElement.getBoundingClientRect();
         const briefRect = brief.getBoundingClientRect();
         const formRect = form.getBoundingClientRect();
-        const firstCardTop = Math.min(...cards.map((rect) => rect.top));
-        const lastCardBottom = Math.max(...cards.map((rect) => rect.bottom));
+        const meterRect = meter.getBoundingClientRect();
 
         return {
             briefWidthRatio: briefRect.width / pageRect.width,
             formWidthRatio: formRect.width / pageRect.width,
-            cardsAreBetweenBriefAndForm: firstCardTop > briefRect.bottom && lastCardBottom < formRect.top,
-            cardMinWidth: Math.min(...cards.map((rect) => rect.width)),
+            formIsBelowBrief: formRect.top > briefRect.bottom,
+            meterIsInsideBrief: meterRect.right <= briefRect.right && meterRect.left >= briefRect.left,
+            loadingStartsHidden: loading.hidden,
         };
     });
 
     expect(layoutState).not.toBeNull();
     expect(layoutState.briefWidthRatio).toBeGreaterThanOrEqual(0.84);
     expect(layoutState.formWidthRatio).toBeGreaterThanOrEqual(0.84);
-    expect(layoutState.cardsAreBetweenBriefAndForm).toBe(true);
-    expect(layoutState.cardMinWidth).toBeGreaterThanOrEqual(220);
+    expect(layoutState.formIsBelowBrief).toBe(true);
+    expect(layoutState.meterIsInsideBrief).toBe(true);
+    expect(layoutState.loadingStartsHidden).toBe(true);
+
+    await page.getByRole('button', { name: /dúvidas/i }).click();
+    const helpDialog = page.getByRole('dialog');
+    await expect(page.locator('.fi-modal.fi-modal-open')).toBeVisible();
+    await expect(helpDialog.getByText('Como usar a central de relatórios')).toBeVisible();
+    await expect(helpDialog.getByText('Fichas de inscrição')).toBeVisible();
+    await helpDialog.locator('.fi-modal-footer').getByRole('button', { name: /fechar/i }).click();
+    await expect(page.locator('.fi-modal.fi-modal-open')).toHaveCount(0);
 
     const reportTypeField = page.locator('.juvenil-report-form .fi-fo-field').filter({ hasText: 'Tipo de relatório' }).first();
+    const searchInput = page.getByPlaceholder('Nome, responsável, bairro ou cidade');
+
+    await searchInput.fill('Ana Costa 101');
+    await page.waitForFunction(() => (
+        [...document.querySelectorAll('a')]
+            .find((link) => link.textContent?.includes('Abrir prévia'))
+            ?.href
+            .includes('search=Ana')
+    ));
 
     await reportTypeField.locator('.fi-select-input-btn').click();
     await expect(reportTypeField.locator('.fi-dropdown-panel[role="listbox"]')).toBeVisible();
@@ -806,21 +827,30 @@ test('authenticated reports page uses native Filament filters in a balanced layo
                 .includes(`type=${type}`)
         ), expectedType);
 
-        const previewPagePromise = page.waitForEvent('popup');
-        await previewLink.click();
-
-        const previewPage = await previewPagePromise;
-        await previewPage.waitForLoadState('domcontentloaded');
-        await expect(previewPage.locator('h1')).toContainText(expectedTitle);
-        await expect(previewPage.getByAltText('Logo do acampamento')).toBeVisible();
-
-        const logoLoaded = await previewPage.getByAltText('Logo do acampamento').evaluate((image) => (
-            image instanceof HTMLImageElement && image.complete && image.naturalWidth > 0 && image.naturalHeight > 0
+        const previewResponsePromise = page.waitForResponse((response) => (
+            response.url().includes('/admin/relatorios/imprimir')
         ));
 
-        expect(logoLoaded).toBe(true);
-        await previewPage.close();
+        await previewLink.click();
+
+        const previewResponse = await previewResponsePromise;
+        const previewHeaders = previewResponse.headers();
+
+        expect(previewResponse.status()).toBe(200);
+        expect(previewHeaders['content-type']).toContain('text/html');
+        await page.waitForURL(/\/admin\/relatorios\/imprimir/);
+        expect(page.url()).toContain(`type=${expectedType}`);
+        await expect(page.locator('.report-print-toolbar')).toBeVisible();
+        await expect(page.getByText(expectedTitle).first()).toBeVisible();
+        await expect(page.getByRole('button', { name: /salvar pdf/i })).toBeVisible();
+        await expect(page.getByRole('button', { name: /imprimir/i })).toBeVisible();
+
+        await page.goBack({ waitUntil: 'domcontentloaded' });
+        await page.waitForSelector('.juvenil-report-page');
+        await page.waitForSelector('.juvenil-report-form .fi-section');
     }
+
+    await page.evaluate(() => window.scrollTo(0, 0));
 
     await page.screenshot({
         path: 'storage/app/screenshots/playwright-admin-reports-filters-layout.png',

--- a/tests/Feature/ReportsPageTest.php
+++ b/tests/Feature/ReportsPageTest.php
@@ -9,8 +9,11 @@ use App\Models\CategoriaLancamento;
 use App\Models\Lancamento;
 use App\Models\Tribo;
 use App\Models\User;
+use App\Support\Reports\CampistaReportData;
+use App\Support\Reports\CampistaReportType;
 use Database\Seeders\ShieldSeeder;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Testing\TestResponse;
 use Spatie\Permission\Models\Permission;
 use Spatie\Permission\Models\Role;
 
@@ -86,6 +89,38 @@ function reportCampistaLinkedPayment(Campista $campista): Lancamento
     return $lancamento;
 }
 
+function reportHtml(string $type, array $filters, User $user): string
+{
+    $filters = [
+        'type' => $type,
+        ...$filters,
+    ];
+
+    return view('admin.reports.print', [
+        'report' => app(CampistaReportData::class)->payload(
+            CampistaReportType::from($type),
+            $filters,
+            $user,
+        ),
+        'returnUrl' => route('filament.admin.pages.reports-page', $filters),
+        'logoSrc' => asset('img/logo.png'),
+    ])->render();
+}
+
+function assertPrintableHtml(TestResponse $response): TestResponse
+{
+    $response->assertOk();
+
+    expect($response->headers->get('content-type'))->toContain('text/html')
+        ->and($response->headers->get('content-disposition'))->toBeNull()
+        ->and($response->getContent())->not->toStartWith('%PDF')
+        ->and($response->getContent())->toContain('Prévia para impressão')
+        ->toContain('data-report-print')
+        ->toContain('data-report-save-pdf');
+
+    return $response;
+}
+
 it('seeds report permissions with least privilege by role', function () {
     $this->seed(ShieldSeeder::class);
 
@@ -150,8 +185,7 @@ it('uses the reports page permission to expose standard operational reports', fu
 
     $this->actingAs($user)
         ->get(route('admin.reports.print', ['type' => 'registration_fichas']))
-        ->assertOk()
-        ->assertSee('Fichas de inscrição');
+        ->tap(fn (TestResponse $response) => assertPrintableHtml($response));
 
     $this->actingAs($user)
         ->get(route('admin.reports.print', ['type' => 'sensitive_health']))
@@ -161,43 +195,135 @@ it('uses the reports page permission to expose standard operational reports', fu
 it('renders the sensitive health disclosure control only for authorized report users', function () {
     $this->seed(ShieldSeeder::class);
 
+    $superAdministrator = reportUserWithRole('Super Administrador');
     $administrator = reportUserWithRole('Administrador');
     $infirmary = reportUserWithRole('Enfermaria');
+
+    $this->actingAs($superAdministrator)
+        ->get(route('filament.admin.pages.reports-page'))
+        ->assertOk()
+        ->assertSee('Exibir dados de pagamento')
+        ->assertSee('Por padrão, dados de pagamento permanecem ocultos');
 
     $this->actingAs($administrator)
         ->get(route('filament.admin.pages.reports-page'))
         ->assertOk()
         ->assertDontSee('Exibir dados médicos')
-        ->assertDontSee('Dados médicos sensíveis');
+        ->assertDontSee('Dados médicos sensíveis')
+        ->assertDontSee('Exibir dados de pagamento');
 
     $this->actingAs($infirmary)
         ->get(route('filament.admin.pages.reports-page'))
         ->assertOk()
         ->assertSee('Exibir dados médicos')
-        ->assertSee('Por padrão, dados médicos permanecem ocultos');
+        ->assertSee('Por padrão, dados médicos permanecem ocultos')
+        ->assertDontSee('Exibir dados de pagamento');
 });
 
 it('builds the report filters with native Filament form components', function () {
     $page = file_get_contents(app_path('Filament/Pages/ReportsPage.php'));
     $view = file_get_contents(resource_path('views/filament/pages/reports-page.blade.php'));
+    $helpView = resource_path('views/filament/pages/partials/reports-help.blade.php');
 
     expect($page)
+        ->toContain("Action::make('reportHelp')")
+        ->toContain('->slideOver()')
+        ->toContain("view('filament.pages.partials.reports-help'")
         ->toContain("Select::make('type')")
         ->toContain("Select::make('status')")
         ->toContain("Select::make('tribo_id')")
         ->toContain("Select::make('presenca')")
         ->toContain("Toggle::make('show_sensitive_health')")
+        ->toContain("Toggle::make('show_payment_data')")
+        ->toContain('Exibir dados de pagamento')
+        ->toContain('Por padrão, dados de pagamento permanecem ocultos')
         ->toContain("Checkbox::make('confirm_sensitive_health')")
         ->toContain('Dados médicos sensíveis')
         ->toContain("TextInput::make('search')")
         ->toContain('->footerActions([')
-        ->toContain('->openUrlInNewTab()')
+        ->not->toContain('->openUrlInNewTab()')
         ->toContain('->live()')
         ->toContain('->live(debounce: 500)')
         ->and($view)
         ->toContain('{{ $this->form }}')
+        ->toContain('juvenil-report-loading')
+        ->toContain('data-report-preview-loading')
+        ->not->toContain('juvenil-report-grid')
+        ->not->toContain('juvenil-report-card')
         ->not->toContain('<select')
-        ->not->toContain('<input');
+        ->not->toContain('<input')
+        ->and($helpView)
+        ->toBeFile()
+        ->and(file_get_contents($helpView))
+        ->toContain('Como usar a central de relatórios')
+        ->toContain('Fichas de inscrição')
+        ->toContain('Quadrante das inscrições por tribo')
+        ->toContain('Lista médica da enfermaria')
+        ->toContain('Contatos e endereços para missão');
+});
+
+it('renders the printable preview as HTML in the same tab', function () {
+    $this->seed(ShieldSeeder::class);
+
+    reportCampista();
+
+    $administrator = reportUserWithRole('Administrador');
+    $returnUrl = route('filament.admin.pages.reports-page', [
+        'type' => 'registration_fichas',
+        'status' => [StatusInscricao::Pago->value],
+        'search' => 'Centro',
+    ]);
+
+    $response = $this->actingAs($administrator)
+        ->get(route('admin.reports.print', [
+            'type' => 'registration_fichas',
+            'status' => [StatusInscricao::Pago->value],
+            'search' => 'Centro',
+            'return' => $returnUrl,
+        ]));
+
+    assertPrintableHtml($response);
+
+    $html = reportHtml('registration_fichas', [
+        'status' => [StatusInscricao::Pago->value],
+        'search' => 'Centro',
+    ], $administrator);
+
+    expect($html)
+        ->toContain('<body class="report-print-document">')
+        ->toContain('report-print-toolbar')
+        ->toContain('report-print-panel')
+        ->toContain('report-print-filter')
+        ->toContain('--report-screen-bg: #03181c')
+        ->toContain('background: var(--report-screen-bg);')
+        ->toContain('report-print-document')
+        ->toContain('Salvar PDF')
+        ->toContain('Imprimir')
+        ->toContain('Voltar para a central')
+        ->toContain(e($returnUrl))
+        ->toContain('Logo do acampamento')
+        ->not->toContain('<dt>Central</dt>');
+});
+
+it('keeps printable previews on the HTML rendering path', function () {
+    $controller = file_get_contents(app_path('Http/Controllers/Admin/PrintableReportController.php'));
+    $printView = file_get_contents(resource_path('views/admin/reports/print.blade.php'));
+
+    expect($controller)
+        ->toContain("return view('admin.reports.print'")
+        ->not->toContain('Pdf::')
+        ->not->toContain('preparePdfRuntime')
+        ->and($printView)
+        ->toContain('report-print-toolbar')
+        ->toContain('report-print-document')
+        ->toContain('data-report-save-pdf')
+        ->toContain('window.print()')
+        ->toContain('-webkit-print-color-adjust: exact;')
+        ->toContain('print-color-adjust: exact;')
+        ->not->toContain('Salvar HTML')
+        ->not->toContain('data-report-save>')
+        ->not->toContain('new Blob')
+        ->not->toContain('report-pdf-document');
 });
 
 it('renders the campista photo in printable registration fichas', function () {
@@ -209,14 +335,14 @@ it('renders the campista photo in printable registration fichas', function () {
 
     $administrator = reportUserWithRole('Administrador');
 
-    $this->actingAs($administrator)
-        ->get(route('admin.reports.print', ['type' => 'registration_fichas']))
-        ->assertOk()
-        ->assertSee('Foto de Ana Maria Juvenil')
-        ->assertSee('/storage/foto-formulario/ana.png', false);
+    $html = reportHtml('registration_fichas', [], $administrator);
+
+    expect($html)
+        ->toContain('Foto de Ana Maria Juvenil')
+        ->toContain('/storage/foto-formulario/ana.png');
 });
 
-it('applies ficha visual styling and linked payment badges to printable registration reports', function () {
+it('applies ficha visual styling and keeps linked payments hidden by default on printable registration reports', function () {
     $this->seed(ShieldSeeder::class);
 
     $tribe = Tribo::query()->create(['cor' => 'Rosa']);
@@ -225,29 +351,72 @@ it('applies ficha visual styling and linked payment badges to printable registra
         'forma_pagamento' => FormaPagamento::Pix,
         'status' => StatusInscricao::Pago,
     ]);
+    reportCampistaLinkedPayment($campista);
+    $superAdministrator = reportUserWithRole('Super Administrador');
+
+    $html = reportHtml('registration_fichas', [], $superAdministrator);
+
+    expect($html)
+        ->toContain('report-registration-summary')
+        ->toContain('report-registration-ficha__bento')
+        ->toContain('report-card--personal')
+        ->toContain('report-card--contact')
+        ->toContain('report-card--address')
+        ->toContain('report-card--community')
+        ->toContain('report-card--health')
+        ->toContain('data-report-summary-icon="polaris-payment-icon"')
+        ->toContain('data-report-summary-icon="fab-pix"')
+        ->toContain('data-report-summary-icon="heroicon-o-flag"')
+        ->toContain('--report-accent: #ec4899')
+        ->not->toContain('report-card--control')
+        ->not->toContain('Controle da inscrição')
+        ->not->toContain('Data de inscrição')
+        ->not->toContain('Data de pagamento')
+        ->not->toContain('<section class="report-card report-registration-payment-section">')
+        ->not->toContain('Pagamentos vinculados')
+        ->not->toContain('Lançamento relatório inscrição')
+        ->not->toContain('Comprovantes anexados');
+
+    $printView = file_get_contents(resource_path('views/admin/reports/print.blade.php'));
+
+    expect($printView)
+        ->toContain('report-fields-table')
+        ->toContain('table-layout: fixed;')
+        ->toContain('report-field__label')
+        ->toContain('report-field__value')
+        ->toContain('.report-card--payments')
+        ->toContain('grid-column: 1 / -1;')
+        ->toContain('margin-top: 0;');
+});
+
+it('shows linked payment badges on printable registration reports only when the financial toggle is enabled', function () {
+    $this->seed(ShieldSeeder::class);
+
+    $campista = reportCampista([
+        'forma_pagamento' => FormaPagamento::Pix,
+        'status' => StatusInscricao::Pago,
+    ]);
     $lancamento = reportCampistaLinkedPayment($campista);
     $superAdministrator = reportUserWithRole('Super Administrador');
 
-    $this->actingAs($superAdministrator)
-        ->get(route('admin.reports.print', ['type' => 'registration_fichas']))
-        ->assertOk()
-        ->assertSee('report-registration-summary', false)
-        ->assertSee('data-report-summary-icon="polaris-payment-icon"', false)
-        ->assertSee('data-report-summary-icon="fab-pix"', false)
-        ->assertSee('data-report-summary-icon="heroicon-o-flag"', false)
-        ->assertSee('--report-accent: #ec4899', false)
-        ->assertSee('<section class="report-card report-registration-payment-section">', false)
-        ->assertSee('Pagamentos vinculados')
-        ->assertSee('Lançamento relatório inscrição')
-        ->assertSee('R$ 350,00')
-        ->assertSee('08/06/2026')
-        ->assertSee('Visualizar lançamento')
-        ->assertSee(route('filament.admin.resources.lancamentos.view', ['record' => $lancamento]), false)
-        ->assertSee('data-report-payment-icon="fab-pix"', false)
-        ->assertSee('data-report-payment-color="teal"', false)
-        ->assertSee('data-report-payment-icon="polaris-payment-icon"', false)
-        ->assertSee('data-report-payment-color="success"', false)
-        ->assertDontSee('Comprovantes anexados');
+    $html = reportHtml('registration_fichas', [
+        'show_payment_data' => 1,
+    ], $superAdministrator);
+
+    expect($html)
+        ->toContain('report-registration-ficha__bento')
+        ->toContain('<section class="report-card report-card--payments report-registration-payment-section">')
+        ->toContain('Pagamentos vinculados')
+        ->toContain('Lançamento relatório inscrição')
+        ->toContain('R$ 350,00')
+        ->toContain('08/06/2026')
+        ->toContain('Visualizar lançamento')
+        ->toContain(route('filament.admin.resources.lancamentos.view', ['record' => $lancamento]))
+        ->toContain('data-report-payment-icon="fab-pix"')
+        ->toContain('data-report-payment-color="teal"')
+        ->toContain('data-report-payment-icon="polaris-payment-icon"')
+        ->toContain('data-report-payment-color="success"')
+        ->not->toContain('Comprovantes anexados');
 });
 
 it('hides linked payments on printable registration reports without financial view permissions', function () {
@@ -257,13 +426,15 @@ it('hides linked payments on printable registration reports without financial vi
     reportCampistaLinkedPayment($campista);
     $administrator = reportUserWithRole('Administrador');
 
-    $this->actingAs($administrator)
-        ->get(route('admin.reports.print', ['type' => 'registration_fichas']))
-        ->assertOk()
-        ->assertSee('report-registration-summary', false)
-        ->assertDontSee('<section class="report-card report-registration-payment-section">', false)
-        ->assertDontSee('Pagamentos vinculados')
-        ->assertDontSee('Lançamento relatório inscrição');
+    $html = reportHtml('registration_fichas', [
+        'show_payment_data' => 1,
+    ], $administrator);
+
+    expect($html)
+        ->toContain('report-registration-summary')
+        ->not->toContain('<section class="report-card report-registration-payment-section">')
+        ->not->toContain('Pagamentos vinculados')
+        ->not->toContain('Lançamento relatório inscrição');
 });
 
 it('renders the camp logo in every printable report header', function () {
@@ -275,18 +446,14 @@ it('renders the camp logo in every printable report header', function () {
     $infirmary = reportUserWithRole('Enfermaria');
 
     foreach (['registration_fichas', 'tribe_quadrant', 'mission_contacts'] as $type) {
-        $this->actingAs($administrator)
-            ->get(route('admin.reports.print', ['type' => $type]))
-            ->assertOk()
-            ->assertSee('Logo do acampamento')
-            ->assertSee('/img/logo.png', false);
+        expect(reportHtml($type, [], $administrator))
+            ->toContain('Logo do acampamento')
+            ->toContain('/img/logo.png');
     }
 
-    $this->actingAs($infirmary)
-        ->get(route('admin.reports.print', ['type' => 'sensitive_health']))
-        ->assertOk()
-        ->assertSee('Logo do acampamento')
-        ->assertSee('/img/logo.png', false);
+    expect(reportHtml('sensitive_health', [], $infirmary))
+        ->toContain('Logo do acampamento')
+        ->toContain('/img/logo.png');
 });
 
 it('blocks the medical report for administrators and exposes it only to the infirmary', function () {
@@ -301,26 +468,21 @@ it('blocks the medical report for administrators and exposes it only to the infi
         ->get(route('admin.reports.print', ['type' => 'sensitive_health']))
         ->assertForbidden();
 
-    $this->actingAs($infirmary)
-        ->get(route('admin.reports.print', ['type' => 'sensitive_health']))
-        ->assertOk()
-        ->assertSee('Lista médica da enfermaria')
-        ->assertSee('Ana Maria Juvenil')
-        ->assertSee('Informação restrita')
-        ->assertDontSee('Dipirona a cada 8 horas')
-        ->assertDontSee('Evitar amendoim');
+    expect(reportHtml('sensitive_health', [], $infirmary))
+        ->toContain('Lista médica da enfermaria')
+        ->toContain('Ana Maria Juvenil')
+        ->toContain('Informação restrita')
+        ->not->toContain('Dipirona a cada 8 horas')
+        ->not->toContain('Evitar amendoim');
 
-    $this->actingAs($infirmary)
-        ->get(route('admin.reports.print', [
-            'type' => 'sensitive_health',
-            'show_sensitive_health' => 1,
-            'confirm_sensitive_health' => 1,
-        ]))
-        ->assertOk()
-        ->assertSee('Lista médica da enfermaria')
-        ->assertSee('Ana Maria Juvenil')
-        ->assertSee('Dipirona a cada 8 horas')
-        ->assertSee('Evitar amendoim');
+    expect(reportHtml('sensitive_health', [
+        'show_sensitive_health' => 1,
+        'confirm_sensitive_health' => 1,
+    ], $infirmary))
+        ->toContain('Lista médica da enfermaria')
+        ->toContain('Ana Maria Juvenil')
+        ->toContain('Dipirona a cada 8 horas')
+        ->toContain('Evitar amendoim');
 });
 
 it('requires the sensitive health toggle and confirmation before exposing medical data in any report', function () {
@@ -330,32 +492,24 @@ it('requires the sensitive health toggle and confirmation before exposing medica
 
     $infirmary = reportUserWithRole('Enfermaria');
 
-    $this->actingAs($infirmary)
-        ->get(route('admin.reports.print', ['type' => 'registration_fichas']))
-        ->assertOk()
-        ->assertSee('Informação restrita')
-        ->assertDontSee('Dipirona a cada 8 horas')
-        ->assertDontSee('Evitar amendoim');
+    expect(reportHtml('registration_fichas', [], $infirmary))
+        ->toContain('Informação restrita')
+        ->not->toContain('Dipirona a cada 8 horas')
+        ->not->toContain('Evitar amendoim');
 
-    $this->actingAs($infirmary)
-        ->get(route('admin.reports.print', [
-            'type' => 'registration_fichas',
-            'show_sensitive_health' => 1,
-        ]))
-        ->assertOk()
-        ->assertSee('Informação restrita')
-        ->assertDontSee('Dipirona a cada 8 horas')
-        ->assertDontSee('Evitar amendoim');
+    expect(reportHtml('registration_fichas', [
+        'show_sensitive_health' => 1,
+    ], $infirmary))
+        ->toContain('Informação restrita')
+        ->not->toContain('Dipirona a cada 8 horas')
+        ->not->toContain('Evitar amendoim');
 
-    $this->actingAs($infirmary)
-        ->get(route('admin.reports.print', [
-            'type' => 'registration_fichas',
-            'show_sensitive_health' => 1,
-            'confirm_sensitive_health' => 1,
-        ]))
-        ->assertOk()
-        ->assertSee('Dipirona a cada 8 horas')
-        ->assertSee('Evitar amendoim');
+    expect(reportHtml('registration_fichas', [
+        'show_sensitive_health' => 1,
+        'confirm_sensitive_health' => 1,
+    ], $infirmary))
+        ->toContain('Dipirona a cada 8 horas')
+        ->toContain('Evitar amendoim');
 });
 
 it('does not leak medical details in non medical reports', function () {
@@ -365,22 +519,18 @@ it('does not leak medical details in non medical reports', function () {
 
     $administrator = reportUserWithRole('Administrador');
 
-    $this->actingAs($administrator)
-        ->get(route('admin.reports.print', ['type' => 'mission_contacts']))
-        ->assertOk()
-        ->assertSee('Contatos e endereços para missão')
-        ->assertSee('Maria Responsavel')
-        ->assertSee('Rua da Missão')
-        ->assertDontSee('Dipirona a cada 8 horas')
-        ->assertDontSee('Evitar amendoim');
+    expect(reportHtml('mission_contacts', [], $administrator))
+        ->toContain('Contatos e endereços para missão')
+        ->toContain('Maria Responsavel')
+        ->toContain('Rua da Missão')
+        ->not->toContain('Dipirona a cada 8 horas')
+        ->not->toContain('Evitar amendoim');
 
-    $this->actingAs($administrator)
-        ->get(route('admin.reports.print', ['type' => 'registration_fichas']))
-        ->assertOk()
-        ->assertSee('Fichas de inscrição')
-        ->assertSee('Informação restrita')
-        ->assertDontSee('Dipirona a cada 8 horas')
-        ->assertDontSee('Evitar amendoim');
+    expect(reportHtml('registration_fichas', [], $administrator))
+        ->toContain('Fichas de inscrição')
+        ->toContain('Informação restrita')
+        ->not->toContain('Dipirona a cada 8 horas')
+        ->not->toContain('Evitar amendoim');
 });
 
 it('renders the tribe quadrant grouped by tribe', function () {
@@ -395,15 +545,13 @@ it('renders the tribe quadrant grouped by tribe', function () {
 
     $administrator = reportUserWithRole('Administrador');
 
-    $this->actingAs($administrator)
-        ->get(route('admin.reports.print', ['type' => 'tribe_quadrant']))
-        ->assertOk()
-        ->assertSee('Quadrante das inscrições por tribo')
-        ->assertSee('Azul')
-        ->assertSee('2 campistas')
-        ->assertSee('Ana Azul')
-        ->assertSee('Bruno Azul')
-        ->assertSee('Verde')
-        ->assertSee('1 campista')
-        ->assertSee('Carla Verde');
+    expect(reportHtml('tribe_quadrant', [], $administrator))
+        ->toContain('Quadrante das inscrições por tribo')
+        ->toContain('Azul')
+        ->toContain('2 campistas')
+        ->toContain('Ana Azul')
+        ->toContain('Bruno Azul')
+        ->toContain('Verde')
+        ->toContain('1 campista')
+        ->toContain('Carla Verde');
 });


### PR DESCRIPTION
- Keep printable reports on the HTML same-tab path with return links, print/PDF actions, and loading feedback
- Add report help content and query-backed filter restoration for the reports page
- Hide linked payment data by default behind an authorized financial toggle
- Tighten printable ficha layout and expand browser/feature coverage for the preview flow