### PR TITLE
Add configurable tribe colors across admin and reports

### DIFF
--- a/app/Filament/Resources/CampistaResource/CampistaTable.php
+++ b/app/Filament/Resources/CampistaResource/CampistaTable.php
@@ -6,6 +6,7 @@ use App\Enums\FormaPagamento;
 use App\Enums\StatusInscricao;
 use App\Models\Campista;
 use App\Models\Tribo;
+use App\Support\Tribes\TribeColor;
 use Carbon\Carbon;
 use Filament\Tables\Columns\IconColumn;
 use Filament\Tables\Columns\ImageColumn;
@@ -57,6 +58,8 @@ abstract class CampistaTable
 
             TextColumn::make('tribo.cor')
                 ->label('Cor da Tribo')
+                ->formatStateUsing(fn (?string $state, Campista $record) => TribeColor::badge($record->tribo))
+                ->html()
                 ->sortable()
                 ->hidden( fn() => auth()->user()->can('update_campista', Campista::class))
                 ->searchable(true)

--- a/app/Filament/Resources/CampistaResource/Pages/ViewCampista.php
+++ b/app/Filament/Resources/CampistaResource/Pages/ViewCampista.php
@@ -9,6 +9,7 @@ use App\Filament\Resources\CampistaResource\CampistaForm;
 use App\Filament\Resources\LancamentoResource;
 use App\Models\LancamentoItem;
 use App\Support\Campistas\ParishCommunityLabels;
+use App\Support\Tribes\TribeColor;
 use Carbon\Carbon;
 use Filament\Actions\EditAction;
 use Filament\Resources\Pages\ViewRecord;
@@ -116,7 +117,7 @@ class ViewCampista extends ViewRecord
                     'tone' => $record->tribo ? 'tribe' : 'neutral',
                     'icon' => 'heroicon-o-flag',
                     'color' => $record->tribo ? 'tribe' : 'neutral',
-                    'accent' => $this->tribeAccent($record->tribo?->cor) ?? $this->summaryAccent('neutral'),
+                    'accent' => TribeColor::forTribe($record->tribo),
                 ],
             ],
             'sections' => [
@@ -338,33 +339,6 @@ class ViewCampista extends ViewRecord
             'orange' => '#f46b12',
             'violet' => '#a78bfa',
             default => '#94a3b8',
-        };
-    }
-
-    private function tribeAccent(?string $color): ?string
-    {
-        if (blank($color)) {
-            return null;
-        }
-
-        $normalized = Str::lower(Str::ascii(trim($color)));
-
-        if (preg_match('/^#(?:[0-9a-f]{3}|[0-9a-f]{6})$/', $normalized) === 1) {
-            return $normalized;
-        }
-
-        return match ($normalized) {
-            'azul' => '#2563eb',
-            'vermelha', 'vermelho' => '#dc2626',
-            'verde' => '#16a34a',
-            'amarela', 'amarelo' => '#eab308',
-            'roxa', 'roxo' => '#7c3aed',
-            'laranja' => '#f97316',
-            'rosa' => '#ec4899',
-            'branca', 'branco' => '#f8fafc',
-            'preta', 'preto' => '#111827',
-            'cinza' => '#64748b',
-            default => null,
         };
     }
 

--- a/app/Filament/Resources/TriboResource.php
+++ b/app/Filament/Resources/TriboResource.php
@@ -4,15 +4,18 @@ namespace App\Filament\Resources;
 
 use App\Filament\Resources\TriboResource\Pages;
 use App\Models\Tribo;
+use App\Support\Tribes\TribeColor;
 use BezhanSalleh\FilamentShield\Contracts\HasShieldPermissions;
 use Filament\Actions\BulkActionGroup;
 use Filament\Actions\DeleteBulkAction;
 use Filament\Actions\EditAction;
+use Filament\Forms\Components\ColorPicker;
 use Filament\Forms\Components\TextInput;
 use Filament\Resources\Resource;
 use Filament\Schemas\Schema;
 use Filament\Tables\Columns\TextColumn;
 use Filament\Tables\Table;
+use Illuminate\Support\HtmlString;
 use Tapp\FilamentAuditing\RelationManagers\AuditsRelationManager;
 
 class TriboResource extends Resource implements HasShieldPermissions
@@ -26,11 +29,28 @@ class TriboResource extends Resource implements HasShieldPermissions
     public static function form(Schema $schema): Schema
     {
         return $schema
-            ->columns(1)
+            ->columns([
+                'default' => 1,
+                'lg' => 4,
+            ])
             ->components([
                 TextInput::make('cor')
-                    ->label('Cor da Tribo')
-                    ->required(),
+                    ->label('Nome da tribo')
+                    ->maxLength(255)
+                    ->required()
+                    ->columnSpan([
+                        'default' => 1,
+                        'lg' => 3,
+                    ]),
+
+                ColorPicker::make('cor_hex')
+                    ->label('Cor da tribo')
+                    ->default(TribeColor::FALLBACK)
+                    ->required()
+                    ->columnSpan([
+                        'default' => 1,
+                        'lg' => 1,
+                    ]),
             ]);
     }
 
@@ -41,7 +61,15 @@ class TriboResource extends Resource implements HasShieldPermissions
                 TextColumn::make('id')
                     ->label('Código'),
                 TextColumn::make('cor')
-                    ->label('Cor da Tribo'),
+                    ->label('Tribo'),
+                TextColumn::make('cor_hex')
+                    ->label('Cor')
+                    ->formatStateUsing(fn (?string $state, Tribo $record): HtmlString => new HtmlString(sprintf(
+                        '<span style="display:inline-flex;align-items:center;gap:.5rem;"><span style="width:1rem;height:1rem;border-radius:999px;border:1px solid rgba(148,163,184,.45);background:%s;"></span><span>%s</span></span>',
+                        e(TribeColor::resolve($state, $record->cor)),
+                        e(TribeColor::resolve($state, $record->cor)),
+                    )))
+                    ->html(),
             ])
             ->filters([
                 //

--- a/app/Filament/Widgets/Operational/OperationalPendingTasksTable.php
+++ b/app/Filament/Widgets/Operational/OperationalPendingTasksTable.php
@@ -4,6 +4,7 @@ namespace App\Filament\Widgets\Operational;
 
 use App\Filament\Widgets\Operational\Concerns\UsesOperationalDashboardData;
 use App\Models\Campista;
+use App\Support\Tribes\TribeColor;
 use Filament\Actions\ViewAction;
 use Filament\Tables\Columns\TextColumn;
 use Filament\Tables\Table;
@@ -54,7 +55,8 @@ class OperationalPendingTasksTable extends TableWidget
                 TextColumn::make('tribo.cor')
                     ->label('Tribo')
                     ->placeholder('Sem tribo')
-                    ->badge(),
+                    ->formatStateUsing(fn (?string $state, Campista $record) => TribeColor::badge($record->tribo))
+                    ->html(),
                 TextColumn::make('pending_issues')
                     ->label('Pendências')
                     ->state(fn (Campista $record): string => $this->pendingIssues($record))

--- a/app/Filament/Widgets/Operational/SensitiveHealthTable.php
+++ b/app/Filament/Widgets/Operational/SensitiveHealthTable.php
@@ -4,6 +4,7 @@ namespace App\Filament\Widgets\Operational;
 
 use App\Filament\Widgets\Operational\Concerns\UsesOperationalDashboardData;
 use App\Models\Campista;
+use App\Support\Tribes\TribeColor;
 use Carbon\Carbon;
 use Filament\Actions\ViewAction;
 use Filament\Facades\Filament;
@@ -56,7 +57,8 @@ class SensitiveHealthTable extends TableWidget
                 TextColumn::make('tribo.cor')
                     ->label('Tribo')
                     ->placeholder('Sem tribo')
-                    ->badge(),
+                    ->formatStateUsing(fn (?string $state, Campista $record) => TribeColor::badge($record->tribo))
+                    ->html(),
                 TextColumn::make('form_data.data_nacimento')
                     ->label('Idade')
                     ->alignCenter()

--- a/app/Filament/Widgets/Operational/TribeDistributionChart.php
+++ b/app/Filament/Widgets/Operational/TribeDistributionChart.php
@@ -3,6 +3,7 @@
 namespace App\Filament\Widgets\Operational;
 
 use App\Filament\Widgets\Operational\Concerns\UsesOperationalDashboardData;
+use App\Support\Tribes\TribeColor;
 use Filament\Support\RawJs;
 use Leandrocfe\FilamentApexCharts\Widgets\ApexChartWidget;
 
@@ -26,7 +27,10 @@ class TribeDistributionChart extends ApexChartWidget
 
     protected function getOptions(): array
     {
-        $data = $this->chartData($this->operationalData()->tribes());
+        $operationalData = $this->operationalData();
+        $data = $this->chartData($operationalData->tribes());
+        $labels = array_keys($data);
+        $colors = $operationalData->tribeColors();
 
         return [
             'chart' => [
@@ -34,7 +38,7 @@ class TribeDistributionChart extends ApexChartWidget
                 'height' => 320,
                 'toolbar' => ['show' => false],
             ],
-            'labels' => array_keys($data),
+            'labels' => $labels,
             'series' => array_values($data),
             'legend' => [
                 'position' => 'bottom',
@@ -43,16 +47,7 @@ class TribeDistributionChart extends ApexChartWidget
             'dataLabels' => [
                 'enabled' => true,
             ],
-            'colors' => [
-                '#7c3aed',
-                '#0891b2',
-                '#f97316',
-                '#16a34a',
-                '#dc2626',
-                '#d946ef',
-                '#64748b',
-                '#eab308',
-            ],
+            'colors' => array_map(fn (string $tribe): string => $colors[$tribe] ?? TribeColor::resolve(null, $tribe), $labels),
             'stroke' => [
                 'width' => 2,
             ],

--- a/app/Filament/Widgets/UtilizaRemedioTableWidget.php
+++ b/app/Filament/Widgets/UtilizaRemedioTableWidget.php
@@ -5,6 +5,7 @@ namespace App\Filament\Widgets;
 use App\Enums\StatusInscricao;
 use App\Filament\Widgets\Concerns\SupportsWidgetShield;
 use App\Models\Campista;
+use App\Support\Tribes\TribeColor;
 use Carbon\Carbon;
 use Filament\Actions\ViewAction;
 use Filament\Tables\Columns\IconColumn;
@@ -52,6 +53,8 @@ class UtilizaRemedioTableWidget extends BaseWidget
                     ->sortable()
                     ->searchable()
                     ->alignCenter()
+                    ->formatStateUsing(fn (?string $state, Campista $record) => TribeColor::badge($record->tribo))
+                    ->html()
                     ->label('Tribo'),
 
                 TextColumn::make('form_data.data_nacimento')

--- a/app/Models/Tribo.php
+++ b/app/Models/Tribo.php
@@ -18,6 +18,7 @@ class Tribo extends Model implements Auditable
      */
     protected $fillable = [
         'cor',
+        'cor_hex',
     ];
 
     public function campistas()

--- a/app/Support/Dashboard/OperationalDashboardData.php
+++ b/app/Support/Dashboard/OperationalDashboardData.php
@@ -5,6 +5,7 @@ namespace App\Support\Dashboard;
 use App\Enums\StatusInscricao;
 use App\Models\Campista;
 use App\Support\Campistas\ParishCommunityLabels;
+use App\Support\Tribes\TribeColor;
 use Carbon\Carbon;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Support\Collection;
@@ -95,6 +96,14 @@ class OperationalDashboardDataSet
             ->groupBy(fn (Campista $campista): string => $campista->tribo?->cor ?: 'Sem tribo')
             ->map->count()
             ->sortDesc()
+            ->all();
+    }
+
+    public function tribeColors(): array
+    {
+        return $this->records
+            ->groupBy(fn (Campista $campista): string => $campista->tribo?->cor ?: 'Sem tribo')
+            ->map(fn (Collection $campistas): string => TribeColor::forTribe($campistas->first()?->tribo))
             ->all();
     }
 

--- a/app/Support/Reports/CampistaReportData.php
+++ b/app/Support/Reports/CampistaReportData.php
@@ -8,6 +8,7 @@ use App\Models\LancamentoItem;
 use App\Models\Tribo;
 use App\Models\User;
 use App\Support\Campistas\ParishCommunityLabels;
+use App\Support\Tribes\TribeColor;
 use Carbon\Carbon;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Support\Collection;
@@ -126,7 +127,7 @@ class CampistaReportData
             'created_at' => $campista->created_at?->format('d/m/Y H:i'),
             'tribe' => [
                 'label' => $campista->tribo?->cor ?? 'Sem tribo',
-                'accent' => $this->tribeAccent($campista->tribo?->cor) ?? $this->summaryAccent('neutral'),
+                'accent' => TribeColor::forTribe($campista->tribo),
             ],
             'sections' => [
                 [
@@ -277,33 +278,6 @@ class CampistaReportData
         };
     }
 
-    private function tribeAccent(?string $color): ?string
-    {
-        if (blank($color)) {
-            return null;
-        }
-
-        $normalized = Str::lower(Str::ascii(trim($color)));
-
-        if (preg_match('/^#(?:[0-9a-f]{3}|[0-9a-f]{6})$/', $normalized) === 1) {
-            return $normalized;
-        }
-
-        return match ($normalized) {
-            'azul' => '#2563eb',
-            'vermelha', 'vermelho' => '#dc2626',
-            'verde' => '#16a34a',
-            'amarela', 'amarelo' => '#eab308',
-            'roxa', 'roxo' => '#7c3aed',
-            'laranja' => '#f97316',
-            'rosa' => '#ec4899',
-            'branca', 'branco' => '#f8fafc',
-            'preta', 'preto' => '#111827',
-            'cinza' => '#64748b',
-            default => null,
-        };
-    }
-
     private function tribeGroups(Collection $records): array
     {
         return $records
@@ -311,6 +285,7 @@ class CampistaReportData
             ->sortKeys()
             ->map(fn (Collection $campistas, string $tribe): array => [
                 'tribe' => $tribe,
+                'accent' => TribeColor::forTribe($campistas->first()?->tribo),
                 'count' => $campistas->count(),
                 'records' => $campistas
                     ->sortBy('nome')
@@ -334,6 +309,7 @@ class CampistaReportData
         return [
             'name' => $campista->nome,
             'tribe' => $campista->tribo?->cor ?? 'Sem tribo',
+            'tribe_accent' => TribeColor::forTribe($campista->tribo),
             'age' => $this->age(data_get($formData, 'data_nacimento')),
             'medicine' => $this->sensitiveValue(data_get($formData, 'remedio'), $this->truthy(data_get($formData, 'toma_remedio')), $showSensitiveHealth),
             'recommendation' => $this->sensitiveValue(data_get($formData, 'recomendacao'), $this->truthy(data_get($formData, 'tem_recomendacao')), $showSensitiveHealth),

--- a/app/Support/Tribes/TribeColor.php
+++ b/app/Support/Tribes/TribeColor.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace App\Support\Tribes;
+
+use App\Models\Tribo;
+use Illuminate\Support\HtmlString;
+use Illuminate\Support\Str;
+
+class TribeColor
+{
+    public const FALLBACK = '#94a3b8';
+
+    public static function forTribe(?Tribo $tribe, string $fallback = self::FALLBACK): string
+    {
+        return self::resolve($tribe?->cor_hex, $tribe?->cor, $fallback);
+    }
+
+    public static function resolve(?string $registeredColor, ?string $label = null, string $fallback = self::FALLBACK): string
+    {
+        return self::normalizeHex($registeredColor)
+            ?? self::normalizeHex($label)
+            ?? self::fromName($label)
+            ?? $fallback;
+    }
+
+    public static function fromName(?string $name): ?string
+    {
+        if (blank($name)) {
+            return null;
+        }
+
+        return match (Str::lower(Str::ascii(trim($name)))) {
+            'azul' => '#2563eb',
+            'vermelha', 'vermelho' => '#dc2626',
+            'verde' => '#16a34a',
+            'amarela', 'amarelo' => '#eab308',
+            'roxa', 'roxo' => '#7c3aed',
+            'laranja' => '#f97316',
+            'rosa' => '#ec4899',
+            'branca', 'branco' => '#f8fafc',
+            'preta', 'preto' => '#111827',
+            'cinza' => '#64748b',
+            default => null,
+        };
+    }
+
+    public static function badge(?Tribo $tribe, string $emptyLabel = 'Sem tribo'): HtmlString
+    {
+        $label = $tribe?->cor ?: $emptyLabel;
+        $color = self::forTribe($tribe);
+
+        return new HtmlString(sprintf(
+            '<span style="display:inline-flex;align-items:center;gap:.4rem;"><span style="width:.72rem;height:.72rem;border-radius:999px;border:1px solid rgba(148,163,184,.45);background:%s;"></span><span>%s</span></span>',
+            e($color),
+            e($label),
+        ));
+    }
+
+    private static function normalizeHex(?string $color): ?string
+    {
+        if (blank($color)) {
+            return null;
+        }
+
+        $normalized = Str::lower(Str::ascii(trim($color)));
+
+        return preg_match('/^#(?:[0-9a-f]{3}|[0-9a-f]{6})$/', $normalized) === 1
+            ? $normalized
+            : null;
+    }
+}

--- a/database/factories/TriboFactory.php
+++ b/database/factories/TriboFactory.php
@@ -3,6 +3,7 @@
 namespace Database\Factories;
 
 use App\Models\Tribo;
+use App\Support\Tribes\TribeColor;
 use Database\Seeders\Support\DemoRegistrationData;
 use Illuminate\Database\Eloquent\Factories\Factory;
 
@@ -20,6 +21,7 @@ class TriboFactory extends Factory
     {
         return [
             'cor' => DemoRegistrationData::TRIBE_COLORS[0],
+            'cor_hex' => TribeColor::fromName(DemoRegistrationData::TRIBE_COLORS[0]),
         ];
     }
 }

--- a/database/migrations/2026_06_09_000100_add_cor_hex_to_tribos_table.php
+++ b/database/migrations/2026_06_09_000100_add_cor_hex_to_tribos_table.php
@@ -1,0 +1,57 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Support\Str;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('tribos', function (Blueprint $table): void {
+            $table->string('cor_hex', 7)->nullable()->after('cor');
+        });
+
+        DB::table('tribos')
+            ->select(['id', 'cor'])
+            ->orderBy('id')
+            ->get()
+            ->each(function (object $tribe): void {
+                DB::table('tribos')
+                    ->where('id', $tribe->id)
+                    ->update(['cor_hex' => $this->colorFor($tribe->cor)]);
+            });
+    }
+
+    public function down(): void
+    {
+        Schema::table('tribos', function (Blueprint $table): void {
+            $table->dropColumn('cor_hex');
+        });
+    }
+
+    private function colorFor(?string $name): string
+    {
+        $normalized = Str::lower(Str::ascii(trim((string) $name)));
+
+        if (preg_match('/^#(?:[0-9a-f]{3}|[0-9a-f]{6})$/', $normalized) === 1) {
+            return $normalized;
+        }
+
+        return match ($normalized) {
+            'azul' => '#2563eb',
+            'vermelha', 'vermelho' => '#dc2626',
+            'verde' => '#16a34a',
+            'amarela', 'amarelo' => '#eab308',
+            'roxa', 'roxo' => '#7c3aed',
+            'laranja' => '#f97316',
+            'rosa' => '#ec4899',
+            'branca', 'branco' => '#f8fafc',
+            'preta', 'preto' => '#111827',
+            'cinza' => '#64748b',
+            default => '#94a3b8',
+        };
+    }
+};

--- a/database/seeders/TriboSeeder.php
+++ b/database/seeders/TriboSeeder.php
@@ -3,6 +3,7 @@
 namespace Database\Seeders;
 
 use App\Models\Tribo;
+use App\Support\Tribes\TribeColor;
 use Database\Seeders\Support\DemoRegistrationData;
 use Illuminate\Database\Seeder;
 
@@ -16,7 +17,10 @@ class TriboSeeder extends Seeder
         foreach (DemoRegistrationData::TRIBE_COLORS as $index => $color) {
             Tribo::query()->updateOrCreate(
                 ['id' => $index + 1],
-                ['cor' => $color],
+                [
+                    'cor' => $color,
+                    'cor_hex' => TribeColor::fromName($color),
+                ],
             );
         }
     }

--- a/resources/css/filament/admin/theme.css
+++ b/resources/css/filament/admin/theme.css
@@ -580,6 +580,19 @@ body.fi-panel-admin:not(.juvenil-admin-auth-body) .fi-fo-date-time-picker-panel 
     z-index: 100;
 }
 
+body.fi-panel-admin:not(.juvenil-admin-auth-body) :is(.fi-section, .fi-sc):has(.fi-fo-color-picker-panel) {
+    position: relative;
+    z-index: 20;
+}
+
+body.fi-panel-admin:not(.juvenil-admin-auth-body) :is(.fi-section, .fi-sc):has(.fi-fo-color-picker:focus-within) {
+    z-index: 70;
+}
+
+body.fi-panel-admin:not(.juvenil-admin-auth-body) :is(.fi-section, .fi-sc) .fi-fo-color-picker-panel {
+    z-index: 100;
+}
+
 body.fi-panel-admin:not(.juvenil-admin-auth-body) .fi-section:has(.fi-select-input-btn[aria-expanded='true']) {
     position: relative;
     z-index: 70;

--- a/resources/views/admin/reports/partials/sensitive-health.blade.php
+++ b/resources/views/admin/reports/partials/sensitive-health.blade.php
@@ -16,7 +16,12 @@
                 @foreach ($rows as $row)
                     <tr>
                         <td>{{ $row['name'] }}</td>
-                        <td>{{ $row['tribe'] }}</td>
+                        <td>
+                            <span class="report-table-tribe" style="--report-accent: {{ $row['tribe_accent'] }};">
+                                <span class="report-table-tribe__swatch" aria-hidden="true"></span>
+                                {{ $row['tribe'] }}
+                            </span>
+                        </td>
                         <td>{{ $row['age'] ?? '-' }}</td>
                         <td>{{ $row['medicine'] }}</td>
                         <td>{{ $row['recommendation'] }}</td>

--- a/resources/views/admin/reports/partials/tribe-quadrant.blade.php
+++ b/resources/views/admin/reports/partials/tribe-quadrant.blade.php
@@ -1,7 +1,10 @@
 @forelse ($tribes as $tribe)
     <section class="report-section">
-        <div class="report-page__top">
-            <h2>{{ $tribe['tribe'] }}</h2>
+        <div class="report-page__top report-page__top--tribe" style="--report-accent: {{ $tribe['accent'] }};">
+            <h2>
+                <span class="report-tribe-swatch" aria-hidden="true"></span>
+                {{ $tribe['tribe'] }}
+            </h2>
             <span class="report-badge">{{ $tribe['count'] }} {{ $tribe['count'] === 1 ? 'campista' : 'campistas' }}</span>
         </div>
 

--- a/resources/views/admin/reports/print.blade.php
+++ b/resources/views/admin/reports/print.blade.php
@@ -293,6 +293,37 @@
             min-width: 0;
         }
 
+        .report-page__top--tribe h2 {
+            display: inline-flex;
+            align-items: center;
+            gap: .45rem;
+        }
+
+        .report-tribe-swatch {
+            width: .85rem;
+            height: .85rem;
+            border: 1px solid rgba(8, 37, 41, .28);
+            border-radius: 999px;
+            background: var(--report-accent);
+            flex: 0 0 auto;
+        }
+
+        .report-table-tribe {
+            display: inline-flex;
+            align-items: center;
+            gap: .35rem;
+            font-weight: 800;
+        }
+
+        .report-table-tribe__swatch {
+            width: .62rem;
+            height: .62rem;
+            border: 1px solid rgba(8, 37, 41, .28);
+            border-radius: 999px;
+            background: var(--report-accent);
+            flex: 0 0 auto;
+        }
+
         .report-photo {
             display: grid;
             width: 4.5rem;

--- a/tests/Browser/admin-panel-layout.spec.js
+++ b/tests/Browser/admin-panel-layout.spec.js
@@ -138,6 +138,29 @@ function firstRecordId(modelClass) {
     return id;
 }
 
+function firstOrCreateTriboId() {
+    const output = execFileSync('php', [
+        'artisan',
+        'tinker',
+        '--execute',
+        "echo App\\Models\\Tribo::query()->firstOrCreate(['cor' => 'Teste ColorPicker'], ['cor_hex' => '#2563eb'])->id;",
+    ], { encoding: 'utf8' }).trim();
+
+    const id = output.match(/\d+/)?.[0];
+    expect(id).toBeTruthy();
+
+    return id;
+}
+
+function deleteColorPickerTestTribo() {
+    execFileSync('php', [
+        'artisan',
+        'tinker',
+        '--execute',
+        "App\\Models\\Tribo::query()->where('cor', 'Teste ColorPicker')->delete();",
+    ], { encoding: 'utf8' });
+}
+
 test('authenticated Filament panel keeps branded layout clear of visual obstructions', async ({ page }) => {
     await mkdir('storage/app/screenshots', { recursive: true });
 
@@ -337,6 +360,55 @@ test('authenticated Filament table column manager opens outside the table and ap
         path: 'storage/app/screenshots/playwright-admin-column-manager-dropdown.png',
         fullPage: false,
     });
+});
+
+test('authenticated tribe color picker opens above relation tables', async ({ page }) => {
+    const triboId = firstOrCreateTriboId();
+
+    try {
+        await signIn(page);
+        await page.goto(`${adminBaseUrl}/admin/tribos/${triboId}/edit`);
+        await page.waitForSelector('.fi-fo-color-picker');
+        await page.waitForSelector('.fi-ta');
+
+        const colorPicker = page.locator('.fi-fo-color-picker').first();
+        await colorPicker.locator('input').focus();
+        await expect(page.locator('.fi-fo-color-picker-panel')).toBeVisible();
+
+        const colorPickerLayer = await page.evaluate(() => {
+            const panel = [...document.querySelectorAll('.fi-fo-color-picker-panel')]
+                .find((element) => {
+                    const rect = element.getBoundingClientRect();
+                    const style = getComputedStyle(element);
+
+                    return rect.width > 0 && rect.height > 0 && style.display !== 'none';
+                });
+            const section = panel?.closest('.fi-section, .fi-sc');
+
+            if (! panel || ! section) {
+                return null;
+            }
+
+            const panelRect = panel.getBoundingClientRect();
+            const topElement = document.elementFromPoint(
+                panelRect.left + (panelRect.width / 2),
+                panelRect.top + (panelRect.height / 2),
+            );
+
+            return {
+                panelZIndex: Number.parseInt(getComputedStyle(panel).zIndex, 10),
+                sectionZIndex: Number.parseInt(getComputedStyle(section).zIndex, 10),
+                topElementInsidePanel: panel.contains(topElement),
+            };
+        });
+
+        expect(colorPickerLayer).not.toBeNull();
+        expect(colorPickerLayer.sectionZIndex).toBeGreaterThanOrEqual(70);
+        expect(colorPickerLayer.panelZIndex).toBeGreaterThanOrEqual(100);
+        expect(colorPickerLayer.topElementInsidePanel).toBe(true);
+    } finally {
+        deleteColorPickerTestTribo();
+    }
 });
 
 test('authenticated Filament notifications render above the branded topbar', async ({ page }) => {

--- a/tests/Feature/CampistaViewFichaTest.php
+++ b/tests/Feature/CampistaViewFichaTest.php
@@ -20,7 +20,7 @@ it('renders the campista view as a registration ficha with a single styled heade
     $user = User::factory()->create();
     $user->assignRole('Super Administrador');
 
-    $tribo = Tribo::query()->firstOrCreate(['cor' => 'Preta']);
+    $tribo = Tribo::query()->firstOrCreate(['cor' => 'Preta'], ['cor_hex' => '#101010']);
 
     $campista = Campista::factory()->create([
         'nome' => 'Lucas Teste Juvenil',
@@ -71,7 +71,7 @@ it('renders the campista view as a registration ficha with a single styled heade
         ->assertSee('data-summary-icon="heroicon-o-check-circle"', false)
         ->assertSee('data-summary-icon="heroicon-o-flag"', false)
         ->assertSee('data-summary-color="tribe"', false)
-        ->assertSee('--summary-accent: #111827', false)
+        ->assertSee('--summary-accent: #101010', false)
         ->assertSee('juvenil-registration-card__summary-badge-icon', false)
         ->assertDontSee('juvenil-registration-card__summary-color', false)
         ->assertSee('juvenil-registration-header-edit', false)

--- a/tests/Feature/DemoRegistrationSeedersTest.php
+++ b/tests/Feature/DemoRegistrationSeedersTest.php
@@ -32,6 +32,18 @@ it('seeds deterministic complete registration data for dashboard validation', fu
             'Preta',
             'Cinza',
         ])
+        ->and(Tribo::query()->pluck('cor_hex', 'cor')->all())->toBe([
+            'Azul' => '#2563eb',
+            'Vermelha' => '#dc2626',
+            'Verde' => '#16a34a',
+            'Amarela' => '#eab308',
+            'Roxa' => '#7c3aed',
+            'Laranja' => '#f97316',
+            'Rosa' => '#ec4899',
+            'Branca' => '#f8fafc',
+            'Preta' => '#111827',
+            'Cinza' => '#64748b',
+        ])
         ->and(Campista::query()->count())->toBe(120)
         ->and(EquipeTrabalho::query()->count())->toBe(200);
 

--- a/tests/Feature/OperationalDashboardDataTest.php
+++ b/tests/Feature/OperationalDashboardDataTest.php
@@ -52,7 +52,7 @@ it('calculates the operational pipeline excluding cancelled records by default',
 });
 
 it('applies status tribe parish community and presence filters to operational metrics', function () {
-    $blue = Tribo::query()->create(['cor' => 'Azul']);
+    $blue = Tribo::query()->create(['cor' => 'Azul', 'cor_hex' => '#123abc']);
     $red = Tribo::query()->create(['cor' => 'Vermelha']);
 
     makeOperationalDashboardCampista(['status' => StatusInscricao::Pago->value, 'presenca' => false, 'tribo_id' => $blue->id], ['paroquia' => 0, 'comunidade' => 2]);
@@ -131,7 +131,7 @@ it('filters operational metrics by community text when another parish is selecte
 });
 
 it('builds tribe shirt community age and sex distributions with incomplete form data tolerance', function () {
-    $blue = Tribo::query()->create(['cor' => 'Azul']);
+    $blue = Tribo::query()->create(['cor' => 'Azul', 'cor_hex' => '#123abc']);
 
     makeOperationalDashboardCampista(['status' => StatusInscricao::Pago->value, 'tribo_id' => $blue->id], [
         'sexo' => 'M',
@@ -161,6 +161,8 @@ it('builds tribe shirt community age and sex distributions with incomplete form 
 
     expect($data->tribes())->toHaveKey('Azul', 1)
         ->and($data->tribes())->toHaveKey('Sem tribo', 2)
+        ->and($data->tribeColors())->toHaveKey('Azul', '#123abc')
+        ->and($data->tribeColors())->toHaveKey('Sem tribo', '#94a3b8')
         ->and($data->shirts())->toHaveKey('Outros: XGG', 1)
         ->and($data->shirts())->toHaveKey('M', 1)
         ->and($data->shirts())->toHaveKey('Sem tamanho', 1)

--- a/tests/Feature/OperationalDashboardWidgetsTest.php
+++ b/tests/Feature/OperationalDashboardWidgetsTest.php
@@ -125,31 +125,32 @@ it('keeps registration trend chart y axis as whole-number counts', function () {
     ]);
 });
 
-it('renders tribe distribution as a pie chart', function () {
-    $fuchsia = Tribo::query()->create(['cor' => 'Fuchsia']);
-    $crimson = Tribo::query()->create(['cor' => 'Crimson']);
+it('renders tribe distribution as a pie chart using the tribe colors', function () {
+    $blue = Tribo::query()->create(['cor' => 'Azul', 'cor_hex' => '#123abc']);
+    $red = Tribo::query()->create(['cor' => 'Vermelha', 'cor_hex' => '#c32121']);
 
     Campista::factory()
         ->count(2)
         ->create([
             'status' => StatusInscricao::Pago->value,
             'presenca' => false,
-            'tribo_id' => $fuchsia->id,
+            'tribo_id' => $blue->id,
             'user_id' => null,
         ]);
 
     Campista::factory()->create([
         'status' => StatusInscricao::Pago->value,
         'presenca' => false,
-        'tribo_id' => $crimson->id,
+        'tribo_id' => $red->id,
         'user_id' => null,
     ]);
 
     $options = operationalDashboardChartOptions(TribeDistributionChart::class);
 
     expect($options['chart']['type'])->toBe('pie')
-        ->and($options['labels'])->toBe(['Fuchsia', 'Crimson'])
-        ->and($options['series'])->toBe([2, 1]);
+        ->and($options['labels'])->toBe(['Azul', 'Vermelha'])
+        ->and($options['series'])->toBe([2, 1])
+        ->and($options['colors'])->toBe(['#123abc', '#c32121']);
 });
 
 it('gives parish community distribution enough label space', function () {

--- a/tests/Feature/ReportsPageTest.php
+++ b/tests/Feature/ReportsPageTest.php
@@ -356,7 +356,7 @@ it('renders the campista photo in printable registration fichas', function () {
 it('applies ficha visual styling and keeps linked payments hidden by default on printable registration reports', function () {
     $this->seed(ShieldSeeder::class);
 
-    $tribe = Tribo::query()->create(['cor' => 'Rosa']);
+    $tribe = Tribo::query()->create(['cor' => 'Rosa', 'cor_hex' => '#123abc']);
     $campista = reportCampista([
         'tribo_id' => $tribe->id,
         'forma_pagamento' => FormaPagamento::Pix,
@@ -375,7 +375,7 @@ it('applies ficha visual styling and keeps linked payments hidden by default on 
         ->toContain('report-card--community')
         ->toContain('report-card--health')
         ->toContain('data-report-badge-icon="heroicon-s-flag"')
-        ->toContain('--report-accent: #ec4899')
+        ->toContain('--report-accent: #123abc')
         ->not->toContain('report-registration-summary')
         ->not->toContain('Resumo da inscrição')
         ->not->toContain('data-report-summary-icon')
@@ -519,7 +519,8 @@ it('renders the camp logo in every printable report header', function () {
 it('blocks the medical report for administrators and exposes it only to the infirmary', function () {
     $this->seed(ShieldSeeder::class);
 
-    reportCampista();
+    $tribe = Tribo::query()->create(['cor' => 'Azul', 'cor_hex' => '#123abc']);
+    reportCampista(['tribo_id' => $tribe->id]);
 
     $administrator = reportUserWithRole('Administrador');
     $infirmary = reportUserWithRole('Enfermaria');
@@ -531,6 +532,8 @@ it('blocks the medical report for administrators and exposes it only to the infi
     expect(reportHtml('sensitive_health', [], $infirmary))
         ->toContain('Lista médica da enfermaria')
         ->toContain('Ana Maria Juvenil')
+        ->toContain('report-table-tribe')
+        ->toContain('--report-accent: #123abc')
         ->toContain('Informação restrita')
         ->not->toContain('Dipirona a cada 8 horas')
         ->not->toContain('Evitar amendoim');
@@ -603,8 +606,8 @@ it('does not leak medical details in non medical reports', function () {
 it('renders the tribe quadrant grouped by tribe', function () {
     $this->seed(ShieldSeeder::class);
 
-    $azul = Tribo::query()->create(['cor' => 'Azul']);
-    $verde = Tribo::query()->create(['cor' => 'Verde']);
+    $azul = Tribo::query()->create(['cor' => 'Azul', 'cor_hex' => '#123abc']);
+    $verde = Tribo::query()->create(['cor' => 'Verde', 'cor_hex' => '#16a34a']);
 
     reportCampista(['nome' => 'Ana Azul', 'tribo_id' => $azul->id]);
     reportCampista(['nome' => 'Bruno Azul', 'tribo_id' => $azul->id]);
@@ -614,6 +617,8 @@ it('renders the tribe quadrant grouped by tribe', function () {
 
     expect(reportHtml('tribe_quadrant', [], $administrator))
         ->toContain('Quadrante das inscrições por tribo')
+        ->toContain('report-tribe-swatch')
+        ->toContain('--report-accent: #123abc')
         ->toContain('Azul')
         ->toContain('2 campistas')
         ->toContain('Ana Azul')

--- a/tests/Feature/TriboResourceTest.php
+++ b/tests/Feature/TriboResourceTest.php
@@ -1,0 +1,29 @@
+<?php
+
+use App\Models\Tribo;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+uses(RefreshDatabase::class);
+
+it('uses a color picker for the registered tribe color', function () {
+    $resource = file_get_contents(app_path('Filament/Resources/TriboResource.php'));
+
+    expect($resource)
+        ->toContain('use Filament\\Forms\\Components\\ColorPicker;')
+        ->toContain("ColorPicker::make('cor_hex')")
+        ->toContain("TextInput::make('cor')")
+        ->toContain("'lg' => 4")
+        ->toContain("'lg' => 3")
+        ->toContain("'lg' => 1")
+        ->toContain('TribeColor::resolve')
+        ->toContain('->html()');
+});
+
+it('stores the custom color on tribes', function () {
+    $tribe = Tribo::query()->create([
+        'cor' => 'Azul',
+        'cor_hex' => '#123abc',
+    ]);
+
+    expect($tribe->refresh()->cor_hex)->toBe('#123abc');
+});


### PR DESCRIPTION
- Store a hex color for each tribe and expose it in the tribe form
- Reuse registered colors for badges, charts, ficha accents, and print reports
- Cover seed data, dashboard data, reports, and color picker layering with tests