### PR TITLE
Seed and manage equipe de trabalho roster

### DIFF
--- a/.claude/napkin.md
+++ b/.claude/napkin.md
@@ -27,26 +27,26 @@
    Do instead: run `php artisan test` commands sequentially because `.env.testing` points to the shared `database/database.sqlite`; if locks corrupt schema state, back up and recreate that untracked file before rerunning.
 
 ## Domain Behavior Guardrails
-1. **[2026-06-07] Filament dropdowns need an explicit layer scale**
+1. **[2026-06-23] EquipeTrabalho public and admin forms share helpers**
+   Do instead: keep `EquipeTrabalhoForm::getFormCreate()` as the full public registration form and add/use explicit admin form methods for simplified admin create/edit flows.
+2. **[2026-06-07] Filament dropdowns need an explicit layer scale**
    Do instead: keep `.fi-ta` as `overflow: visible`, keep content dropdowns below sidebar/topbar flyouts, and use `Table::configureUsing(...->deferColumnManager(false))` so column toggles apply live.
-2. **[2026-06-07] Filament overlays inside sections need active stacking**
+3. **[2026-06-07] Filament overlays inside sections need active stacking**
    Do instead: when a DatePicker/Select/dropdown opens inside `.fi-section`, raise the active section and panel in `resources/css/filament/admin/theme.css`, then validate with Playwright `admin-panel-layout.spec.js`.
-3. **[2026-06-07] Filament fixed modals must not sit under transform containers**
+4. **[2026-06-07] Filament fixed modals must not sit under transform containers**
    Do instead: avoid `transform` and `will-change: transform` on `.filament-registration-shell` ancestors, or clear them after GSAP one-shot animations before opening FileUpload editors/modals.
-4. **[2026-06-07] Campista view should read like a ficha, not a disabled form**
+5. **[2026-06-07] Campista view should read like a ficha, not a disabled form**
    Do instead: override the view page `content()` with a schema `View` component plus ficha CSS, append relation manager content, and keep `EditCampista` using the editable `CampistaForm` schema.
-5. **[2026-06-06] Public registration flow is campista-first**
+6. **[2026-06-06] Public registration flow is campista-first**
    Do instead: render `welcome`/`content-form` with `campista-form` on `/` and `/campista`; keep `/inscricao-equipe-trabalho` redirected away unless explicitly re-enabled.
-6. **[2026-06-06] Mobile public page is app-like and form-first**
+7. **[2026-06-06] Mobile public page is app-like and form-first**
    Do instead: keep the mobile bottom bar active by section, hide it on desktop with explicit CSS, and order the Filament form before payment/instructions on mobile.
-7. **[2026-06-06] Public page must have only document-level vertical scroll**
+8. **[2026-06-06] Public page must have only document-level vertical scroll**
    Do instead: use `overflow-x-clip` for horizontal clipping; avoid `overflow-x-hidden` on `main` because it computes `overflow-y: auto` and creates a second vertical scrollbar.
-8. **[2026-06-06] GSAP anchor scrolling conflicts with Tailwind `scroll-smooth`**
+9. **[2026-06-06] GSAP anchor scrolling conflicts with Tailwind `scroll-smooth`**
    Do instead: temporarily disable smooth CSS and drive scroll with a GSAP numeric tween plus `window.scrollTo()` on update.
-9. **[2026-06-06] Public Filament forms need official CSS above legacy resets**
+10. **[2026-06-06] Public Filament forms need official CSS above legacy resets**
    Do instead: import Filament support/actions/forms/notifications/schemas CSS in `resources/css/app.css` and keep `output.css` in a `legacy` cascade layer before `components`.
-10. **[2026-06-06] Mobile GSAP motion must not initialize during loader lock**
-   Do instead: initialize ScrollTrigger-dependent motion after the loader removes `body.is-loading`, use native anchor scrolling on touch layouts, and avoid scrub/parallax on mobile.
 
 ## User Directives
 1. **[2026-06-08] Public campista photo upload is upload-only**

--- a/app/Filament/Exports/EquipeTrabalhoExporter.php
+++ b/app/Filament/Exports/EquipeTrabalhoExporter.php
@@ -7,6 +7,7 @@ use Carbon\Carbon;
 use Filament\Actions\Exports\ExportColumn;
 use Filament\Actions\Exports\Exporter;
 use Filament\Actions\Exports\Models\Export;
+use Throwable;
 
 class EquipeTrabalhoExporter extends Exporter
 {
@@ -21,8 +22,11 @@ class EquipeTrabalhoExporter extends Exporter
             ExportColumn::make('nome')
                 ->label('Campista'),
 
+            ExportColumn::make('descricao')
+                ->label('Equipe'),
+
             ExportColumn::make('data_form.data_nacimento')
-                ->formatStateUsing(fn ($state) => Carbon::createFromFormat('d/m/Y', $state)->age)
+                ->formatStateUsing(fn (mixed $state): ?int => self::ageFromBirthDate($state))
                 ->label('Idade'),
 
             ExportColumn::make('data_form.telefone')
@@ -36,12 +40,14 @@ class EquipeTrabalhoExporter extends Exporter
 
             ExportColumn::make('data_form.tamanho_camiseta')
                 ->label('Tamanho da Camiseta')
-                ->state(function (EquipeTrabalho $record) {
-                    if ($record->data_form['tamanho_camiseta'] === 'O') {
-                        return $record->data_form['tamanho_camiseta_outro'];
+                ->state(function (EquipeTrabalho $record): ?string {
+                    $shirtSize = data_get($record->data_form, 'tamanho_camiseta');
+
+                    if ($shirtSize === 'O') {
+                        return data_get($record->data_form, 'tamanho_camiseta_outro');
                     }
 
-                    return $record->data_form['tamanho_camiseta'];
+                    return $shirtSize;
                 }),
 
             ExportColumn::make('data_form.servir_no_acampamento')
@@ -79,5 +85,18 @@ class EquipeTrabalhoExporter extends Exporter
     public static function getCompletedNotificationBody(Export $export): string
     {
         return $export->successful_rows.' inscrições da equipe de trabalho exportadas.';
+    }
+
+    private static function ageFromBirthDate(mixed $state): ?int
+    {
+        if (! is_string($state) || trim($state) === '') {
+            return null;
+        }
+
+        try {
+            return Carbon::createFromFormat('d/m/Y', $state)->age;
+        } catch (Throwable) {
+            return null;
+        }
     }
 }

--- a/app/Filament/Resources/EquipeTrabalhoResource.php
+++ b/app/Filament/Resources/EquipeTrabalhoResource.php
@@ -44,7 +44,7 @@ class EquipeTrabalhoResource extends Resource
                 EquipeTrabalhoTable::getColumns()
             )
             ->filters([
-                //
+                ...EquipeTrabalhoTable::getFilters(),
             ])
             ->defaultSort('created_at', 'desc')
             ->actions([

--- a/app/Filament/Resources/EquipeTrabalhoResource/EquipeTrabalhoForm.php
+++ b/app/Filament/Resources/EquipeTrabalhoResource/EquipeTrabalhoForm.php
@@ -3,12 +3,12 @@
 namespace App\Filament\Resources\EquipeTrabalhoResource;
 
 use App\Enums\StatusInscricaoEquipeTrabalho;
+use App\Models\EquipeTrabalho as EquipeTrabalhoModel;
 use Carbon\Carbon;
 use Filament\Actions\Action as FormAction;
 use Filament\Forms\Components\FileUpload;
 use Filament\Forms\Components\Select;
 use Filament\Forms\Components\TagsInput;
-use Filament\Forms\Components\Textarea;
 use Filament\Forms\Components\TextInput;
 use Filament\Forms\Components\ToggleButtons;
 use Filament\Schemas\Components\Actions;
@@ -32,15 +32,58 @@ abstract class EquipeTrabalhoForm
         ];
     }
 
-    public static function getFormUpdate(): array
+    public static function getAdminFormCreate(): array
     {
         return [
-            ...self::getFormInformacaoInscricao(),
-            ...self::getFormEquipeTrabalho(),
+            Section::make('Dados básicos')
+                ->icon('phosphor-user-list-fill')
+                ->columns([
+                    'default' => 1,
+                    'lg' => 2,
+                ])
+                ->schema([
+                    TextInput::make('nome')
+                        ->required()
+                        ->maxLength(255)
+                        ->columnSpanFull(),
+
+                    TextInput::make('descricao')
+                        ->label('Equipe')
+                        ->placeholder('Ex.: Cozinha, Missão, Ordem e Limpeza')
+                        ->datalist(fn (): array => self::registeredEquipeNames())
+                        ->maxLength(255),
+
+                    Select::make('status')
+                        ->label('Status da Inscrição')
+                        ->searchable()
+                        ->preload()
+                        ->default(StatusInscricaoEquipeTrabalho::Aprovado->value)
+                        ->options(StatusInscricaoEquipeTrabalho::class),
+
+                    Select::make('tribo_id')
+                        ->relationship('tribo', 'cor')
+                        ->searchable()
+                        ->preload()
+                        ->getOptionLabelFromRecordUsing(fn (Model $record): string => $record->cor ?? 'Não há tribos cadastradas')
+                        ->label('Tribo'),
+                ]),
         ];
     }
 
-    public static function getFormEquipeTrabalho(): array
+    public static function getFormUpdate(): array
+    {
+        return self::getAdminFormUpdate();
+    }
+
+    public static function getAdminFormUpdate(): array
+    {
+        return [
+            ...self::getFormInformacaoInscricao(),
+            ...self::getFormEquipeTrabalho(requireDetails: false),
+        ];
+    }
+
+    public static function getFormEquipeTrabalho(bool $requireDetails = true): array
     {
         return [
             Section::make('Dados de Inscrição')
@@ -50,21 +93,21 @@ abstract class EquipeTrabalhoForm
                     'lg' => 5,
                 ])
                 ->schema([
-                    ...self::getFormFoto(),
+                    ...self::getFormFoto($requireDetails),
                     TextInput::make('nome')
                         ->required()
                         ->columnSpan(['default' => 1, 'lg' => 4])
                         ->maxLength(255),
 
                     TextInput::make('data_form.data_nacimento')
-                        ->required()
+                        ->required($requireDetails)
                         ->mask('99/99/9999')
                         ->placeholder('DD/MM/AAAA')
                         ->columnSpan(1)
                         ->label('Data de Nascimento'),
 
                     ToggleButtons::make('data_form.sexo')
-                        ->required()
+                        ->required($requireDetails)
                         ->inline(true)
                         ->inlineLabel(false)
                         ->columnSpan([
@@ -95,7 +138,7 @@ abstract class EquipeTrabalhoForm
 
                     TextInput::make('data_form.telefone')
                         ->mask('(99) 9 9999-9999')
-                        ->required()
+                        ->required($requireDetails)
                         ->columnSpan([
                             'default' => 1,
                             'lg' => 2,
@@ -104,7 +147,7 @@ abstract class EquipeTrabalhoForm
                         ->label('Telefone'),
 
                     TextInput::make('data_form.reponsavel_nome')
-                        ->required()
+                        ->required($requireDetails)
                         ->columnSpan([
                             'default' => 1,
                             'lg' => 3,
@@ -112,7 +155,7 @@ abstract class EquipeTrabalhoForm
                         ->label('Nome do Responsável Fora do Acampamento'),
 
                     TextInput::make('data_form.reponsavel_telefone')
-                        ->required()
+                        ->required($requireDetails)
                         ->mask('(99) 9 9999-9999')
                         ->prefixIcon('heroicon-o-phone')
                         ->columnSpan([
@@ -133,7 +176,7 @@ abstract class EquipeTrabalhoForm
 
                             CepInput::make('data_form.cep')
                                 ->label('CEP')
-                                ->required()
+                                ->required($requireDetails)
                                 ->columnSpan([
                                     'default' => 1,
                                     'lg' => 1,
@@ -148,7 +191,7 @@ abstract class EquipeTrabalhoForm
                                 ->setStateField('data_form.estado'),
 
                             TextInput::make('data_form.rua')
-                                ->required()
+                                ->required($requireDetails)
                                 ->columnSpan([
                                     'default' => 1,
                                     'lg' => 4,
@@ -156,7 +199,7 @@ abstract class EquipeTrabalhoForm
                                 ->label('Rua'),
 
                             TextInput::make('data_form.numero')
-                                ->required()
+                                ->required($requireDetails)
                                 ->numeric()
                                 ->columnSpan([
                                     'default' => 1,
@@ -173,7 +216,7 @@ abstract class EquipeTrabalhoForm
                                 ]),
 
                             TextInput::make('data_form.bairro')
-                                ->required()
+                                ->required($requireDetails)
                                 ->columnSpan([
                                     'default' => 1,
                                     'sm' => 1,
@@ -183,7 +226,7 @@ abstract class EquipeTrabalhoForm
                                 ->label('Bairro'),
 
                             TextInput::make('data_form.cidade')
-                                ->required()
+                                ->required($requireDetails)
                                 ->columnSpan([
                                     'default' => 1,
                                     'sm' => 1,
@@ -194,7 +237,7 @@ abstract class EquipeTrabalhoForm
                                 ->label('Cidade'),
 
                             TextInput::make('data_form.estado')
-                                ->required()
+                                ->required($requireDetails)
                                 ->columnSpan([
                                     'default' => 1,
                                     'sm' => 1,
@@ -209,7 +252,7 @@ abstract class EquipeTrabalhoForm
                         ->label('Já participou de algum acampamento/retiro ?')
                         ->live()
                         ->columnSpanFull()
-                        ->required()
+                        ->required($requireDetails)
                         ->inline()
                         ->inlineLabel(false)
                         ->colors([
@@ -229,13 +272,13 @@ abstract class EquipeTrabalhoForm
                         ->validationMessages([
                             'required' => 'Necessário informar ao menos um acampamento que já tenha participado.',
                         ])
-                        ->required(fn (Get $get) => $get('data_form.ja_participou_retiro'))
+                        ->required(fn (Get $get): bool => $requireDetails && (bool) $get('data_form.ja_participou_retiro'))
                         ->visible(fn (Get $get) => $get('data_form.ja_participou_retiro') ?? false),
 
                     ToggleButtons::make('data_form.pode_missas_diarias')
                         ->label('Pode participar das missas diárias ?')
                         ->columnSpanFull()
-                        ->required()
+                        ->required($requireDetails)
                         ->inline()
                         ->inlineLabel(false)
                         ->colors([
@@ -264,7 +307,7 @@ abstract class EquipeTrabalhoForm
                         ->inline()
                         ->inlineLabel(false)
                         ->live()
-                        ->required(),
+                        ->required($requireDetails),
 
                     TextInput::make('data_form.tamanho_camiseta_outro')
                         ->label('Tamanho da camiseta:')
@@ -272,16 +315,15 @@ abstract class EquipeTrabalhoForm
                             'class' => 'uppercase',
                         ])
                         ->columnSpan(1)
-                        ->required()
+                        ->required(fn (Get $get): bool => $requireDetails && $get('data_form.tamanho_camiseta') === 'O')
                         ->visible(fn (Get $get) => $get('data_form.tamanho_camiseta') == 'O')
-                        ->requiredIf('tamanho_camiseta', fn (Get $get) => $get('data_form.tamanho_camiseta') == 'O')
                         ->minLength(1)
                         ->maxLength(3),
 
                     ToggleButtons::make('data_form.servir_no_acampamento')
                         ->label('Pode servir lá dentro do acampamento ?')
                         ->columnSpanFull()
-                        ->required()
+                        ->required($requireDetails)
                         ->inline()
                         ->inlineLabel(false)
                         ->colors([
@@ -297,7 +339,7 @@ abstract class EquipeTrabalhoForm
         ];
     }
 
-    public static function getFormFoto(): array
+    public static function getFormFoto(bool $required = true): array
     {
         return [
 
@@ -333,7 +375,7 @@ abstract class EquipeTrabalhoForm
                 ->extraAttributes(['class' => 'juvenil-photo-upload'])
                 ->imagePreviewHeight('250')
                 ->panelLayout('integrated')
-                ->required(),
+                ->required($required),
 
             Actions::make([
                 FormAction::make('star')
@@ -383,14 +425,29 @@ abstract class EquipeTrabalhoForm
                             'default' => 1,
                         ]),
 
-                    Textarea::make('observacoes')
-                        ->label('Observações')
-                        ->rows(3)
-                        ->placeholder('Observações sobre a inscricão.')
+                    TextInput::make('descricao')
+                        ->label('Equipe')
+                        ->placeholder('Ex.: Cozinha, Missão, Ordem e Limpeza')
+                        ->datalist(fn (): array => self::registeredEquipeNames())
+                        ->maxLength(255)
                         ->columnSpan([
                             'default' => 1,
                         ]),
                 ]),
         ];
+    }
+
+    /**
+     * @return array<int, string>
+     */
+    private static function registeredEquipeNames(): array
+    {
+        return EquipeTrabalhoModel::query()
+            ->whereNotNull('descricao')
+            ->where('descricao', '!=', '')
+            ->distinct()
+            ->orderBy('descricao')
+            ->pluck('descricao')
+            ->all();
     }
 }

--- a/app/Filament/Resources/EquipeTrabalhoResource/EquipeTrabalhoTable.php
+++ b/app/Filament/Resources/EquipeTrabalhoResource/EquipeTrabalhoTable.php
@@ -3,11 +3,14 @@
 namespace App\Filament\Resources\EquipeTrabalhoResource;
 
 use App\Enums\StatusInscricaoEquipeTrabalho;
+use App\Models\EquipeTrabalho;
 use Carbon\Carbon;
 use Filament\Support\Colors\Color;
 use Filament\Tables\Columns\ImageColumn;
 use Filament\Tables\Columns\SelectColumn;
 use Filament\Tables\Columns\TextColumn;
+use Filament\Tables\Filters\SelectFilter;
+use Throwable;
 
 abstract class EquipeTrabalhoTable
 {
@@ -39,12 +42,20 @@ abstract class EquipeTrabalhoTable
                 ->sortable()
                 ->searchable(),
 
+            TextColumn::make('descricao')
+                ->label('Equipe')
+                ->badge()
+                ->placeholder('Sem equipe')
+                ->sortable()
+                ->searchable(),
+
             TextColumn::make('data_form.data_nacimento')
                 ->label('Idade')
                 ->numeric()
                 ->sortable()
                 ->alignCenter()
-                ->formatStateUsing(fn($state) => Carbon::createFromFormat('d/m/Y', $state)->age)
+                ->formatStateUsing(fn (mixed $state): ?int => self::ageFromBirthDate($state))
+                ->placeholder('-')
                 ->toggleable(isToggledHiddenByDefault: true)
                 ->visibleFrom('md'),
 
@@ -82,5 +93,35 @@ abstract class EquipeTrabalhoTable
                 ->toggleable(isToggledHiddenByDefault: true)
                 ->visibleFrom('md'),
         ];
+    }
+
+    public static function getFilters(): array
+    {
+        return [
+            SelectFilter::make('descricao')
+                ->label('Equipe')
+                ->options(fn (): array => EquipeTrabalho::query()
+                    ->whereNotNull('descricao')
+                    ->where('descricao', '!=', '')
+                    ->distinct()
+                    ->orderBy('descricao')
+                    ->pluck('descricao', 'descricao')
+                    ->all())
+                ->searchable()
+                ->preload(),
+        ];
+    }
+
+    private static function ageFromBirthDate(mixed $state): ?int
+    {
+        if (! is_string($state) || trim($state) === '') {
+            return null;
+        }
+
+        try {
+            return Carbon::createFromFormat('d/m/Y', $state)->age;
+        } catch (Throwable) {
+            return null;
+        }
     }
 }

--- a/app/Filament/Resources/EquipeTrabalhoResource/Pages/CreateEquipeTrabalho.php
+++ b/app/Filament/Resources/EquipeTrabalhoResource/Pages/CreateEquipeTrabalho.php
@@ -6,6 +6,7 @@ use App\Filament\Resources\EquipeTrabalhoResource;
 use App\Filament\Resources\EquipeTrabalhoResource\EquipeTrabalhoForm;
 use Filament\Resources\Pages\CreateRecord;
 use Filament\Schemas\Schema;
+use Illuminate\Database\Eloquent\Model;
 
 class CreateEquipeTrabalho extends CreateRecord
 {
@@ -15,7 +16,14 @@ class CreateEquipeTrabalho extends CreateRecord
     {
         return $schema
             ->components(
-                EquipeTrabalhoForm::getFormCreate(),
+                EquipeTrabalhoForm::getAdminFormCreate(),
             );
+    }
+
+    protected function handleRecordCreation(array $data): Model
+    {
+        $data['data_form'] ??= [];
+
+        return static::getModel()::query()->create($data);
     }
 }

--- a/app/Filament/Resources/EquipeTrabalhoResource/Pages/ListEquipeTrabalhos.php
+++ b/app/Filament/Resources/EquipeTrabalhoResource/Pages/ListEquipeTrabalhos.php
@@ -20,7 +20,7 @@ class ListEquipeTrabalhos extends ListRecords
     protected function getHeaderWidgets(): array
     {
         return [
-            EquipeTrabalhoResource\Widgets\EquipeTrabalhoStatsWidget::class
+            EquipeTrabalhoResource\Widgets\EquipeTrabalhoStatsWidget::class,
         ];
     }
 }

--- a/app/Filament/Resources/EquipeTrabalhoResource/Widgets/EquipeTrabalhoStatsWidget.php
+++ b/app/Filament/Resources/EquipeTrabalhoResource/Widgets/EquipeTrabalhoStatsWidget.php
@@ -28,12 +28,11 @@ class EquipeTrabalhoStatsWidget extends BaseWidget
             'M' => 0,
         ];
 
-        foreach ($data as $value) {
+        foreach ($data as $registration) {
+            $sex = data_get($registration->data_form, 'sexo');
 
-            if ($value->data_form['sexo'] == 'F') {
-                $sexo['F']++;
-            } else {
-                $sexo['M']++;
+            if (array_key_exists($sex, $sexo)) {
+                $sexo[$sex]++;
             }
         }
 

--- a/app/Models/EquipeTrabalho.php
+++ b/app/Models/EquipeTrabalho.php
@@ -21,6 +21,11 @@ class EquipeTrabalho extends Model implements Auditable
         'data_form',
         'status',
         'tribo_id',
+        'descricao',
+    ];
+
+    protected $attributes = [
+        'data_form' => '[]',
     ];
 
     protected $casts = [

--- a/database/seeders/EquipeTrabalhoRosterSeeder.php
+++ b/database/seeders/EquipeTrabalhoRosterSeeder.php
@@ -1,0 +1,240 @@
+<?php
+
+namespace Database\Seeders;
+
+use App\Enums\StatusInscricaoEquipeTrabalho;
+use App\Models\EquipeTrabalho;
+use Illuminate\Database\Console\Seeds\WithoutModelEvents;
+use Illuminate\Database\Seeder;
+
+class EquipeTrabalhoRosterSeeder extends Seeder
+{
+    use WithoutModelEvents;
+
+    /**
+     * Run the database seeds.
+     */
+    public function run(): void
+    {
+        foreach (self::roster() as $team => $names) {
+            foreach ($names as $name) {
+                EquipeTrabalho::query()->firstOrCreate([
+                    'nome' => $name,
+                    'descricao' => $team,
+                ], [
+                    'data_form' => [],
+                    'status' => StatusInscricaoEquipeTrabalho::Aprovado->value,
+                ]);
+            }
+        }
+    }
+
+    public static function totalMembers(): int
+    {
+        return collect(self::roster())
+            ->flatten(1)
+            ->count();
+    }
+
+    public static function totalTeams(): int
+    {
+        return count(self::roster());
+    }
+
+    /**
+     * @return array<string, array<int, string>>
+     */
+    public static function roster(): array
+    {
+        return [
+            'Coordenação' => [
+                'Frei Kleiton',
+                'Luana Cristina Fonseca',
+                'Micael Márcio Borba',
+                'Jocemar Silverio da Silva',
+                'Anderson Santos de Oliveira',
+            ],
+            'Direção Espiritual' => [
+                'Tiago Mellies',
+                'Larissa Bissoli Vieira',
+            ],
+            'Servos' => [
+                'Thaise Berkenbrock Inacio',
+                'Diego André Inacio',
+                'Ailton Motta',
+                'Aldaberto Cidnei Menezes',
+                'Ana Paula Amaro',
+                'Antonio Braz de Oliveira',
+                'Barbara Braz de Morais',
+                'Bruna Thais Pinheiro Ferreira',
+                'Bruno de Mello Sabino (Mega)',
+                'Daiane Cristina Longo',
+                'Dereck Adriano',
+                'Edenilson de Souza',
+                'Jefferson Macarini',
+                'João Francisco Ferreiro',
+                'Josilene Lessa Barbosa',
+                'Katia Regina Brasil',
+                'Laurinda Vilvert Inácio',
+                'Lincon Kaue Espindola',
+                'Marcelo Gomes da Silva',
+                'Marcio Mello dos Santos',
+                'Mareleia Nascimento Felicio',
+                'Mariana Francisco Pacheco',
+                'Marileia Moura Ferreira',
+                'Mateus A. Grosskopf',
+                'Osmair Donizete Noli (Zeca)',
+                'Rafaela Elize Benassi',
+                'Roberta Rebello',
+                'Ronaldo Bertolli',
+                'Saulo de Oliveira Silveira',
+                'Tainara Mianes',
+                'Tainara Rossatti de Souza',
+                'Taise de Augustinho',
+                'Tuanny Silva',
+                'Valdemar Chagas Junior',
+            ],
+            'Cozinha' => [
+                'Jean José Bento',
+                'Francirlei Ribeiro',
+                'Jair Figueredo',
+                'José Maria de Oliveira',
+                'Mariza Pivatto Ramos',
+                'Mayara de Oliveira',
+                'Rosiley Motta',
+                'Schaieni Carolini Bento',
+                'Sheila',
+                'Valdeci Mafra',
+            ],
+            'Secretaria' => [
+                'Leandro Marcos dos Santos',
+                'Alexandra',
+                'Aline Garcia Lazzaris',
+                'Ana Cristina Figueredo',
+                'Jocelaine Amaro Dittrich',
+                'Renata Ricobom Pivatto',
+                'Silvana Souza',
+                'Solange Mello dos Santos',
+            ],
+            'Recreação' => [
+                'Felipe Itamar da Silveira',
+                'Diego dos Santos Souza',
+            ],
+            'Manutenção' => [
+                'Ciduinei João da Silva',
+                'Antonio Fernandes (Chico)',
+                'Ataídes dos Santos',
+                'Everton Gazaniga',
+                'Iago Gonçalves Borba',
+                'Jairo Amaro',
+                'Jonatan C. de Souza',
+                'Pedro Dorval Felicio',
+            ],
+            'Intercessão' => [
+                'Nerozilda Ferreira',
+                'Alcione Santos Garcez',
+                'Dileta de Menezes',
+                'Edmilson Miguel Holtin',
+                'Luciana de Souza',
+                'Monica Zimmermann',
+                'Nilsa Rodrigues',
+                'Rozane Fatima Santos de Oliveira',
+                'Salete Ribeiro da Silva',
+                'Zeferino Ferreira',
+                'Zulmira Fideleski',
+            ],
+            'Apoio' => [
+                'Camila Thaisi Inácio da Cunha',
+                'Joabe da Silva Maria',
+                'Kaylayne Eduarda de Almeida Gazaniga',
+                'Milton Bortolado',
+                'Tieli Costa de Oliveira',
+            ],
+            'Ordem e Limpeza' => [
+                'Magali de Fátima',
+                'Moacir da Silva Filho',
+                'Ane Karoline Portella',
+                'Jennifer Laura Rocha',
+                'José Augusto Gonçalves',
+                'Mirian Carmen de Mello',
+                'Pedro Ferreira de Oliveira',
+                'Silvia Silva',
+                'Tatiane de Souza',
+            ],
+            'Enfermagem' => [
+                'Sabrina Coelho Bento',
+            ],
+            'Animação' => [
+                'Rodrigo Berlanda Pimental',
+                'Cleiton',
+                'Hermínio',
+                'Lucas',
+                'Marcos',
+                'Nei',
+            ],
+            'Externa' => [
+                'Eduana Fonseca White',
+                'Geovana Floriano Sabino',
+                'Alexsandro do Nascimento',
+                'Ane Caroline Adriano',
+                'Arianne dos Santos Vanderlinde',
+                'Berg',
+                'Camila Aparecida Pinheiro Marmitt',
+                'Carlos Antonio Gazaniga',
+                'Cris',
+                'Cristiane Espíndola',
+                'Daiane Russi da Silva Bastos',
+                'Edneia Francieli Rodrigues de Almeida Gazaniga',
+                'Franciane Marquetti',
+                'Jaison Amaro',
+                'Juliana',
+                'Mariane de Freitas Maria',
+                'Naiara Dognini',
+                'Naiara Gabriela Assis da Silva',
+                'Rodrigo da Silva',
+                'Sidnei de Lima',
+            ],
+            'Missão' => [
+                'Graziele de Oliveira Andriani',
+                'Luiz Fernando Andriani Júnior',
+                'Adriana de Souza dos Santos',
+                'Amanda Goulart Pontes',
+                'Anderson Rodrigues',
+                'Andrea Rosemari de Souza dos Santos',
+                'Augustinho Pedrozo',
+                'Benta keller',
+                'Bianca Reiser',
+                'Daniela longo',
+                'Dionei Pereira',
+                'Elisângela Alexandre dos Santos',
+                'Fabiane Pierre dos Passos',
+                'Fabio Mello dos Santos',
+                'Felipe Mellies',
+                'Gabriella Estrogueia Mellies',
+                'Giancarlo Mafra',
+                'Gilmar Martins',
+                'Ivan Jayme de Souza',
+                'Jéssica Felício de Souza Nunes',
+                'João Guilherme Corrêa Harger',
+                'João Paulo Nunes',
+                'Luciana do Rocio Ribeiro Oliveira',
+                'Luciano dos Santos',
+                'Luiz Henrique de Mello',
+                'Márcia Aparecida Silva Ricardo',
+                'Maria Eva Amaro',
+                'Mariela Marcelino de Mello',
+                'Priscila Mayara Kienolt',
+                'Renato Nunes da Silva',
+                'Roberta Ricardo de Souza',
+                'Rosinei Aparecida Oliveira',
+                'Sandra Catarina Inácio',
+                'Simone M Henrique de Souza',
+                'Solange Gonçalves Alves',
+                'Terezinha Oliveira',
+                'Tiago Etges',
+                'Vanessa Schmitter',
+                'Zoraide da Silva',
+            ],
+        ];
+    }
+}

--- a/resources/views/admin/reports/partials/registration-fichas.blade.php
+++ b/resources/views/admin/reports/partials/registration-fichas.blade.php
@@ -27,6 +27,16 @@
             </div>
 
             <div class="report-registration-ficha__badges">
+                @if (filled($logoSrc ?? null))
+                    <span class="report-registration-ficha__brand-logo">
+                        <img
+                            src="{{ $logoSrc }}"
+                            alt="Logo do acampamento"
+                            data-report-registration-logo
+                        >
+                    </span>
+                @endif
+
                 <span
                     class="report-badge report-badge--tribe"
                     data-report-badge-icon="heroicon-s-flag"

--- a/resources/views/admin/reports/print.blade.php
+++ b/resources/views/admin/reports/print.blade.php
@@ -419,9 +419,25 @@
 
         .report-registration-ficha__badges {
             display: flex;
+            align-items: center;
             flex-wrap: wrap;
             justify-content: flex-end;
             gap: .35rem;
+        }
+
+        .report-registration-ficha__brand-logo {
+            display: flex;
+            align-items: center;
+            justify-content: flex-end;
+            width: 8.6rem;
+            min-height: 2.55rem;
+        }
+
+        .report-registration-ficha__brand-logo img {
+            display: block;
+            max-width: 100%;
+            max-height: 2.55rem;
+            object-fit: contain;
         }
 
         .report-registration-ficha__sections {

--- a/tests/Feature/EquipeTrabalhoRosterSeederTest.php
+++ b/tests/Feature/EquipeTrabalhoRosterSeederTest.php
@@ -1,0 +1,94 @@
+<?php
+
+use App\Enums\StatusInscricaoEquipeTrabalho;
+use App\Filament\Resources\EquipeTrabalhoResource\Pages\CreateEquipeTrabalho;
+use App\Filament\Resources\EquipeTrabalhoResource\Widgets\EquipeTrabalhoStatsWidget;
+use App\Models\EquipeTrabalho;
+use App\Models\User;
+use Database\Seeders\EquipeTrabalhoRosterSeeder;
+use Database\Seeders\ShieldSeeder;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Queue;
+use Livewire\Livewire;
+
+uses(RefreshDatabase::class);
+
+it('seeds the fixed PDF roster with members linked to their equipes', function () {
+    Queue::fake();
+
+    $this->seed(EquipeTrabalhoRosterSeeder::class);
+
+    expect(EquipeTrabalhoRosterSeeder::totalMembers())->toBe(160)
+        ->and(EquipeTrabalhoRosterSeeder::totalTeams())->toBe(14)
+        ->and(EquipeTrabalho::query()->count())->toBe(160)
+        ->and(EquipeTrabalho::query()->distinct('descricao')->count('descricao'))->toBe(14)
+        ->and(EquipeTrabalho::query()
+            ->where('descricao', 'Servos')
+            ->pluck('nome')
+            ->all())
+        ->toContain('Thaise Berkenbrock Inacio', 'Bruno de Mello Sabino (Mega)')
+        ->and(EquipeTrabalho::query()
+            ->where('descricao', 'Missão')
+            ->pluck('nome')
+            ->all())
+        ->toContain('Graziele de Oliveira Andriani', 'Zoraide da Silva')
+        ->and(EquipeTrabalho::query()
+            ->where('nome', 'Jean José Bento')
+            ->firstOrFail())
+        ->descricao->toBe('Cozinha')
+        ->status->toBe(StatusInscricaoEquipeTrabalho::Aprovado)
+        ->data_form->toBe([]);
+
+    Queue::assertNothingPushed();
+});
+
+it('can rerun the fixed roster seeder without duplicating members', function () {
+    $this->seed(EquipeTrabalhoRosterSeeder::class);
+    $this->seed(EquipeTrabalhoRosterSeeder::class);
+
+    expect(EquipeTrabalho::query()->count())->toBe(160);
+});
+
+it('does not keep an upload import action on the equipe de trabalho list page', function () {
+    $page = file_get_contents(app_path('Filament/Resources/EquipeTrabalhoResource/Pages/ListEquipeTrabalhos.php'));
+
+    expect($page)
+        ->not->toContain('FileUpload::make')
+        ->not->toContain('importarEquipeTrabalho')
+        ->not->toContain('EquipeTrabalhoRosterImport')
+        ->toContain('Actions\\CreateAction::make()');
+});
+
+it('creates an admin work team registration with only the name required', function () {
+    $this->seed(ShieldSeeder::class);
+
+    $user = User::factory()->create();
+    $user->assignRole('Super Administrador');
+    $this->actingAs($user);
+    Queue::fake();
+
+    Livewire::test(CreateEquipeTrabalho::class)
+        ->fillForm([
+            'nome' => 'Servo Importado Manualmente',
+        ])
+        ->call('create')
+        ->assertHasNoFormErrors();
+
+    $registration = EquipeTrabalho::query()
+        ->where('nome', 'Servo Importado Manualmente')
+        ->firstOrFail();
+
+    expect($registration)
+        ->data_form->toBe([])
+        ->status->toBe(StatusInscricaoEquipeTrabalho::Aprovado);
+});
+
+it('renders equipe de trabalho stats for roster records without sex data', function () {
+    $this->seed(EquipeTrabalhoRosterSeeder::class);
+
+    Livewire::test(EquipeTrabalhoStatsWidget::class)
+        ->assertOk()
+        ->assertSee('Qtd de Inscrições')
+        ->assertSee('Qtd Mulheres')
+        ->assertSee('Qtd Homens');
+});

--- a/tests/Feature/ReportsPageTest.php
+++ b/tests/Feature/ReportsPageTest.php
@@ -374,6 +374,8 @@ it('applies ficha visual styling and keeps linked payments hidden by default on 
         ->toContain('report-card--address')
         ->toContain('report-card--community')
         ->toContain('report-card--health')
+        ->toContain('data-report-registration-logo')
+        ->toContain('/img/logo.png')
         ->toContain('data-report-badge-icon="heroicon-s-flag"')
         ->toContain('--report-accent: #123abc')
         ->not->toContain('report-registration-summary')


### PR DESCRIPTION
- Add fixed roster seeder with idempotent approved team members
- Simplify admin creation while preserving full public registration form
- Surface equipe names in tables, filters, exports, and report fichas
- Make stats and age formatting tolerate incomplete roster records