### PR TITLE
Show restricted health flags in campista reports

### DIFF
--- a/app/Support/Reports/CampistaReportData.php
+++ b/app/Support/Reports/CampistaReportData.php
@@ -181,9 +181,9 @@ class CampistaReportData
                     'title' => 'Saúde e cuidados',
                     'area' => 'health',
                     'fields' => [
-                        ['label' => 'Toma remédio?', 'value' => $this->sensitiveBooleanLabel($takesMedicine, $showSensitiveHealth), 'tone' => $takesMedicine ? 'warning' : 'success'],
+                        ['label' => 'Toma remédio?', 'value' => $this->sensitiveBooleanLabel($takesMedicine), 'tone' => $takesMedicine ? 'warning' : 'success'],
                         ['label' => 'Detalhes do remédio', 'value' => $this->sensitiveValue(data_get($formData, 'remedio'), $takesMedicine, $showSensitiveHealth)],
-                        ['label' => 'Tem recomendação?', 'value' => $this->sensitiveBooleanLabel($hasRecommendation, $showSensitiveHealth), 'tone' => $hasRecommendation ? 'warning' : 'success'],
+                        ['label' => 'Tem recomendação?', 'value' => $this->sensitiveBooleanLabel($hasRecommendation), 'tone' => $hasRecommendation ? 'warning' : 'success'],
                         ['label' => 'Recomendação de cuidado', 'value' => $this->sensitiveValue(data_get($formData, 'recomendacao'), $hasRecommendation, $showSensitiveHealth)],
                     ],
                 ],
@@ -591,17 +591,9 @@ class CampistaReportData
         return filled($value) ? (string) $value : 'Não detalhado';
     }
 
-    private function sensitiveBooleanLabel(bool $hasSensitiveInfo, bool $showSensitiveHealth): string
+    private function sensitiveBooleanLabel(bool $hasSensitiveInfo): string
     {
-        if (! $hasSensitiveInfo) {
-            return 'Não';
-        }
-
-        if (! $showSensitiveHealth) {
-            return 'Informação restrita';
-        }
-
-        return 'Sim';
+        return $hasSensitiveInfo ? 'Sim' : 'Não';
     }
 
     private function truthy(mixed $value): bool

--- a/tests/Feature/ReportsPageTest.php
+++ b/tests/Feature/ReportsPageTest.php
@@ -552,10 +552,17 @@ it('requires the sensitive health toggle and confirmation before exposing medica
 
     $infirmary = reportUserWithRole('Enfermaria');
 
-    expect(reportHtml('registration_fichas', [], $infirmary))
+    $restrictedHtml = reportHtml('registration_fichas', [], $infirmary);
+
+    expect($restrictedHtml)
+        ->toContain('<span class="report-field__label">Toma remédio?</span>')
+        ->toContain('<span class="report-field__label">Tem recomendação?</span>')
         ->toContain('Informação restrita')
         ->not->toContain('Dipirona a cada 8 horas')
         ->not->toContain('Evitar amendoim');
+
+    expect(substr_count($restrictedHtml, '<strong class="report-field__value">Sim</strong>'))
+        ->toBeGreaterThanOrEqual(2);
 
     expect(reportHtml('registration_fichas', [
         'show_sensitive_health' => 1,


### PR DESCRIPTION
- Keep yes/no indicators visible while hiding sensitive health details
- Cover restricted infirmary report output with assertions for labels and flags