### PR TITLE
Improve printable report previews and sensitive health flow

### DIFF
--- a/app/Filament/Pages/ReportsPage.php
+++ b/app/Filament/Pages/ReportsPage.php
@@ -206,6 +206,7 @@ class ReportsPage extends Page
                                     ->label('Confirmo que desejo exibir dados médicos sensíveis neste relatório.')
                                     ->helperText('A impressão só exibirá os dados médicos após esta confirmação.')
                                     ->accepted()
+                                    ->live()
                                     ->visible(fn (Get $get): bool => $this->canUseSensitiveHealthFilter() && (bool) $get('show_sensitive_health'))
                                     ->columnSpanFull(),
                             ]),

--- a/app/Support/Reports/CampistaReportData.php
+++ b/app/Support/Reports/CampistaReportData.php
@@ -130,7 +130,7 @@ class CampistaReportData
             'status' => [
                 'label' => $status?->getLabel() ?? 'Sem status',
                 'tone' => $this->statusTone($status),
-                'icon' => $status?->getIcon() ?? 'heroicon-o-question-mark-circle',
+                'icon' => $this->filledReportIcon($status?->getIcon() ?? 'heroicon-o-question-mark-circle'),
                 'color' => $this->summaryColor($status?->getColor(), $this->statusTone($status)),
                 'accent' => $this->summaryAccent($status?->getColor(), $this->statusTone($status)),
             ],
@@ -143,7 +143,7 @@ class CampistaReportData
                     'label' => 'Status',
                     'value' => $status?->getLabel() ?? 'Sem status',
                     'tone' => $this->statusTone($status),
-                    'icon' => $status?->getIcon() ?? 'heroicon-o-question-mark-circle',
+                    'icon' => $this->filledReportIcon($status?->getIcon() ?? 'heroicon-o-question-mark-circle'),
                     'color' => $this->summaryColor($status?->getColor(), $this->statusTone($status)),
                     'accent' => $this->summaryAccent($status?->getColor(), $this->statusTone($status)),
                 ],
@@ -151,7 +151,7 @@ class CampistaReportData
                     'label' => 'Pagamento',
                     'value' => $payment?->getLabel() ?? 'Não informado',
                     'tone' => $this->paymentTone($payment),
-                    'icon' => $payment?->getIcon() ?? 'heroicon-o-credit-card',
+                    'icon' => $this->filledReportIcon($payment?->getIcon() ?? 'heroicon-o-credit-card'),
                     'color' => $this->summaryColor($payment?->getColor(), $this->paymentTone($payment)),
                     'accent' => $this->summaryAccent($payment?->getColor(), $this->paymentTone($payment)),
                 ],
@@ -159,7 +159,7 @@ class CampistaReportData
                     'label' => 'Presença',
                     'value' => $campista->presenca ? 'Confirmada' : 'Pendente',
                     'tone' => $campista->presenca ? 'success' : 'warning',
-                    'icon' => $campista->presenca ? 'heroicon-o-check-circle' : 'heroicon-o-clock',
+                    'icon' => $campista->presenca ? 'heroicon-s-check-circle' : 'heroicon-s-clock',
                     'color' => $campista->presenca ? 'success' : 'warning',
                     'accent' => $this->summaryAccent($campista->presenca ? 'success' : 'warning'),
                 ],
@@ -167,7 +167,7 @@ class CampistaReportData
                     'label' => 'Tribo',
                     'value' => $campista->tribo?->cor ?? 'Sem tribo',
                     'tone' => $campista->tribo ? 'tribe' : 'neutral',
-                    'icon' => 'heroicon-o-flag',
+                    'icon' => 'heroicon-s-flag',
                     'color' => $campista->tribo ? 'tribe' : 'neutral',
                     'accent' => $this->tribeAccent($campista->tribo?->cor) ?? $this->summaryAccent('neutral'),
                 ],
@@ -268,13 +268,13 @@ class CampistaReportData
             'date' => $lancamento?->data ? Carbon::parse($lancamento->data)->format('d/m/Y') : 'Sem data',
             'method' => [
                 'label' => $method?->getLabel() ?? 'Sem forma',
-                'icon' => $method?->getIcon() ?? 'heroicon-o-credit-card',
+                'icon' => $this->filledReportIcon($method?->getIcon() ?? 'heroicon-o-credit-card'),
                 'color' => $this->summaryColor($method?->getColor(), 'neutral'),
                 'accent' => $this->summaryAccent($method?->getColor(), 'neutral'),
             ],
             'status' => [
                 'label' => $status?->getLabel() ?? 'Sem status',
-                'icon' => $status?->getIcon() ?? 'heroicon-o-question-mark-circle',
+                'icon' => $this->filledReportIcon($status?->getIcon() ?? 'heroicon-o-question-mark-circle'),
                 'color' => $this->summaryColor($status?->getColor(), 'neutral'),
                 'accent' => $this->summaryAccent($status?->getColor(), 'neutral'),
             ],
@@ -285,6 +285,15 @@ class CampistaReportData
     private function money(int $amount): string
     {
         return 'R$ '.number_format(abs($amount) / 100, 2, ',', '.');
+    }
+
+    private function filledReportIcon(?string $icon): string
+    {
+        $icon = filled($icon) ? (string) $icon : 'heroicon-o-question-mark-circle';
+
+        return Str::startsWith($icon, 'heroicon-o-')
+            ? Str::replaceStart('heroicon-o-', 'heroicon-s-', $icon)
+            : $icon;
     }
 
     private function statusTone(?StatusInscricao $status): string

--- a/resources/views/admin/reports/partials/registration-fichas.blade.php
+++ b/resources/views/admin/reports/partials/registration-fichas.blade.php
@@ -33,10 +33,10 @@
                 </span>
                 <span
                     class="report-badge report-badge--tribe"
-                    data-report-summary-icon="heroicon-o-flag"
+                    data-report-summary-icon="heroicon-s-flag"
                     style="--report-accent: {{ $ficha['tribe']['accent'] }};"
                 >
-                    @svg('heroicon-o-flag', 'report-badge__icon', ['aria-hidden' => 'true'])
+                    @svg('heroicon-s-flag', 'report-badge__icon', ['aria-hidden' => 'true'])
                     {{ $ficha['tribe']['label'] }}
                 </span>
             </div>
@@ -65,7 +65,12 @@
         ])>
             @foreach ($ficha['sections'] as $section)
                 <section class="report-card report-card--{{ $section['area'] }}">
-                    <h3>{{ $section['title'] }}</h3>
+                    <h3>
+                        <span>{{ $section['title'] }}</span>
+                        @if (($showSensitiveHealth ?? false) && ($section['area'] ?? null) === 'health')
+                            <span class="report-sensitive-badge">Dados sensíveis</span>
+                        @endif
+                    </h3>
                     @php
                         $fieldRows = [];
                         $pendingFields = [];

--- a/resources/views/admin/reports/print.blade.php
+++ b/resources/views/admin/reports/print.blade.php
@@ -3,7 +3,8 @@
 <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <title>{{ $report['title'] }}</title>
+    <title>{{ $report['title'] }} - {{ config('app.name') }}</title>
+    <link rel="icon" type="image/png" href="{{ $logoSrc ?? asset('img/logo.png') }}">
     <style>
         :root {
             --ink: #082529;
@@ -85,6 +86,7 @@
             min-height: 2.75rem;
             align-items: center;
             justify-content: center;
+            gap: .45rem;
             border: 1px solid rgba(244, 107, 18, .72);
             background: var(--accent);
             color: var(--ink);
@@ -102,10 +104,20 @@
             color: var(--report-screen-text);
         }
 
+        .report-print-action__icon {
+            width: 1rem;
+            height: 1rem;
+            flex: 0 0 auto;
+        }
+
         .report-shell {
             max-width: 1180px;
             margin: 0 auto;
             padding: 1.5rem;
+        }
+
+        .report-content {
+            display: block;
         }
 
         .report-section,
@@ -216,11 +228,52 @@
         .report-page {
             margin-bottom: 1rem;
             padding: 1rem;
+            break-after: page;
             page-break-after: always;
         }
 
         .report-page:last-child {
+            break-after: auto;
             page-break-after: auto;
+        }
+
+        .report-cover {
+            display: grid;
+            align-content: start;
+            gap: 1rem;
+            break-after: page;
+            page-break-after: always;
+        }
+
+        .report-cover .report-heading,
+        .report-cover .report-filters,
+        .report-cover .report-sensitive-alert {
+            margin-bottom: 0;
+        }
+
+        .report-cover__intro {
+            border-left: .28rem solid var(--accent);
+            padding-left: .85rem;
+        }
+
+        .report-cover__intro span {
+            color: var(--muted);
+            display: block;
+            font-size: .68rem;
+            font-weight: 900;
+            letter-spacing: .1em;
+            text-transform: uppercase;
+        }
+
+        .report-cover__intro h2 {
+            margin: .2rem 0 .3rem;
+            font-size: 1.15rem;
+        }
+
+        .report-cover__intro p {
+            color: var(--muted);
+            margin: 0;
+            max-width: 44rem;
         }
 
         .report-page__top {
@@ -416,6 +469,20 @@
             flex: 0 0 auto;
         }
 
+        .report-sensitive-badge {
+            border: 1px solid rgba(244, 107, 18, .42);
+            background: rgba(244, 107, 18, .1);
+            color: #9a3f00;
+            display: inline-flex;
+            align-items: center;
+            font-size: .58rem;
+            font-weight: 900;
+            letter-spacing: .08em;
+            line-height: 1;
+            padding: .25rem .38rem;
+            text-transform: uppercase;
+        }
+
         .report-two-col,
         .report-grid {
             display: grid;
@@ -609,14 +676,15 @@
 
         .report-sensitive-alert {
             border: 1px solid rgba(244, 107, 18, .55);
-            background: rgba(244, 107, 18, .12);
-            color: var(--report-screen-text);
+            background: #fff7ed;
+            color: #7a2e04;
             margin-bottom: 1rem;
             padding: .85rem 1rem;
         }
 
         .report-sensitive-alert strong {
             display: block;
+            color: #9a3f00;
             font-size: .72rem;
             font-weight: 800;
             letter-spacing: .08em;
@@ -644,6 +712,10 @@
             .report-shell {
                 max-width: none;
                 padding: 0;
+            }
+
+            .report-cover {
+                min-height: calc(297mm - 22mm);
             }
 
             .report-heading,
@@ -674,7 +746,10 @@
 
             .report-heading p,
             .report-heading dt,
-            .report-filter span {
+            .report-filter span,
+            .report-cover__intro,
+            .report-cover__intro span,
+            .report-cover__intro p {
                 color: var(--muted);
             }
 
@@ -692,62 +767,100 @@
             <span>{{ $report['recordsCount'] }} registros - gerado em {{ $report['generatedAt'] }}</span>
         </div>
         <div class="report-print-toolbar__actions">
-            <a class="report-print-action report-print-action--secondary" href="{{ $returnUrl }}">Voltar para a central</a>
-            <button type="button" data-report-save-pdf onclick="window.print()">Salvar PDF</button>
-            <button type="button" data-report-print onclick="window.print()">Imprimir</button>
+            <a class="report-print-action report-print-action--secondary" href="{{ $returnUrl }}" data-report-action-icon="heroicon-s-arrow-left">
+                @svg('heroicon-s-arrow-left', 'report-print-action__icon', ['aria-hidden' => 'true'])
+                <span>Voltar para a central</span>
+            </a>
+            <button class="report-print-action" type="button" data-report-save-pdf data-report-action-icon="heroicon-s-arrow-down-tray" onclick="window.print()">
+                @svg('heroicon-s-arrow-down-tray', 'report-print-action__icon', ['aria-hidden' => 'true'])
+                <span>Salvar PDF</span>
+            </button>
+            <button class="report-print-action" type="button" data-report-print data-report-action-icon="heroicon-s-printer" onclick="window.print()">
+                @svg('heroicon-s-printer', 'report-print-action__icon', ['aria-hidden' => 'true'])
+                <span>Imprimir</span>
+            </button>
         </div>
     </div>
 
-    <main class="report-shell">
-        <header class="report-heading report-print-panel">
-            <div class="report-heading__brand">
-                <img class="report-heading__logo" src="{{ $logoSrc ?? asset('img/logo.png') }}" alt="Logo do acampamento">
-                <div>
-                    <h1>{{ $report['title'] }}</h1>
-                    <p>{{ $report['description'] }}</p>
-                </div>
-            </div>
-            <dl>
-                <dt>Gerado em</dt>
-                <dd>{{ $report['generatedAt'] }}</dd>
-                <dt>Total</dt>
-                <dd>{{ $report['recordsCount'] }} registros</dd>
-            </dl>
-        </header>
+    @php
+        $isRegistrationFichas = $report['type']->value === 'registration_fichas';
+    @endphp
 
-        <section class="report-filters" aria-label="Filtros aplicados">
-            @foreach ($report['filters'] as $label => $value)
-                <div class="report-filter report-print-filter">
-                    <span>{{ $label }}</span>
-                    <strong>{{ $value ?: 'Não informado' }}</strong>
+    <main class="report-shell">
+        <section
+            @class([
+                'report-page',
+                'report-cover',
+                'report-cover--registration-fichas' => $isRegistrationFichas,
+            ])
+            aria-label="Dados do relatório"
+        >
+            <header class="report-heading report-print-panel">
+                <div class="report-heading__brand">
+                    <img class="report-heading__logo" src="{{ $logoSrc ?? asset('img/logo.png') }}" alt="Logo do acampamento">
+                    <div>
+                        <h1>{{ $report['title'] }}</h1>
+                        <p>{{ $report['description'] }}</p>
+                    </div>
                 </div>
-            @endforeach
+                <dl>
+                    <dt>Gerado em</dt>
+                    <dd>{{ $report['generatedAt'] }}</dd>
+                    <dt>Total</dt>
+                    <dd>{{ $report['recordsCount'] }} registros</dd>
+                </dl>
+            </header>
+
+            <div class="report-cover__intro">
+                <span>Dados do relatório</span>
+                <h2>Conferência da impressão</h2>
+                <p>Confira o tipo de relatório, a quantidade de registros e os filtros aplicados antes de distribuir as fichas.</p>
+            </div>
+
+            <section class="report-filters report-cover__filters" aria-label="Filtros aplicados">
+                @foreach ($report['filters'] as $label => $value)
+                    <div class="report-filter report-print-filter">
+                        <span>{{ $label }}</span>
+                        <strong>{{ $value ?: 'Não informado' }}</strong>
+                    </div>
+                @endforeach
+            </section>
+
+            @if ($report['showSensitiveHealth'] ?? false)
+                <section class="report-sensitive-alert" aria-label="Aviso sobre dados médicos sensíveis">
+                    <strong>Dados médicos sensíveis exibidos</strong>
+                    Este relatório contém informações de saúde e deve ser tratado com cuidado, sem compartilhamento fora das pessoas responsáveis pelo cuidado e pela operação do acampamento.
+                </section>
+            @endif
         </section>
 
-        @if ($report['showSensitiveHealth'] ?? false)
-            <section class="report-sensitive-alert" aria-label="Aviso sobre dados médicos sensíveis">
-                <strong>Dados médicos sensíveis exibidos</strong>
-                Este relatório contém informações de saúde e deve ser tratado com cuidado, sem compartilhamento fora das pessoas responsáveis pelo cuidado e pela operação do acampamento.
-            </section>
-        @endif
+        <section
+            @class([
+                'report-content',
+                'report-content--registration-fichas' => $isRegistrationFichas,
+            ])
+        >
+            @switch($report['type']->value)
+                @case('registration_fichas')
+                    @include('admin.reports.partials.registration-fichas', [
+                        'fichas' => $report['fichas'],
+                        'showSensitiveHealth' => $report['showSensitiveHealth'] ?? false,
+                    ])
+                    @break
 
-        @switch($report['type']->value)
-            @case('registration_fichas')
-                @include('admin.reports.partials.registration-fichas', ['fichas' => $report['fichas']])
-                @break
+                @case('tribe_quadrant')
+                    @include('admin.reports.partials.tribe-quadrant', ['tribes' => $report['tribes']])
+                    @break
 
-            @case('tribe_quadrant')
-                @include('admin.reports.partials.tribe-quadrant', ['tribes' => $report['tribes']])
-                @break
+                @case('sensitive_health')
+                    @include('admin.reports.partials.sensitive-health', ['rows' => $report['medicalRows']])
+                    @break
 
-            @case('sensitive_health')
-                @include('admin.reports.partials.sensitive-health', ['rows' => $report['medicalRows']])
-                @break
-
-            @case('mission_contacts')
-                @include('admin.reports.partials.mission-contacts', ['rows' => $report['missionRows']])
-                @break
-        @endswitch
+                @case('mission_contacts')
+                    @include('admin.reports.partials.mission-contacts', ['rows' => $report['missionRows']])
+                    @break
+            @endswitch
+        </section>
     </main>
 </body>
 </html>

--- a/tests/Browser/admin-panel-layout.spec.js
+++ b/tests/Browser/admin-panel-layout.spec.js
@@ -808,7 +808,22 @@ test('authenticated reports page uses native Filament filters with help and same
 
     await page.keyboard.press('Escape');
 
+    const previewAction = page.locator('[data-report-preview-link="true"]').first();
     const previewLink = page.getByRole('link', { name: /abrir prévia/i });
+    const sensitiveHealthToggle = page.getByRole('switch', { name: /exibir dados médicos/i });
+
+    await sensitiveHealthToggle.check({ force: true });
+    await expect(page.getByText('Dados médicos sensíveis', { exact: true })).toBeVisible();
+    await expect(previewAction).toHaveAttribute('aria-disabled', 'true');
+
+    await page.getByRole('checkbox', {
+        name: /confirmo que desejo exibir dados médicos sensíveis/i,
+    }).check({ force: true });
+
+    await expect(previewAction).not.toHaveAttribute('aria-disabled', 'true');
+    await expect(previewAction).toHaveAttribute('href', /show_sensitive_health=1/);
+    await expect(previewAction).toHaveAttribute('href', /confirm_sensitive_health=1/);
+
     const reportTypeChecks = [
         ['Fichas de inscrição', 'registration_fichas', 'Fichas de inscrição'],
         ['Quadrante por tribo', 'tribe_quadrant', 'Quadrante das inscrições por tribo'],
@@ -841,6 +856,8 @@ test('authenticated reports page uses native Filament filters with help and same
         await page.waitForURL(/\/admin\/relatorios\/imprimir/);
         expect(page.url()).toContain(`type=${expectedType}`);
         await expect(page.locator('.report-print-toolbar')).toBeVisible();
+        await expect(page.locator('.report-print-toolbar [data-report-action-icon]')).toHaveCount(3);
+        await expect(page.locator('.report-print-toolbar .report-print-action__icon')).toHaveCount(3);
         await expect(page.getByText(expectedTitle).first()).toBeVisible();
         await expect(page.getByRole('button', { name: /salvar pdf/i })).toBeVisible();
         await expect(page.getByRole('button', { name: /imprimir/i })).toBeVisible();

--- a/tests/Feature/ReportsPageTest.php
+++ b/tests/Feature/ReportsPageTest.php
@@ -116,7 +116,8 @@ function assertPrintableHtml(TestResponse $response): TestResponse
         ->and($response->getContent())->not->toStartWith('%PDF')
         ->and($response->getContent())->toContain('Prévia para impressão')
         ->toContain('data-report-print')
-        ->toContain('data-report-save-pdf');
+        ->toContain('data-report-save-pdf')
+        ->toContain('data-report-action-icon="heroicon-s-printer"');
 
     return $response;
 }
@@ -238,6 +239,7 @@ it('builds the report filters with native Filament form components', function ()
         ->toContain('Exibir dados de pagamento')
         ->toContain('Por padrão, dados de pagamento permanecem ocultos')
         ->toContain("Checkbox::make('confirm_sensitive_health')")
+        ->toContain("->accepted()\n                                    ->live()")
         ->toContain('Dados médicos sensíveis')
         ->toContain("TextInput::make('search')")
         ->toContain('->footerActions([')
@@ -290,6 +292,8 @@ it('renders the printable preview as HTML in the same tab', function () {
     ], $administrator);
 
     expect($html)
+        ->toContain('<title>Fichas de inscrição - '.e(config('app.name')).'</title>')
+        ->toContain('<link rel="icon" type="image/png" href="'.asset('img/logo.png').'">')
         ->toContain('<body class="report-print-document">')
         ->toContain('report-print-toolbar')
         ->toContain('report-print-panel')
@@ -300,6 +304,11 @@ it('renders the printable preview as HTML in the same tab', function () {
         ->toContain('Salvar PDF')
         ->toContain('Imprimir')
         ->toContain('Voltar para a central')
+        ->toContain('report-print-action__icon')
+        ->toContain('data-report-action-icon="heroicon-s-arrow-left"')
+        ->toContain('data-report-action-icon="heroicon-s-arrow-down-tray"')
+        ->toContain('data-report-action-icon="heroicon-s-printer"')
+        ->not->toContain('data-report-action-icon="heroicon-o-')
         ->toContain(e($returnUrl))
         ->toContain('Logo do acampamento')
         ->not->toContain('<dt>Central</dt>');
@@ -317,6 +326,8 @@ it('keeps printable previews on the HTML rendering path', function () {
         ->toContain('report-print-toolbar')
         ->toContain('report-print-document')
         ->toContain('data-report-save-pdf')
+        ->toContain('data-report-action-icon="heroicon-s-arrow-down-tray"')
+        ->toContain('data-report-action-icon="heroicon-s-printer"')
         ->toContain('window.print()')
         ->toContain('-webkit-print-color-adjust: exact;')
         ->toContain('print-color-adjust: exact;')
@@ -366,7 +377,9 @@ it('applies ficha visual styling and keeps linked payments hidden by default on 
         ->toContain('report-card--health')
         ->toContain('data-report-summary-icon="polaris-payment-icon"')
         ->toContain('data-report-summary-icon="fab-pix"')
-        ->toContain('data-report-summary-icon="heroicon-o-flag"')
+        ->toContain('data-report-summary-icon="heroicon-s-flag"')
+        ->toContain('data-report-summary-icon="heroicon-s-clock"')
+        ->not->toContain('data-report-summary-icon="heroicon-o-')
         ->toContain('--report-accent: #ec4899')
         ->not->toContain('report-card--control')
         ->not->toContain('Controle da inscrição')
@@ -387,6 +400,51 @@ it('applies ficha visual styling and keeps linked payments hidden by default on 
         ->toContain('.report-card--payments')
         ->toContain('grid-column: 1 / -1;')
         ->toContain('margin-top: 0;');
+});
+
+it('starts printable registration fichas after a report data cover page', function () {
+    $this->seed(ShieldSeeder::class);
+
+    reportCampista();
+
+    $administrator = reportUserWithRole('Administrador');
+
+    $html = reportHtml('registration_fichas', [], $administrator);
+    $printView = file_get_contents(resource_path('views/admin/reports/print.blade.php'));
+
+    expect($html)
+        ->toContain('aria-label="Dados do relatório"')
+        ->toContain('report-cover')
+        ->toContain('report-content--registration-fichas')
+        ->toContain('Dados do relatório')
+        ->toContain('Filtros aplicados')
+        ->and(strpos($html, 'report-cover'))
+        ->toBeLessThan(strpos($html, 'report-registration-ficha'))
+        ->and($printView)
+        ->toContain('.report-cover')
+        ->toContain('break-after: page;')
+        ->toContain('background: #fff7ed;')
+        ->toContain('color: #7a2e04;')
+        ->toContain('color: #9a3f00;');
+});
+
+it('marks the health section with a sensitive data badge only when medical data is exposed', function () {
+    $this->seed(ShieldSeeder::class);
+
+    reportCampista();
+
+    $infirmary = reportUserWithRole('Enfermaria');
+
+    expect(reportHtml('registration_fichas', [], $infirmary))
+        ->toContain('Saúde e cuidados')
+        ->not->toContain('Dados sensíveis');
+
+    expect(reportHtml('registration_fichas', [
+        'show_sensitive_health' => 1,
+        'confirm_sensitive_health' => 1,
+    ], $infirmary))
+        ->toContain('Saúde e cuidados')
+        ->toContain('<span class="report-sensitive-badge">Dados sensíveis</span>');
 });
 
 it('shows linked payment badges on printable registration reports only when the financial toggle is enabled', function () {


### PR DESCRIPTION
- Add a cover page with report metadata, filters, favicon, and print action icons
- Use filled report icons and mark exposed health sections as sensitive
- Keep preview disabled until sensitive health disclosure is confirmed