### PR TITLE
Remove registration summary from printable fichas

### DIFF
--- a/app/Support/Reports/CampistaReportData.php
+++ b/app/Support/Reports/CampistaReportData.php
@@ -2,7 +2,6 @@
 
 namespace App\Support\Reports;
 
-use App\Enums\FormaPagamento;
 use App\Enums\StatusInscricao;
 use App\Models\Campista;
 use App\Models\LancamentoItem;
@@ -117,8 +116,6 @@ class CampistaReportData
     private function ficha(Campista $campista, bool $showSensitiveHealth, bool $showPaymentData): array
     {
         $formData = $campista->form_data ?? [];
-        $status = $this->statusEnum($campista);
-        $payment = $this->paymentEnum($campista);
         $takesMedicine = $this->truthy(data_get($formData, 'toma_remedio'));
         $hasRecommendation = $this->truthy(data_get($formData, 'tem_recomendacao'));
 
@@ -127,50 +124,9 @@ class CampistaReportData
             'name' => $campista->nome,
             'avatar_url' => $this->avatarUrl($campista),
             'created_at' => $campista->created_at?->format('d/m/Y H:i'),
-            'status' => [
-                'label' => $status?->getLabel() ?? 'Sem status',
-                'tone' => $this->statusTone($status),
-                'icon' => $this->filledReportIcon($status?->getIcon() ?? 'heroicon-o-question-mark-circle'),
-                'color' => $this->summaryColor($status?->getColor(), $this->statusTone($status)),
-                'accent' => $this->summaryAccent($status?->getColor(), $this->statusTone($status)),
-            ],
             'tribe' => [
                 'label' => $campista->tribo?->cor ?? 'Sem tribo',
                 'accent' => $this->tribeAccent($campista->tribo?->cor) ?? $this->summaryAccent('neutral'),
-            ],
-            'summary' => [
-                [
-                    'label' => 'Status',
-                    'value' => $status?->getLabel() ?? 'Sem status',
-                    'tone' => $this->statusTone($status),
-                    'icon' => $this->filledReportIcon($status?->getIcon() ?? 'heroicon-o-question-mark-circle'),
-                    'color' => $this->summaryColor($status?->getColor(), $this->statusTone($status)),
-                    'accent' => $this->summaryAccent($status?->getColor(), $this->statusTone($status)),
-                ],
-                [
-                    'label' => 'Pagamento',
-                    'value' => $payment?->getLabel() ?? 'Não informado',
-                    'tone' => $this->paymentTone($payment),
-                    'icon' => $this->filledReportIcon($payment?->getIcon() ?? 'heroicon-o-credit-card'),
-                    'color' => $this->summaryColor($payment?->getColor(), $this->paymentTone($payment)),
-                    'accent' => $this->summaryAccent($payment?->getColor(), $this->paymentTone($payment)),
-                ],
-                [
-                    'label' => 'Presença',
-                    'value' => $campista->presenca ? 'Confirmada' : 'Pendente',
-                    'tone' => $campista->presenca ? 'success' : 'warning',
-                    'icon' => $campista->presenca ? 'heroicon-s-check-circle' : 'heroicon-s-clock',
-                    'color' => $campista->presenca ? 'success' : 'warning',
-                    'accent' => $this->summaryAccent($campista->presenca ? 'success' : 'warning'),
-                ],
-                [
-                    'label' => 'Tribo',
-                    'value' => $campista->tribo?->cor ?? 'Sem tribo',
-                    'tone' => $campista->tribo ? 'tribe' : 'neutral',
-                    'icon' => 'heroicon-s-flag',
-                    'color' => $campista->tribo ? 'tribe' : 'neutral',
-                    'accent' => $this->tribeAccent($campista->tribo?->cor) ?? $this->summaryAccent('neutral'),
-                ],
             ],
             'sections' => [
                 [
@@ -294,27 +250,6 @@ class CampistaReportData
         return Str::startsWith($icon, 'heroicon-o-')
             ? Str::replaceStart('heroicon-o-', 'heroicon-s-', $icon)
             : $icon;
-    }
-
-    private function statusTone(?StatusInscricao $status): string
-    {
-        return match ($status) {
-            StatusInscricao::Pago => 'success',
-            StatusInscricao::Cancelado => 'danger',
-            StatusInscricao::Pendente => 'warning',
-            default => 'neutral',
-        };
-    }
-
-    private function paymentTone(?FormaPagamento $payment): string
-    {
-        return match ($payment) {
-            FormaPagamento::Pix => 'info',
-            FormaPagamento::Dinheiro => 'success',
-            FormaPagamento::Cartao => 'warning',
-            FormaPagamento::NaoPago => 'danger',
-            default => 'neutral',
-        };
     }
 
     private function summaryColor(string|array|null $color, string $fallback = 'neutral'): string
@@ -583,15 +518,6 @@ class CampistaReportData
         return $campista->status instanceof StatusInscricao
             ? $campista->status
             : StatusInscricao::tryFrom((int) $campista->status);
-    }
-
-    private function paymentEnum(Campista $campista): ?FormaPagamento
-    {
-        if ($campista->forma_pagamento instanceof FormaPagamento) {
-            return $campista->forma_pagamento;
-        }
-
-        return blank($campista->forma_pagamento) ? null : FormaPagamento::tryFrom((int) $campista->forma_pagamento);
     }
 
     private function sexLabel(mixed $sex): ?string

--- a/resources/views/admin/reports/partials/registration-fichas.blade.php
+++ b/resources/views/admin/reports/partials/registration-fichas.blade.php
@@ -27,13 +27,9 @@
             </div>
 
             <div class="report-registration-ficha__badges">
-                <span class="report-badge report-badge--{{ $ficha['status']['tone'] }}">
-                    @svg($ficha['status']['icon'], 'report-badge__icon', ['aria-hidden' => 'true'])
-                    {{ $ficha['status']['label'] }}
-                </span>
                 <span
                     class="report-badge report-badge--tribe"
-                    data-report-summary-icon="heroicon-s-flag"
+                    data-report-badge-icon="heroicon-s-flag"
                     style="--report-accent: {{ $ficha['tribe']['accent'] }};"
                 >
                     @svg('heroicon-s-flag', 'report-badge__icon', ['aria-hidden' => 'true'])
@@ -41,23 +37,6 @@
                 </span>
             </div>
         </header>
-
-        <section class="report-registration-summary" aria-label="Resumo da inscrição">
-            @foreach ($ficha['summary'] as $summary)
-                <div
-                    class="report-registration-summary__item report-registration-summary__item--{{ $summary['tone'] }}"
-                    data-report-summary-icon="{{ $summary['icon'] }}"
-                    data-report-summary-color="{{ $summary['color'] }}"
-                    style="--report-accent: {{ $summary['accent'] }};"
-                >
-                    <span>{{ $summary['label'] }}</span>
-                    <strong>
-                        @svg($summary['icon'], 'report-registration-summary__icon', ['aria-hidden' => 'true'])
-                        {{ $summary['value'] }}
-                    </strong>
-                </div>
-            @endforeach
-        </section>
 
         <div @class([
             'report-registration-ficha__bento',

--- a/resources/views/admin/reports/print.blade.php
+++ b/resources/views/admin/reports/print.blade.php
@@ -393,52 +393,6 @@
             gap: .35rem;
         }
 
-        .report-registration-summary {
-            display: grid;
-            grid-template-columns: repeat(4, minmax(0, 1fr));
-            border: 1px solid var(--line);
-            margin-bottom: .75rem;
-            background: #f9fcfc;
-        }
-
-        .report-registration-summary__item {
-            display: grid;
-            gap: .28rem;
-            min-width: 0;
-            border-top: 3px solid var(--report-accent);
-            border-right: 1px solid var(--line);
-            padding: .6rem .7rem;
-        }
-
-        .report-registration-summary__item:last-child {
-            border-right: 0;
-        }
-
-        .report-registration-summary__item span {
-            color: var(--muted);
-            font-size: .64rem;
-            font-weight: 900;
-            letter-spacing: .08em;
-            text-transform: uppercase;
-        }
-
-        .report-registration-summary__item strong {
-            display: inline-flex;
-            min-width: 0;
-            align-items: center;
-            gap: .35rem;
-            color: var(--ink);
-            font-size: .86rem;
-            line-height: 1.2;
-        }
-
-        .report-registration-summary__icon {
-            width: .95rem;
-            height: .95rem;
-            flex: 0 0 auto;
-            color: var(--report-accent);
-        }
-
         .report-registration-ficha__sections {
             align-items: start;
         }
@@ -722,8 +676,6 @@
             .report-section,
             .report-page,
             .report-card,
-            .report-registration-summary,
-            .report-registration-summary__item,
             .report-registration-payment,
             .report-filter,
             .report-table th,

--- a/tests/Feature/ReportsPageTest.php
+++ b/tests/Feature/ReportsPageTest.php
@@ -368,19 +368,20 @@ it('applies ficha visual styling and keeps linked payments hidden by default on 
     $html = reportHtml('registration_fichas', [], $superAdministrator);
 
     expect($html)
-        ->toContain('report-registration-summary')
         ->toContain('report-registration-ficha__bento')
         ->toContain('report-card--personal')
         ->toContain('report-card--contact')
         ->toContain('report-card--address')
         ->toContain('report-card--community')
         ->toContain('report-card--health')
-        ->toContain('data-report-summary-icon="polaris-payment-icon"')
-        ->toContain('data-report-summary-icon="fab-pix"')
-        ->toContain('data-report-summary-icon="heroicon-s-flag"')
-        ->toContain('data-report-summary-icon="heroicon-s-clock"')
-        ->not->toContain('data-report-summary-icon="heroicon-o-')
+        ->toContain('data-report-badge-icon="heroicon-s-flag"')
         ->toContain('--report-accent: #ec4899')
+        ->not->toContain('report-registration-summary')
+        ->not->toContain('Resumo da inscrição')
+        ->not->toContain('data-report-summary-icon')
+        ->not->toContain('data-report-summary-color')
+        ->not->toContain('class="report-badge report-badge--success"')
+        ->not->toContain('class="report-badge report-badge--warning"')
         ->not->toContain('report-card--control')
         ->not->toContain('Controle da inscrição')
         ->not->toContain('Data de inscrição')
@@ -399,7 +400,8 @@ it('applies ficha visual styling and keeps linked payments hidden by default on 
         ->toContain('report-field__value')
         ->toContain('.report-card--payments')
         ->toContain('grid-column: 1 / -1;')
-        ->toContain('margin-top: 0;');
+        ->toContain('margin-top: 0;')
+        ->not->toContain('.report-registration-summary');
 });
 
 it('starts printable registration fichas after a report data cover page', function () {
@@ -489,7 +491,7 @@ it('hides linked payments on printable registration reports without financial vi
     ], $administrator);
 
     expect($html)
-        ->toContain('report-registration-summary')
+        ->not->toContain('report-registration-summary')
         ->not->toContain('<section class="report-card report-registration-payment-section">')
         ->not->toContain('Pagamentos vinculados')
         ->not->toContain('Lançamento relatório inscrição');


### PR DESCRIPTION
- Keep printable fichas focused on the detailed bento sections
- Drop status/payment/presence summary data and related print CSS
- Update report tests to assert the summary markup is absent