### PR TITLE
Add campista waitlist and invitation flow

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,15 @@
+# Domain Context
+
+## Glossary
+
+### Fila de espera
+
+Registro público de interesse em vaga quando a inscrição de campista está indisponível por limite de capacidade, incluindo limite por sexo. A fila preserva a ordem de chegada geral e por sexo.
+
+### Convite da fila
+
+Link único gerado pela organização para que uma pessoa da fila de espera conclua a ficha de inscrição quando uma vaga compatível com seu sexo estiver disponível.
+
+### Vaga reservada
+
+Vaga temporariamente bloqueada para uma pessoa convocada da fila enquanto o convite da fila está válido.

--- a/app/Enums/WaitlistEntryStatus.php
+++ b/app/Enums/WaitlistEntryStatus.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace App\Enums;
+
+use Filament\Support\Contracts\HasColor;
+use Filament\Support\Contracts\HasIcon;
+use Filament\Support\Contracts\HasLabel;
+
+enum WaitlistEntryStatus: string implements HasColor, HasIcon, HasLabel
+{
+    case Aguardando = 'aguardando';
+    case Convocado = 'convocado';
+    case Inscrito = 'inscrito';
+    case Desistiu = 'desistiu';
+    case Cancelado = 'cancelado';
+    case Expirado = 'expirado';
+
+    public function getLabel(): ?string
+    {
+        return match ($this) {
+            self::Aguardando => 'Aguardando',
+            self::Convocado => 'Convocado',
+            self::Inscrito => 'Inscrito',
+            self::Desistiu => 'Desistiu',
+            self::Cancelado => 'Cancelado',
+            self::Expirado => 'Expirado',
+        };
+    }
+
+    public function getColor(): string|array|null
+    {
+        return match ($this) {
+            self::Aguardando => 'warning',
+            self::Convocado => 'info',
+            self::Inscrito => 'success',
+            self::Desistiu, self::Cancelado => 'danger',
+            self::Expirado => 'gray',
+        };
+    }
+
+    public function getIcon(): ?string
+    {
+        return match ($this) {
+            self::Aguardando => 'heroicon-o-clock',
+            self::Convocado => 'heroicon-o-link',
+            self::Inscrito => 'heroicon-o-check-circle',
+            self::Desistiu => 'heroicon-o-arrow-left-on-rectangle',
+            self::Cancelado => 'heroicon-o-x-circle',
+            self::Expirado => 'heroicon-o-calendar',
+        };
+    }
+
+    public function isActiveQueueStatus(): bool
+    {
+        return in_array($this, [self::Aguardando, self::Convocado], true);
+    }
+}

--- a/app/Filament/Pages/GeneralSettingsPage.php
+++ b/app/Filament/Pages/GeneralSettingsPage.php
@@ -165,6 +165,19 @@ class GeneralSettingsPage extends SettingsPage
                                         'lg' => '3',
                                     ]),
 
+                                TextInput::make('waitlist_invitation_hours')
+                                    ->label('Validade do convite da fila')
+                                    ->integer()
+                                    ->minValue(1)
+                                    ->required()
+                                    ->suffix('horas')
+                                    ->helperText('Tempo padrão para a pessoa convocada finalizar a ficha pelo link único.')
+                                    ->columnSpan([
+                                        'default' => 'full',
+                                        'md' => '6',
+                                        'lg' => '3',
+                                    ]),
+
                             ])
                             ->columnSpan([
                                 'default' => 'full',

--- a/app/Filament/Resources/WaitlistEntries/Pages/CreateWaitlistEntry.php
+++ b/app/Filament/Resources/WaitlistEntries/Pages/CreateWaitlistEntry.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\Filament\Resources\WaitlistEntries\Pages;
+
+use App\Filament\Resources\WaitlistEntries\WaitlistEntryResource;
+use App\Support\Campistas\WaitlistManager;
+use Filament\Resources\Pages\CreateRecord;
+
+class CreateWaitlistEntry extends CreateRecord
+{
+    protected static string $resource = WaitlistEntryResource::class;
+
+    protected function mutateFormDataBeforeCreate(array $data): array
+    {
+        $data['telefone_normalizado'] = app(WaitlistManager::class)->normalizePhone($data['telefone'] ?? null);
+        $data['accepted_privacy_at'] ??= now();
+
+        return parent::mutateFormDataBeforeCreate($data);
+    }
+}

--- a/app/Filament/Resources/WaitlistEntries/Pages/EditWaitlistEntry.php
+++ b/app/Filament/Resources/WaitlistEntries/Pages/EditWaitlistEntry.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace App\Filament\Resources\WaitlistEntries\Pages;
+
+use App\Filament\Resources\WaitlistEntries\WaitlistEntryResource;
+use App\Support\Campistas\WaitlistManager;
+use Filament\Actions\DeleteAction;
+use Filament\Actions\ViewAction;
+use Filament\Resources\Pages\EditRecord;
+
+class EditWaitlistEntry extends EditRecord
+{
+    protected static string $resource = WaitlistEntryResource::class;
+
+    protected function getHeaderActions(): array
+    {
+        return [
+            ViewAction::make(),
+            DeleteAction::make(),
+        ];
+    }
+
+    protected function mutateFormDataBeforeSave(array $data): array
+    {
+        $data['telefone_normalizado'] = app(WaitlistManager::class)->normalizePhone($data['telefone'] ?? null);
+
+        return parent::mutateFormDataBeforeSave($data);
+    }
+}

--- a/app/Filament/Resources/WaitlistEntries/Pages/ListWaitlistEntries.php
+++ b/app/Filament/Resources/WaitlistEntries/Pages/ListWaitlistEntries.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Filament\Resources\WaitlistEntries\Pages;
+
+use App\Filament\Resources\WaitlistEntries\WaitlistEntryResource;
+use Filament\Actions\CreateAction;
+use Filament\Resources\Pages\ListRecords;
+
+class ListWaitlistEntries extends ListRecords
+{
+    protected static string $resource = WaitlistEntryResource::class;
+
+    protected function getHeaderActions(): array
+    {
+        return [
+            CreateAction::make(),
+        ];
+    }
+}

--- a/app/Filament/Resources/WaitlistEntries/Pages/ViewWaitlistEntry.php
+++ b/app/Filament/Resources/WaitlistEntries/Pages/ViewWaitlistEntry.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Filament\Resources\WaitlistEntries\Pages;
+
+use App\Filament\Resources\WaitlistEntries\WaitlistEntryResource;
+use Filament\Actions\EditAction;
+use Filament\Resources\Pages\ViewRecord;
+
+class ViewWaitlistEntry extends ViewRecord
+{
+    protected static string $resource = WaitlistEntryResource::class;
+
+    protected function getHeaderActions(): array
+    {
+        return [
+            EditAction::make(),
+        ];
+    }
+}

--- a/app/Filament/Resources/WaitlistEntries/Schemas/WaitlistEntryForm.php
+++ b/app/Filament/Resources/WaitlistEntries/Schemas/WaitlistEntryForm.php
@@ -1,0 +1,136 @@
+<?php
+
+namespace App\Filament\Resources\WaitlistEntries\Schemas;
+
+use App\Enums\WaitlistEntryStatus;
+use Filament\Forms\Components\DatePicker;
+use Filament\Forms\Components\Select;
+use Filament\Forms\Components\Textarea;
+use Filament\Forms\Components\TextInput;
+use Filament\Forms\Components\ToggleButtons;
+use Filament\Schemas\Components\Section;
+use Filament\Schemas\Schema;
+use Filament\Support\Colors\Color;
+
+class WaitlistEntryForm
+{
+    public static function configure(Schema $schema): Schema
+    {
+        return $schema
+            ->columns([
+                'default' => 1,
+                'lg' => 12,
+            ])
+            ->components([
+                Section::make('Dados pessoais')
+                    ->description('Identificação e contato da pessoa na fila.')
+                    ->icon('phosphor-user-list-fill')
+                    ->columns([
+                        'default' => 1,
+                        'md' => 2,
+                        'xl' => 12,
+                    ])
+                    ->columnSpan([
+                        'default' => 'full',
+                        'lg' => 7,
+                    ])
+                    ->schema([
+                        TextInput::make('nome')
+                            ->label('Nome completo')
+                            ->required()
+                            ->maxLength(255)
+                            ->columnSpan([
+                                'default' => 'full',
+                                'xl' => 7,
+                            ]),
+
+                        TextInput::make('telefone')
+                            ->label('WhatsApp')
+                            ->required()
+                            ->maxLength(32)
+                            ->columnSpan([
+                                'default' => 'full',
+                                'xl' => 5,
+                            ]),
+
+                        TextInput::make('email')
+                            ->label('E-mail')
+                            ->email()
+                            ->maxLength(255)
+                            ->columnSpan([
+                                'default' => 'full',
+                                'xl' => 7,
+                            ]),
+
+                        DatePicker::make('data_nascimento')
+                            ->label('Data de nascimento')
+                            ->native(false)
+                            ->displayFormat('d/m/Y')
+                            ->columnSpan([
+                                'default' => 'full',
+                                'xl' => 5,
+                            ]),
+
+                        ToggleButtons::make('sexo')
+                            ->label('Sexo')
+                            ->required()
+                            ->inline()
+                            ->options([
+                                'M' => 'Masculino',
+                                'F' => 'Feminino',
+                            ])
+                            ->colors([
+                                'M' => Color::Blue,
+                                'F' => Color::Pink,
+                            ])
+                            ->icons([
+                                'M' => 'eos-male',
+                                'F' => 'eos-female',
+                            ])
+                            ->columnSpanFull(),
+                    ]),
+
+                Section::make('Controle da fila')
+                    ->description('Status usado para acompanhar a convocação.')
+                    ->icon('heroicon-o-clipboard-document-check')
+                    ->columns(1)
+                    ->columnSpan([
+                        'default' => 'full',
+                        'lg' => 5,
+                    ])
+                    ->schema([
+                        Select::make('status')
+                            ->label('Status')
+                            ->options(WaitlistEntryStatus::class)
+                            ->required()
+                            ->native(false),
+                    ]),
+
+                Section::make('Observações')
+                    ->description('Anotações visíveis no contexto público e observações internas da coordenação.')
+                    ->icon('heroicon-o-chat-bubble-left-right')
+                    ->columns([
+                        'default' => 1,
+                        'lg' => 2,
+                    ])
+                    ->columnSpanFull()
+                    ->schema([
+                        Textarea::make('observacao')
+                            ->label('Observação pública')
+                            ->rows(4)
+                            ->columnSpan([
+                                'default' => 'full',
+                                'lg' => 1,
+                            ]),
+
+                        Textarea::make('admin_notes')
+                            ->label('Observação interna')
+                            ->rows(4)
+                            ->columnSpan([
+                                'default' => 'full',
+                                'lg' => 1,
+                            ]),
+                    ]),
+            ]);
+    }
+}

--- a/app/Filament/Resources/WaitlistEntries/Schemas/WaitlistEntryInfolist.php
+++ b/app/Filament/Resources/WaitlistEntries/Schemas/WaitlistEntryInfolist.php
@@ -1,0 +1,221 @@
+<?php
+
+namespace App\Filament\Resources\WaitlistEntries\Schemas;
+
+use App\Models\WaitlistEntry;
+use App\Support\Campistas\WaitlistManager;
+use Filament\Infolists\Components\TextEntry;
+use Filament\Schemas\Components\Section;
+use Filament\Schemas\Schema;
+use Filament\Support\Enums\FontWeight;
+
+class WaitlistEntryInfolist
+{
+    public static function configure(Schema $schema): Schema
+    {
+        return $schema
+            ->columns([
+                'default' => 1,
+                'lg' => 12,
+            ])
+            ->components([
+                Section::make('Resumo da fila')
+                    ->description('Posição, status e validade do convite.')
+                    ->icon('heroicon-o-queue-list')
+                    ->columns([
+                        'default' => 1,
+                        'md' => 2,
+                        'xl' => 12,
+                    ])
+                    ->columnSpanFull()
+                    ->schema([
+                        TextEntry::make('status')
+                            ->label('Status')
+                            ->badge()
+                            ->columnSpan([
+                                'default' => 'full',
+                                'md' => 1,
+                                'xl' => 3,
+                            ]),
+
+                        TextEntry::make('general_position')
+                            ->label('Posição geral')
+                            ->state(fn (WaitlistEntry $record): ?int => app(WaitlistManager::class)->generalPosition($record))
+                            ->placeholder('-')
+                            ->badge()
+                            ->color('info')
+                            ->columnSpan([
+                                'default' => 'full',
+                                'md' => 1,
+                                'xl' => 3,
+                            ]),
+
+                        TextEntry::make('sex_position')
+                            ->label('Posição por sexo')
+                            ->state(fn (WaitlistEntry $record): ?int => app(WaitlistManager::class)->sexPosition($record))
+                            ->placeholder('-')
+                            ->badge()
+                            ->color('info')
+                            ->columnSpan([
+                                'default' => 'full',
+                                'md' => 1,
+                                'xl' => 3,
+                            ]),
+
+                        TextEntry::make('created_at')
+                            ->label('Entrada na fila')
+                            ->dateTime('d/m/Y H:i')
+                            ->placeholder('-')
+                            ->columnSpan([
+                                'default' => 'full',
+                                'md' => 1,
+                                'xl' => 3,
+                            ]),
+
+                        TextEntry::make('invitation_generated_at')
+                            ->label('Convite gerado em')
+                            ->dateTime('d/m/Y H:i')
+                            ->placeholder('Sem convite gerado')
+                            ->columnSpan([
+                                'default' => 'full',
+                                'md' => 1,
+                                'xl' => 4,
+                            ]),
+
+                        TextEntry::make('invitation_expires_at')
+                            ->label('Convite expira em')
+                            ->dateTime('d/m/Y H:i')
+                            ->placeholder('Sem convite ativo')
+                            ->columnSpan([
+                                'default' => 'full',
+                                'md' => 1,
+                                'xl' => 4,
+                            ]),
+
+                        TextEntry::make('invitation_accepted_at')
+                            ->label('Convite aceito em')
+                            ->dateTime('d/m/Y H:i')
+                            ->placeholder('Ainda não aceito')
+                            ->columnSpan([
+                                'default' => 'full',
+                                'md' => 1,
+                                'xl' => 4,
+                            ]),
+                    ]),
+
+                Section::make('Dados pessoais')
+                    ->description('Identificação e contato deixados pela pessoa.')
+                    ->icon('phosphor-user-list-fill')
+                    ->columns([
+                        'default' => 1,
+                        'md' => 2,
+                        'xl' => 12,
+                    ])
+                    ->columnSpan([
+                        'default' => 'full',
+                        'lg' => 7,
+                    ])
+                    ->schema([
+                        TextEntry::make('nome')
+                            ->label('Nome completo')
+                            ->weight(FontWeight::Bold)
+                            ->columnSpan([
+                                'default' => 'full',
+                                'xl' => 6,
+                            ]),
+
+                        TextEntry::make('sexo')
+                            ->label('Sexo')
+                            ->formatStateUsing(fn (?string $state): string => $state === 'F' ? 'Feminino' : 'Masculino')
+                            ->badge()
+                            ->color(fn (?string $state): string => $state === 'F' ? 'pink' : 'blue')
+                            ->columnSpan([
+                                'default' => 'full',
+                                'xl' => 3,
+                            ]),
+
+                        TextEntry::make('data_nascimento')
+                            ->label('Nascimento')
+                            ->date('d/m/Y')
+                            ->placeholder('Não informado')
+                            ->columnSpan([
+                                'default' => 'full',
+                                'xl' => 3,
+                            ]),
+
+                        TextEntry::make('telefone')
+                            ->label('WhatsApp')
+                            ->copyable()
+                            ->columnSpan([
+                                'default' => 'full',
+                                'xl' => 6,
+                            ]),
+
+                        TextEntry::make('email')
+                            ->label('E-mail')
+                            ->copyable()
+                            ->placeholder('Sem e-mail')
+                            ->columnSpan([
+                                'default' => 'full',
+                                'xl' => 6,
+                            ]),
+                    ]),
+
+                Section::make('Controle interno')
+                    ->description('Acompanhamento operacional da fila.')
+                    ->icon('heroicon-o-clipboard-document-check')
+                    ->columns([
+                        'default' => 1,
+                        'xl' => 2,
+                    ])
+                    ->columnSpan([
+                        'default' => 'full',
+                        'lg' => 5,
+                    ])
+                    ->schema([
+                        TextEntry::make('campista.nome')
+                            ->label('Inscrição vinculada')
+                            ->placeholder('Ainda não gerou inscrição')
+                            ->url(fn (WaitlistEntry $record): ?string => $record->campista_id === null
+                                ? null
+                                : route('filament.admin.resources.campistas.view', ['record' => $record->campista_id]))
+                            ->openUrlInNewTab(false)
+                            ->columnSpanFull(),
+
+                        TextEntry::make('invitationGeneratedBy.name')
+                            ->label('Convocado por')
+                            ->placeholder('Não informado'),
+
+                        TextEntry::make('cancelledBy.name')
+                            ->label('Cancelado por')
+                            ->placeholder('Não informado'),
+                    ]),
+
+                Section::make('Observações')
+                    ->description('Anotações públicas e internas registradas na fila.')
+                    ->icon('heroicon-o-chat-bubble-left-right')
+                    ->columns([
+                        'default' => 1,
+                        'lg' => 2,
+                    ])
+                    ->columnSpanFull()
+                    ->schema([
+                        TextEntry::make('observacao')
+                            ->label('Observação pública')
+                            ->placeholder('Sem observação')
+                            ->columnSpan([
+                                'default' => 'full',
+                                'lg' => 1,
+                            ]),
+
+                        TextEntry::make('admin_notes')
+                            ->label('Observação interna')
+                            ->placeholder('Sem observação')
+                            ->columnSpan([
+                                'default' => 'full',
+                                'lg' => 1,
+                            ]),
+                    ]),
+            ]);
+    }
+}

--- a/app/Filament/Resources/WaitlistEntries/Tables/WaitlistEntriesTable.php
+++ b/app/Filament/Resources/WaitlistEntries/Tables/WaitlistEntriesTable.php
@@ -1,0 +1,177 @@
+<?php
+
+namespace App\Filament\Resources\WaitlistEntries\Tables;
+
+use App\Enums\WaitlistEntryStatus;
+use App\Models\WaitlistEntry;
+use App\Support\Campistas\WaitlistManager;
+use Filament\Actions\Action;
+use Filament\Actions\BulkActionGroup;
+use Filament\Actions\DeleteBulkAction;
+use Filament\Actions\EditAction;
+use Filament\Actions\ViewAction;
+use Filament\Notifications\Notification;
+use Filament\Tables\Columns\TextColumn;
+use Filament\Tables\Filters\SelectFilter;
+use Filament\Tables\Filters\TernaryFilter;
+use Filament\Tables\Table;
+use Illuminate\Support\HtmlString;
+use Illuminate\Support\Js;
+use Illuminate\Validation\ValidationException;
+
+class WaitlistEntriesTable
+{
+    public static function configure(Table $table): Table
+    {
+        return $table
+            ->columns([
+                TextColumn::make('general_position')
+                    ->label('Geral')
+                    ->state(fn (WaitlistEntry $record): ?int => app(WaitlistManager::class)->generalPosition($record))
+                    ->placeholder('-')
+                    ->alignCenter(),
+
+                TextColumn::make('sex_position')
+                    ->label('Por sexo')
+                    ->state(fn (WaitlistEntry $record): ?int => app(WaitlistManager::class)->sexPosition($record))
+                    ->placeholder('-')
+                    ->alignCenter(),
+
+                TextColumn::make('nome')
+                    ->label('Nome')
+                    ->searchable()
+                    ->sortable(),
+
+                TextColumn::make('telefone')
+                    ->label('WhatsApp')
+                    ->searchable(),
+
+                TextColumn::make('sexo')
+                    ->label('Sexo')
+                    ->badge()
+                    ->formatStateUsing(fn (?string $state): string => $state === 'F' ? 'Feminino' : 'Masculino')
+                    ->color(fn (?string $state): string => $state === 'F' ? 'pink' : 'blue'),
+
+                TextColumn::make('status')
+                    ->label('Status')
+                    ->badge(),
+
+                TextColumn::make('created_at')
+                    ->label('Entrada')
+                    ->dateTime('d/m/Y H:i')
+                    ->sortable(),
+
+                TextColumn::make('invitation_expires_at')
+                    ->label('Expira')
+                    ->dateTime('d/m/Y H:i')
+                    ->placeholder('-'),
+            ])
+            ->filters([
+                SelectFilter::make('sexo')
+                    ->label('Sexo')
+                    ->options([
+                        'M' => 'Masculino',
+                        'F' => 'Feminino',
+                    ]),
+
+                SelectFilter::make('status')
+                    ->label('Status')
+                    ->options(WaitlistEntryStatus::class),
+
+                TernaryFilter::make('active_invitation')
+                    ->label('Convite ativo')
+                    ->queries(
+                        true: fn ($query) => $query
+                            ->where('status', WaitlistEntryStatus::Convocado->value)
+                            ->where('invitation_expires_at', '>', now()),
+                        false: fn ($query) => $query
+                            ->where(function ($query): void {
+                                $query
+                                    ->where('status', '<>', WaitlistEntryStatus::Convocado->value)
+                                    ->orWhereNull('invitation_expires_at')
+                                    ->orWhere('invitation_expires_at', '<=', now());
+                            }),
+                    ),
+            ])
+            ->defaultSort('created_at')
+            ->recordActions([
+                Action::make('generateInvitation')
+                    ->label('Gerar link')
+                    ->icon('heroicon-o-link')
+                    ->color('info')
+                    ->authorize('generateInvitation')
+                    ->requiresConfirmation()
+                    ->visible(fn (WaitlistEntry $record): bool => app(WaitlistManager::class)->canGenerateInvitation($record))
+                    ->action(function (WaitlistEntry $record): void {
+                        try {
+                            $url = app(WaitlistManager::class)->generateInvitation($record, auth()->user());
+                        } catch (ValidationException $exception) {
+                            Notification::make()
+                                ->title('Convite não gerado')
+                                ->body(collect($exception->errors())->flatten()->first())
+                                ->danger()
+                                ->send();
+
+                            return;
+                        }
+
+                        Notification::make()
+                            ->title('Link único gerado')
+                            ->body(new HtmlString('<a href="'.e($url).'" target="_blank" class="font-bold underline">Abrir link de inscrição</a>'))
+                            ->success()
+                            ->send();
+                    }),
+
+                Action::make('sendInvitationLink')
+                    ->label('Enviar link de inscrição')
+                    ->icon('heroicon-o-paper-airplane')
+                    ->color('success')
+                    ->modalHeading('Enviar link de inscrição')
+                    ->modalDescription('Escolha como deseja compartilhar o link único desta pessoa.')
+                    ->modalContent(fn (WaitlistEntry $record): HtmlString => new HtmlString(
+                        '<div class="space-y-3">'
+                        .'<p class="text-sm font-medium text-white/75">Link de inscrição</p>'
+                        .'<div class="break-all rounded-lg border border-gray-200 bg-gray-50 p-3 text-sm font-medium text-gray-900 dark:border-white/10 dark:bg-white/5 dark:text-gray-100">'
+                        .e(app(WaitlistManager::class)->invitationUrl($record))
+                        .'</div>'
+                        .'</div>',
+                    ))
+                    ->modalSubmitAction(false)
+                    ->modalCancelActionLabel('Fechar')
+                    ->extraModalFooterActions(fn (WaitlistEntry $record): array => [
+                        Action::make('copyInvitationLink')
+                            ->label('Copiar link')
+                            ->icon('heroicon-o-clipboard-document')
+                            ->color('gray')
+                            ->alpineClickHandler('navigator.clipboard.writeText('.Js::from(app(WaitlistManager::class)->invitationUrl($record))->toHtml().'); close()'),
+
+                        Action::make('sendInvitationWhatsapp')
+                            ->label('Enviar via WhatsApp')
+                            ->icon('fab-whatsapp')
+                            ->color('success')
+                            ->url(fn (): ?string => app(WaitlistManager::class)->whatsappUrl($record), shouldOpenInNewTab: true)
+                            ->visible(fn (): bool => filled(app(WaitlistManager::class)->whatsappUrl($record))),
+                    ])
+                    ->visible(fn (WaitlistEntry $record): bool => filled($record->invitation_token_encrypted)
+                        && $record->status === WaitlistEntryStatus::Convocado
+                        && $record->invitation_expires_at?->isFuture()),
+
+                Action::make('markWithdrawn')
+                    ->label('Desistiu')
+                    ->icon('heroicon-o-arrow-left-on-rectangle')
+                    ->color('danger')
+                    ->authorize('update')
+                    ->requiresConfirmation()
+                    ->visible(fn (WaitlistEntry $record): bool => in_array($record->status, [WaitlistEntryStatus::Aguardando, WaitlistEntryStatus::Convocado], true))
+                    ->action(fn (WaitlistEntry $record) => $record->update(['status' => WaitlistEntryStatus::Desistiu])),
+
+                ViewAction::make(),
+                EditAction::make(),
+            ])
+            ->toolbarActions([
+                BulkActionGroup::make([
+                    DeleteBulkAction::make(),
+                ]),
+            ]);
+    }
+}

--- a/app/Filament/Resources/WaitlistEntries/WaitlistEntryResource.php
+++ b/app/Filament/Resources/WaitlistEntries/WaitlistEntryResource.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace App\Filament\Resources\WaitlistEntries;
+
+use App\Filament\Resources\WaitlistEntries\Pages\CreateWaitlistEntry;
+use App\Filament\Resources\WaitlistEntries\Pages\EditWaitlistEntry;
+use App\Filament\Resources\WaitlistEntries\Pages\ListWaitlistEntries;
+use App\Filament\Resources\WaitlistEntries\Pages\ViewWaitlistEntry;
+use App\Filament\Resources\WaitlistEntries\Schemas\WaitlistEntryForm;
+use App\Filament\Resources\WaitlistEntries\Schemas\WaitlistEntryInfolist;
+use App\Filament\Resources\WaitlistEntries\Tables\WaitlistEntriesTable;
+use App\Models\WaitlistEntry;
+use BackedEnum;
+use Filament\Resources\Resource;
+use Filament\Schemas\Schema;
+use Filament\Tables\Table;
+
+class WaitlistEntryResource extends Resource
+{
+    protected static ?string $model = WaitlistEntry::class;
+
+    protected static string|BackedEnum|null $navigationIcon = 'heroicon-o-queue-list';
+
+    protected static string|\UnitEnum|null $navigationGroup = 'Gestão Acampamento';
+
+    protected static ?string $label = 'Fila de espera';
+
+    protected static ?string $pluralLabel = 'Fila de espera';
+
+    public static function form(Schema $schema): Schema
+    {
+        return WaitlistEntryForm::configure($schema);
+    }
+
+    public static function infolist(Schema $schema): Schema
+    {
+        return WaitlistEntryInfolist::configure($schema);
+    }
+
+    public static function table(Table $table): Table
+    {
+        return WaitlistEntriesTable::configure($table);
+    }
+
+    public static function getRelations(): array
+    {
+        return [
+            //
+        ];
+    }
+
+    public static function getPages(): array
+    {
+        return [
+            'index' => ListWaitlistEntries::route('/'),
+            'create' => CreateWaitlistEntry::route('/create'),
+            'view' => ViewWaitlistEntry::route('/{record}'),
+            'edit' => EditWaitlistEntry::route('/{record}/edit'),
+        ];
+    }
+}

--- a/app/Livewire/CampistaForm.php
+++ b/app/Livewire/CampistaForm.php
@@ -4,8 +4,10 @@ namespace App\Livewire;
 
 use App\Models\Campista;
 use App\Models\User;
+use App\Models\WaitlistEntry;
 use App\Settings\GeneralSettings;
 use App\Support\CampistaRegistrationAvailability;
+use App\Support\Campistas\WaitlistManager;
 use App\Support\FilamentUploadState;
 use App\Support\RegistrationAgeLimits;
 use Filament\Actions\Concerns\InteractsWithActions;
@@ -48,16 +50,22 @@ class CampistaForm extends Component implements HasActions, HasForms
     #[Session]
     public $comprado = false;
 
+    public ?WaitlistEntry $waitlistEntry = null;
+
+    public ?string $waitlistToken = null;
+
     public function render()
     {
         return view('livewire.campista-form');
     }
 
-    public function mount()
+    public function mount(?WaitlistEntry $waitlistEntry = null, ?string $token = null)
     {
         $this->settings = app(GeneralSettings::class)->toArray();
+        $this->waitlistEntry = $waitlistEntry;
+        $this->waitlistToken = $token;
         // pega o valor de comprado do localstorage
-        $this->getForm('form')->fill();
+        $this->getForm('form')->fill($this->waitlistFormDefaults());
     }
 
     #[Computed]
@@ -131,6 +139,8 @@ class CampistaForm extends Component implements HasActions, HasForms
                         TextInput::make('nome')
                             ->label('Nome Completo')
                             ->required()
+                            ->disabled(fn (): bool => $this->hasWaitlistInvitation())
+                            ->dehydrated()
                             ->columnSpan([
                                 'default' => 1,
                                 'sm' => 3,
@@ -151,6 +161,8 @@ class CampistaForm extends Component implements HasActions, HasForms
 
                         ToggleButtons::make('form_data.sexo')
                             ->required()
+                            ->disabled(fn (): bool => $this->hasWaitlistInvitation())
+                            ->dehydrated()
                             ->columnSpan([
                                 'default' => 1,
                                 'sm' => 1,
@@ -171,7 +183,7 @@ class CampistaForm extends Component implements HasActions, HasForms
                                 'M' => 'eos-male',
                                 'F' => 'eos-female',
                             ])
-                            ->disableOptionWhen(fn (string $value): bool => ! $this->availability->sexHasVacancy($value))
+                            ->disableOptionWhen(fn (string $value): bool => ! $this->hasWaitlistInvitation() && ! $this->availability->sexHasVacancy($value))
                             ->label('Sexo'),
 
                         TextInput::make('form_data.altura')
@@ -216,6 +228,8 @@ class CampistaForm extends Component implements HasActions, HasForms
                         TextInput::make('form_data.telefone_campista')
                             ->mask('(99) 9 9999-9999')
                             ->required()
+                            ->disabled(fn (): bool => $this->hasWaitlistInvitation())
+                            ->dehydrated()
                             ->columnSpan([
                                 'default' => 1,
                                 'sm' => 1,
@@ -590,7 +604,7 @@ class CampistaForm extends Component implements HasActions, HasForms
     {
         $availability = CampistaRegistrationAvailability::fromSettings(app(GeneralSettings::class));
 
-        if (! $availability->registrationOpen()) {
+        if (! $this->hasWaitlistInvitation() && ! $availability->registrationOpen()) {
             Notification::make()
                 ->title('Inscrições encerradas')
                 ->body($availability->unavailableRegistrationMessage())
@@ -603,7 +617,7 @@ class CampistaForm extends Component implements HasActions, HasForms
 
         $selectedSex = data_get($this->data, 'form_data.sexo');
 
-        if ($selectedSex !== null && $selectedSex !== '' && ! $availability->sexHasVacancy($selectedSex)) {
+        if (! $this->hasWaitlistInvitation() && $selectedSex !== null && $selectedSex !== '' && ! $availability->sexHasVacancy($selectedSex)) {
             Notification::make()
                 ->title('Vagas indisponíveis')
                 ->body($availability->unavailableSelectedSexMessage($selectedSex))
@@ -618,7 +632,7 @@ class CampistaForm extends Component implements HasActions, HasForms
 
         $availability = CampistaRegistrationAvailability::fromSettings(app(GeneralSettings::class));
 
-        if (! $availability->registrationOpen()) {
+        if (! $this->hasWaitlistInvitation() && ! $availability->registrationOpen()) {
             Notification::make()
                 ->title('Inscrições encerradas')
                 ->body($availability->unavailableRegistrationMessage())
@@ -629,7 +643,7 @@ class CampistaForm extends Component implements HasActions, HasForms
             return;
         }
 
-        if (! $availability->sexHasVacancy($selectedSex)) {
+        if (! $this->hasWaitlistInvitation() && ! $availability->sexHasVacancy($selectedSex)) {
             Notification::make()
                 ->title('Vagas indisponíveis')
                 ->body($availability->unavailableSelectedSexMessage($selectedSex))
@@ -686,9 +700,29 @@ class CampistaForm extends Component implements HasActions, HasForms
 
             $this->data = Arr::only($this->data, ['nome', 'avatar_url', 'form_data']);
 
+            if ($this->hasWaitlistInvitation()) {
+                if (! app(WaitlistManager::class)->invitationCanBeUsed($this->waitlistEntry, (string) $this->waitlistToken)) {
+                    Notification::make()
+                        ->title('Convite indisponível')
+                        ->body('Este link da fila de espera expirou ou já foi usado.')
+                        ->danger()
+                        ->send();
+
+                    return;
+                }
+
+                $this->data['nome'] = $this->waitlistEntry->nome;
+                data_set($this->data, 'form_data.sexo', $this->waitlistEntry->sexo);
+                data_set($this->data, 'form_data.telefone_campista', $this->waitlistEntry->telefone);
+            }
+
             $this->data['avatar_url'] = FilamentUploadState::storedPath($this->data['avatar_url'] ?? null, 'foto-formulario');
 
             $campista = Campista::create($this->data);
+
+            if ($this->hasWaitlistInvitation()) {
+                app(WaitlistManager::class)->markInscribed($this->waitlistEntry, $campista);
+            }
 
             $this->comprado = true;
             $this->dispatch('inscricao-realizada');
@@ -709,6 +743,8 @@ class CampistaForm extends Component implements HasActions, HasForms
                 ->sendToDatabase($recipient);
 
         } catch (\Exception $exception) {
+            report($exception);
+
             Notification::make()
                 ->title('Ops! Algo deu errado')
                 ->body('Por favor, tente novamente mais tarde.')
@@ -722,5 +758,25 @@ class CampistaForm extends Component implements HasActions, HasForms
     {
         $this->comprado = false;
         $this->reset(['data']);
+    }
+
+    public function hasWaitlistInvitation(): bool
+    {
+        return $this->waitlistEntry !== null && filled($this->waitlistToken);
+    }
+
+    private function waitlistFormDefaults(): array
+    {
+        if (! $this->hasWaitlistInvitation()) {
+            return [];
+        }
+
+        return [
+            'nome' => $this->waitlistEntry->nome,
+            'form_data' => [
+                'sexo' => $this->waitlistEntry->sexo,
+                'telefone_campista' => $this->waitlistEntry->telefone,
+            ],
+        ];
     }
 }

--- a/app/Livewire/CampistaWaitlistForm.php
+++ b/app/Livewire/CampistaWaitlistForm.php
@@ -1,0 +1,221 @@
+<?php
+
+namespace App\Livewire;
+
+use App\Settings\GeneralSettings;
+use App\Support\CampistaRegistrationAvailability;
+use App\Support\Campistas\WaitlistManager;
+use App\Support\RegistrationAgeLimits;
+use Closure;
+use Filament\Actions\Action;
+use Filament\Actions\Concerns\InteractsWithActions;
+use Filament\Actions\Contracts\HasActions;
+use Filament\Forms\Components\Checkbox;
+use Filament\Forms\Components\Textarea;
+use Filament\Forms\Components\TextInput;
+use Filament\Forms\Components\ToggleButtons;
+use Filament\Forms\Concerns\InteractsWithForms;
+use Filament\Forms\Contracts\HasForms;
+use Filament\Notifications\Notification;
+use Filament\Schemas\Components\Grid;
+use Filament\Schemas\Components\Utilities\Get;
+use Filament\Schemas\Schema;
+use Filament\Support\Colors\Color;
+use Illuminate\Validation\ValidationException;
+use Livewire\Component;
+
+class CampistaWaitlistForm extends Component implements HasActions, HasForms
+{
+    use InteractsWithActions;
+    use InteractsWithForms;
+
+    public ?array $data = [];
+
+    public ?string $sex = null;
+
+    public ?int $generalPosition = null;
+
+    public ?int $sexPosition = null;
+
+    public function render()
+    {
+        return view('livewire.campista-waitlist-form');
+    }
+
+    public function mount(?string $sex = null): void
+    {
+        $this->sex = in_array($sex, ['M', 'F'], true) ? $sex : null;
+        $this->form->fill();
+    }
+
+    public function form(Schema $schema): Schema
+    {
+        return $schema
+            ->statePath('data')
+            ->components($this->waitlistSchema());
+    }
+
+    public function joinWaitlistAction(): Action
+    {
+        return Action::make('joinWaitlist')
+            ->label('Entrar na fila de espera')
+            ->icon('heroicon-o-queue-list')
+            ->color('warning')
+            ->modalHeading('Entrar na fila de espera')
+            ->modalDescription('Deixe seu contato para ser chamado caso uma vaga compatível seja liberada por desistência.')
+            ->modalSubmitActionLabel('Cadastrar na fila')
+            ->extraModalWindowAttributes(['class' => 'waitlist-entry-modal'], merge: true)
+            ->fillForm(fn (): array => $this->sex === null ? [] : ['sexo' => $this->sex])
+            ->schema($this->waitlistSchema())
+            ->action(fn (array $data): mixed => $this->createWaitlistEntry($data));
+    }
+
+    public function submit(): void
+    {
+        try {
+            $this->createWaitlistEntry($this->form->getState());
+            $this->form->fill();
+        } catch (ValidationException $exception) {
+            throw ValidationException::withMessages(
+                collect($exception->errors())
+                    ->mapWithKeys(fn (array $messages, string $field): array => ['data.'.$field => $messages])
+                    ->all(),
+            );
+        }
+    }
+
+    /**
+     * @return array<int, mixed>
+     */
+    private function waitlistSchema(): array
+    {
+        return [
+            Grid::make([
+                'default' => 1,
+                'md' => 2,
+            ])
+                ->schema([
+                    TextInput::make('nome')
+                        ->label('Nome completo')
+                        ->required()
+                        ->maxLength(255),
+
+                    TextInput::make('telefone')
+                        ->label('WhatsApp')
+                        ->required()
+                        ->mask('(99) 9 9999-9999')
+                        ->rules([
+                            fn (Get $get): Closure => function (string $attribute, mixed $value, Closure $fail) use ($get): void {
+                                $sex = $this->sex ?? $get('sexo');
+                                $normalizedPhone = app(WaitlistManager::class)->normalizePhone(is_string($value) ? $value : null);
+
+                                if ($normalizedPhone !== null && is_string($sex) && app(WaitlistManager::class)->hasActiveDuplicate($normalizedPhone, $sex)) {
+                                    $fail('Este telefone já está na fila de espera para o sexo selecionado.');
+                                }
+                            },
+                        ])
+                        ->maxLength(32),
+
+                    TextInput::make('email')
+                        ->label('E-mail')
+                        ->email()
+                        ->maxLength(255),
+
+                    TextInput::make('data_nascimento')
+                        ->label('Data de nascimento')
+                        ->mask('99/99/9999')
+                        ->rules([
+                            fn (): Closure => function (string $attribute, mixed $value, Closure $fail): void {
+                                $message = RegistrationAgeLimits::fromSettings(app(GeneralSettings::class))
+                                    ->violationMessage(is_string($value) ? $value : null);
+
+                                if ($message !== null) {
+                                    $fail($message);
+                                }
+                            },
+                        ])
+                        ->required(),
+
+                    ToggleButtons::make('sexo')
+                        ->label('Sexo da vaga')
+                        ->required()
+                        ->inline()
+                        ->options([
+                            'M' => 'Masculino',
+                            'F' => 'Feminino',
+                        ])
+                        ->colors([
+                            'M' => Color::Blue,
+                            'F' => Color::Pink,
+                        ])
+                        ->icons([
+                            'M' => 'eos-male',
+                            'F' => 'eos-female',
+                        ])
+                        ->default($this->sex)
+                        ->disableOptionWhen(fn (string $value): bool => $this->sex !== null && $value !== $this->sex)
+                        ->columnSpanFull(),
+
+                    Textarea::make('observacao')
+                        ->label('Observação')
+                        ->placeholder('Opcional')
+                        ->rows(3)
+                        ->maxLength(1000)
+                        ->columnSpanFull(),
+
+                    Checkbox::make('aceitar_politica_privacidade')
+                        ->label('Eu aceito a Política de Privacidade')
+                        ->accepted()
+                        ->required()
+                        ->columnSpanFull(),
+                ]),
+        ];
+    }
+
+    private function createWaitlistEntry(array $data): null
+    {
+        if ($this->sex !== null) {
+            $data['sexo'] = $this->sex;
+        }
+
+        $availability = CampistaRegistrationAvailability::fromSettings(app(GeneralSettings::class));
+
+        if ($availability->sexHasVacancy($data['sexo'] ?? null)) {
+            Notification::make()
+                ->title('Ainda há vaga disponível')
+                ->body('Você pode preencher a inscrição completa normalmente.')
+                ->warning()
+                ->send();
+
+            return null;
+        }
+
+        $ageLimitMessage = RegistrationAgeLimits::fromSettings(app(GeneralSettings::class))
+            ->violationMessage($data['data_nascimento'] ?? null);
+
+        if ($ageLimitMessage !== null) {
+            throw ValidationException::withMessages([
+                'data_nascimento' => $ageLimitMessage,
+            ]);
+        }
+
+        $entry = app(WaitlistManager::class)->createPublicEntry($data);
+
+        $this->generalPosition = app(WaitlistManager::class)->generalPosition($entry);
+        $this->sexPosition = app(WaitlistManager::class)->sexPosition($entry);
+
+        $this->form->fill();
+
+        Notification::make()
+            ->title('Você entrou na fila de espera')
+            ->body(sprintf(
+                'Sua posição geral é %s e sua posição por sexo é %s.',
+                $this->generalPosition,
+                $this->sexPosition,
+            ))
+            ->success()
+            ->send();
+
+        return null;
+    }
+}

--- a/app/Models/WaitlistEntry.php
+++ b/app/Models/WaitlistEntry.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace App\Models;
+
+use App\Enums\WaitlistEntryStatus;
+use Database\Factories\WaitlistEntryFactory;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class WaitlistEntry extends Model
+{
+    /** @use HasFactory<WaitlistEntryFactory> */
+    use HasFactory;
+
+    protected $fillable = [
+        'nome',
+        'telefone',
+        'telefone_normalizado',
+        'email',
+        'sexo',
+        'data_nascimento',
+        'observacao',
+        'status',
+        'accepted_privacy_at',
+        'admin_notes',
+        'invitation_token_hash',
+        'invitation_token_encrypted',
+        'invitation_generated_at',
+        'invitation_generated_by',
+        'invitation_expires_at',
+        'invitation_accepted_at',
+        'cancelled_at',
+        'cancelled_by',
+        'campista_id',
+    ];
+
+    protected $attributes = [
+        'status' => WaitlistEntryStatus::Aguardando->value,
+    ];
+
+    protected function casts(): array
+    {
+        return [
+            'status' => WaitlistEntryStatus::class,
+            'data_nascimento' => 'date',
+            'accepted_privacy_at' => 'datetime',
+            'invitation_generated_at' => 'datetime',
+            'invitation_expires_at' => 'datetime',
+            'invitation_accepted_at' => 'datetime',
+            'cancelled_at' => 'datetime',
+        ];
+    }
+
+    public function campista(): BelongsTo
+    {
+        return $this->belongsTo(Campista::class);
+    }
+
+    public function invitationGeneratedBy(): BelongsTo
+    {
+        return $this->belongsTo(User::class, 'invitation_generated_by');
+    }
+
+    public function cancelledBy(): BelongsTo
+    {
+        return $this->belongsTo(User::class, 'cancelled_by');
+    }
+}

--- a/app/Policies/WaitlistEntryPolicy.php
+++ b/app/Policies/WaitlistEntryPolicy.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace App\Policies;
+
+use App\Models\User;
+use App\Models\WaitlistEntry;
+
+class WaitlistEntryPolicy
+{
+    public function viewAny(User $user): bool
+    {
+        return $user->can('view_any_campista');
+    }
+
+    public function view(User $user, WaitlistEntry $waitlistEntry): bool
+    {
+        return $user->can('view_campista');
+    }
+
+    public function create(User $user): bool
+    {
+        return $user->can('create_campista');
+    }
+
+    public function update(User $user, WaitlistEntry $waitlistEntry): bool
+    {
+        return $user->can('update_campista');
+    }
+
+    public function delete(User $user, WaitlistEntry $waitlistEntry): bool
+    {
+        return $user->can('delete_campista');
+    }
+
+    public function deleteAny(User $user): bool
+    {
+        return $user->can('delete_any_campista');
+    }
+
+    public function generateInvitation(User $user, WaitlistEntry $waitlistEntry): bool
+    {
+        return $user->can('create_campista') && $user->can('update_campista');
+    }
+}

--- a/app/Settings/GeneralSettings.php
+++ b/app/Settings/GeneralSettings.php
@@ -24,6 +24,8 @@ class GeneralSettings extends Settings
 
     public ?int $qtd_max_vagas_masculino;
 
+    public int $waitlist_invitation_hours;
+
     public ?\DateTime $data_inicio_inscricoes;
 
     public ?\DateTime $data_final_inscricoes;

--- a/app/Support/CampistaRegistrationAvailability.php
+++ b/app/Support/CampistaRegistrationAvailability.php
@@ -6,6 +6,7 @@ use App\Enums\LiberacaoInscricoesStatusEnum;
 use App\Enums\StatusInscricao;
 use App\Models\Campista;
 use App\Settings\GeneralSettings;
+use App\Support\Campistas\WaitlistManager;
 use Carbon\CarbonImmutable;
 use DateTimeInterface;
 
@@ -24,6 +25,13 @@ class CampistaRegistrationAvailability
      * @var array<string, int>
      */
     private array $activeSexCounts = [];
+
+    private ?int $activeReservations = null;
+
+    /**
+     * @var array<string, int>
+     */
+    private array $activeSexReservations = [];
 
     /**
      * @param  array<string, mixed>  $settings
@@ -128,7 +136,7 @@ class CampistaRegistrationAvailability
             return null;
         }
 
-        return max(0, $capacity - $this->activeCount());
+        return max(0, $capacity - $this->activeCount() - $this->activeReservationCount());
     }
 
     public function activeRegistrations(): int
@@ -195,13 +203,27 @@ class CampistaRegistrationAvailability
 
     public function unavailableSexMessage(): ?string
     {
-        $labels = $this->unavailableSexLabels();
+        $labels = collect($this->unavailableSexes())
+            ->map(fn (string $sex): string => self::SEX_LABELS[$sex])
+            ->values()
+            ->all();
 
         if ($labels === []) {
             return null;
         }
 
         return 'Não há vagas disponíveis para o sexo '.$this->formatSexLabels($labels).'.';
+    }
+
+    /**
+     * @return array<int, string>
+     */
+    public function unavailableSexes(): array
+    {
+        return collect(array_keys(self::SEX_LABELS))
+            ->filter(fn (string $sex): bool => $this->sexLimitReached($sex))
+            ->values()
+            ->all();
     }
 
     public function unavailableSelectedSexMessage(?string $sex): string
@@ -221,26 +243,16 @@ class CampistaRegistrationAvailability
 
         $limit = $this->totalLimit();
 
-        return $limit !== null && $this->activeCount() >= $limit;
+        return ($limit !== null && ($this->activeCount() + $this->activeReservationCount()) >= $limit)
+            || app(WaitlistManager::class)->activeDemand() > 0;
     }
 
     public function sexLimitReached(string $sex): bool
     {
         $limit = $this->sexLimit($sex);
 
-        return $limit !== null && $this->activeCountForSex($sex) >= $limit;
-    }
-
-    /**
-     * @return array<int, string>
-     */
-    private function unavailableSexLabels(): array
-    {
-        return collect(array_keys(self::SEX_LABELS))
-            ->filter(fn (string $sex): bool => $this->sexLimitReached($sex))
-            ->map(fn (string $sex): string => self::SEX_LABELS[$sex])
-            ->values()
-            ->all();
+        return ($limit !== null && ($this->activeCountForSex($sex) + $this->activeReservationCountForSex($sex)) >= $limit)
+            || app(WaitlistManager::class)->activeDemandForSex($sex) > 0;
     }
 
     private function activeCount(): int
@@ -261,6 +273,20 @@ class CampistaRegistrationAvailability
             ->get(['form_data'])
             ->filter(fn (Campista $campista): bool => data_get($campista->form_data, 'sexo') === $sex)
             ->count();
+    }
+
+    private function activeReservationCount(): int
+    {
+        return $this->activeReservations ??= app(WaitlistManager::class)->activeReservations();
+    }
+
+    private function activeReservationCountForSex(string $sex): int
+    {
+        if (array_key_exists($sex, $this->activeSexReservations)) {
+            return $this->activeSexReservations[$sex];
+        }
+
+        return $this->activeSexReservations[$sex] = app(WaitlistManager::class)->activeReservationsForSex($sex);
     }
 
     private function manualStatus(): LiberacaoInscricoesStatusEnum

--- a/app/Support/Campistas/WaitlistManager.php
+++ b/app/Support/Campistas/WaitlistManager.php
@@ -1,0 +1,334 @@
+<?php
+
+namespace App\Support\Campistas;
+
+use App\Enums\StatusInscricao;
+use App\Enums\WaitlistEntryStatus;
+use App\Models\Campista;
+use App\Models\User;
+use App\Models\WaitlistEntry;
+use App\Settings\GeneralSettings;
+use App\Support\AtendenteWhatsapp;
+use Carbon\CarbonImmutable;
+use Illuminate\Support\Facades\Crypt;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\URL;
+use Illuminate\Support\Str;
+use Illuminate\Validation\ValidationException;
+
+class WaitlistManager
+{
+    /**
+     * @return array<int, string>
+     */
+    public function activeStatuses(): array
+    {
+        return [
+            WaitlistEntryStatus::Aguardando->value,
+            WaitlistEntryStatus::Convocado->value,
+        ];
+    }
+
+    public function normalizePhone(?string $phone): ?string
+    {
+        return AtendenteWhatsapp::number($phone);
+    }
+
+    public function activeDemandForSex(string $sex): int
+    {
+        return $this->activeQueueQuery()
+            ->where('sexo', $sex)
+            ->count();
+    }
+
+    public function activeDemand(): int
+    {
+        return $this->activeQueueQuery()->count();
+    }
+
+    public function activeReservationsForSex(string $sex, ?WaitlistEntry $excluding = null): int
+    {
+        return $this->activeReservationQuery()
+            ->where('sexo', $sex)
+            ->when($excluding !== null, fn ($query) => $query->whereKeyNot($excluding->getKey()))
+            ->count();
+    }
+
+    public function activeReservations(?WaitlistEntry $excluding = null): int
+    {
+        return $this->activeReservationQuery()
+            ->when($excluding !== null, fn ($query) => $query->whereKeyNot($excluding->getKey()))
+            ->count();
+    }
+
+    public function generalPosition(WaitlistEntry $entry): ?int
+    {
+        if (! $this->isActiveQueueEntry($entry)) {
+            return null;
+        }
+
+        return $this->activeQueueQuery()
+            ->where(function ($query) use ($entry): void {
+                $query
+                    ->where('created_at', '<', $entry->created_at)
+                    ->orWhere(function ($query) use ($entry): void {
+                        $query
+                            ->where('created_at', $entry->created_at)
+                            ->where('id', '<=', $entry->id);
+                    });
+            })
+            ->count();
+    }
+
+    public function sexPosition(WaitlistEntry $entry): ?int
+    {
+        if (! $this->isActiveQueueEntry($entry)) {
+            return null;
+        }
+
+        return $this->activeQueueQuery()
+            ->where('sexo', $entry->sexo)
+            ->where(function ($query) use ($entry): void {
+                $query
+                    ->where('created_at', '<', $entry->created_at)
+                    ->orWhere(function ($query) use ($entry): void {
+                        $query
+                            ->where('created_at', $entry->created_at)
+                            ->where('id', '<=', $entry->id);
+                    });
+            })
+            ->count();
+    }
+
+    public function createPublicEntry(array $data): WaitlistEntry
+    {
+        $normalizedPhone = $this->normalizePhone($data['telefone'] ?? null);
+
+        if ($normalizedPhone !== null && $this->hasActiveDuplicate($normalizedPhone, (string) $data['sexo'])) {
+            throw ValidationException::withMessages([
+                'telefone' => 'Este telefone já está na fila de espera para o sexo selecionado.',
+            ]);
+        }
+
+        return WaitlistEntry::query()->create([
+            'nome' => trim((string) $data['nome']),
+            'telefone' => (string) $data['telefone'],
+            'telefone_normalizado' => $normalizedPhone,
+            'email' => filled($data['email'] ?? null) ? trim((string) $data['email']) : null,
+            'sexo' => (string) $data['sexo'],
+            'data_nascimento' => $this->birthDate($data['data_nascimento'] ?? null),
+            'observacao' => filled($data['observacao'] ?? null) ? trim((string) $data['observacao']) : null,
+            'status' => WaitlistEntryStatus::Aguardando,
+            'accepted_privacy_at' => now(),
+        ]);
+    }
+
+    public function generateInvitation(WaitlistEntry $entry, User $user): string
+    {
+        return DB::transaction(function () use ($entry, $user): string {
+            $entry->refresh();
+
+            if (! $this->canGenerateInvitation($entry)) {
+                throw ValidationException::withMessages([
+                    'waitlist' => 'Esta pessoa não pode ser convocada no status atual.',
+                ]);
+            }
+
+            if (! $this->hasVacancyForInvitation($entry)) {
+                throw ValidationException::withMessages([
+                    'waitlist' => 'Não há vaga disponível para este sexo no momento.',
+                ]);
+            }
+
+            $token = Str::random(64);
+            $expiresAt = now()->addHours($this->invitationHours());
+
+            $entry->forceFill([
+                'status' => WaitlistEntryStatus::Convocado,
+                'invitation_token_hash' => hash('sha256', $token),
+                'invitation_token_encrypted' => Crypt::encryptString($token),
+                'invitation_generated_at' => now(),
+                'invitation_generated_by' => $user->getKey(),
+                'invitation_expires_at' => $expiresAt,
+            ])->save();
+
+            return $this->invitationUrl($entry->fresh(), $token);
+        });
+    }
+
+    public function invitationUrl(WaitlistEntry $entry, ?string $token = null): string
+    {
+        $token ??= Crypt::decryptString((string) $entry->invitation_token_encrypted);
+
+        return URL::temporarySignedRoute(
+            'waitlist.invitation.show',
+            $entry->invitation_expires_at ?? now()->addHours($this->invitationHours()),
+            [
+                'waitlistEntry' => $entry,
+                'token' => $token,
+            ],
+        );
+    }
+
+    public function whatsappUrl(WaitlistEntry $entry): ?string
+    {
+        if (blank($entry->telefone_normalizado) || blank($entry->invitation_token_encrypted)) {
+            return null;
+        }
+
+        $message = sprintf(
+            'Olá %s! Surgiu uma vaga para o Acampamento Juvenil. Complete sua inscrição pelo link: %s',
+            $entry->nome,
+            $this->invitationUrl($entry),
+        );
+
+        return 'https://wa.me/'.$entry->telefone_normalizado.'?text='.rawurlencode($message);
+    }
+
+    public function invitationCanBeUsed(WaitlistEntry $entry, string $token): bool
+    {
+        return $entry->status === WaitlistEntryStatus::Convocado
+            && filled($entry->invitation_token_hash)
+            && hash_equals((string) $entry->invitation_token_hash, hash('sha256', $token))
+            && $entry->invitation_expires_at !== null
+            && $entry->invitation_expires_at->isFuture();
+    }
+
+    public function markInscribed(WaitlistEntry $entry, Campista $campista): void
+    {
+        $entry->forceFill([
+            'status' => WaitlistEntryStatus::Inscrito,
+            'campista_id' => $campista->getKey(),
+            'invitation_accepted_at' => now(),
+        ])->save();
+    }
+
+    public function expireOverdueInvitations(): void
+    {
+        WaitlistEntry::query()
+            ->where('status', WaitlistEntryStatus::Convocado->value)
+            ->whereNotNull('invitation_expires_at')
+            ->where('invitation_expires_at', '<=', now())
+            ->update(['status' => WaitlistEntryStatus::Expirado->value]);
+    }
+
+    public function hasActiveDuplicate(string $normalizedPhone, string $sex): bool
+    {
+        return $this->activeQueueQuery()
+            ->where('telefone_normalizado', $normalizedPhone)
+            ->where('sexo', $sex)
+            ->exists();
+    }
+
+    public function canGenerateInvitation(WaitlistEntry $entry): bool
+    {
+        return in_array($entry->status, [WaitlistEntryStatus::Aguardando, WaitlistEntryStatus::Expirado], true);
+    }
+
+    public function hasVacancyForInvitation(WaitlistEntry $entry): bool
+    {
+        $settings = app(GeneralSettings::class)->toArray();
+        $sex = (string) $entry->sexo;
+
+        if ($this->hasSexSpecificLimits($settings)) {
+            $limit = $this->limit($settings['qtd_max_vagas_'.$this->sexSettingSuffix($sex)] ?? null);
+
+            if ($limit === null) {
+                return true;
+            }
+
+            return ($this->activeCampistaCountForSex($sex) + $this->activeReservationsForSex($sex, $entry)) < $limit;
+        }
+
+        $limit = $this->limit($settings['qtd_max_vagas'] ?? null);
+
+        if ($limit === null) {
+            return true;
+        }
+
+        return ($this->activeCampistaCount() + $this->activeReservations($entry)) < $limit;
+    }
+
+    private function activeQueueQuery()
+    {
+        return WaitlistEntry::query()
+            ->where(function ($query): void {
+                $query
+                    ->where('status', WaitlistEntryStatus::Aguardando->value)
+                    ->orWhere(function ($query): void {
+                        $query
+                            ->where('status', WaitlistEntryStatus::Convocado->value)
+                            ->where('invitation_expires_at', '>', now());
+                    });
+            });
+    }
+
+    private function activeReservationQuery()
+    {
+        return WaitlistEntry::query()
+            ->where('status', WaitlistEntryStatus::Convocado->value)
+            ->where('invitation_expires_at', '>', now());
+    }
+
+    private function isActiveQueueEntry(WaitlistEntry $entry): bool
+    {
+        return $entry->status === WaitlistEntryStatus::Aguardando
+            || ($entry->status === WaitlistEntryStatus::Convocado && $entry->invitation_expires_at?->isFuture());
+    }
+
+    private function invitationHours(): int
+    {
+        return max(1, (int) (app(GeneralSettings::class)->waitlist_invitation_hours ?? 24));
+    }
+
+    private function activeCampistaCount(): int
+    {
+        return Campista::query()
+            ->where('status', '<>', StatusInscricao::Cancelado->value)
+            ->count();
+    }
+
+    private function activeCampistaCountForSex(string $sex): int
+    {
+        return Campista::query()
+            ->where('status', '<>', StatusInscricao::Cancelado->value)
+            ->where('form_data->sexo', $sex)
+            ->count();
+    }
+
+    /**
+     * @param  array<string, mixed>  $settings
+     */
+    private function hasSexSpecificLimits(array $settings): bool
+    {
+        return $this->limit($settings['qtd_max_vagas_masculino'] ?? null) !== null
+            || $this->limit($settings['qtd_max_vagas_feminino'] ?? null) !== null;
+    }
+
+    private function sexSettingSuffix(string $sex): string
+    {
+        return $sex === 'M' ? 'masculino' : 'feminino';
+    }
+
+    private function limit(mixed $value): ?int
+    {
+        if ($value === null || $value === '') {
+            return null;
+        }
+
+        $limit = (int) $value;
+
+        return $limit > 0 ? $limit : null;
+    }
+
+    private function birthDate(mixed $value): ?string
+    {
+        if (! is_string($value) || blank($value)) {
+            return null;
+        }
+
+        $date = CarbonImmutable::createFromFormat('d/m/Y', $value);
+
+        return $date instanceof CarbonImmutable ? $date->toDateString() : null;
+    }
+}

--- a/database/factories/WaitlistEntryFactory.php
+++ b/database/factories/WaitlistEntryFactory.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Enums\WaitlistEntryStatus;
+use App\Models\WaitlistEntry;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<WaitlistEntry>
+ */
+class WaitlistEntryFactory extends Factory
+{
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            'nome' => fake()->name(),
+            'telefone' => '(47) 9 '.fake()->numerify('####-####'),
+            'telefone_normalizado' => '55479'.fake()->numerify('########'),
+            'email' => fake()->safeEmail(),
+            'sexo' => fake()->randomElement(['M', 'F']),
+            'data_nascimento' => fake()->dateTimeBetween('-18 years', '-12 years')->format('Y-m-d'),
+            'observacao' => null,
+            'status' => WaitlistEntryStatus::Aguardando,
+            'accepted_privacy_at' => now(),
+        ];
+    }
+}

--- a/database/migrations/2026_06_30_221625_update_lancamento_items_registration_unique_index.php
+++ b/database/migrations/2026_06_30_221625_update_lancamento_items_registration_unique_index.php
@@ -12,6 +12,10 @@ return new class extends Migration
     public function up(): void
     {
         Schema::table('lancamento_items', function (Blueprint $table): void {
+            $table->index('lancamento_id', 'lancamento_items_lancamento_id_index');
+        });
+
+        Schema::table('lancamento_items', function (Blueprint $table): void {
             $table->dropUnique('lancamento_items_registration_unique');
 
             $table->unique([
@@ -21,6 +25,10 @@ return new class extends Migration
                 'categoria_lancamento_id',
             ], 'lancamento_items_registration_category_unique');
         });
+
+        Schema::table('lancamento_items', function (Blueprint $table): void {
+            $table->dropIndex('lancamento_items_lancamento_id_index');
+        });
     }
 
     /**
@@ -29,13 +37,15 @@ return new class extends Migration
     public function down(): void
     {
         Schema::table('lancamento_items', function (Blueprint $table): void {
-            $table->dropUnique('lancamento_items_registration_category_unique');
-
             $table->unique([
                 'lancamento_id',
                 'registration_type',
                 'registration_id',
             ], 'lancamento_items_registration_unique');
+        });
+
+        Schema::table('lancamento_items', function (Blueprint $table): void {
+            $table->dropUnique('lancamento_items_registration_category_unique');
         });
     }
 };

--- a/database/migrations/2026_06_30_225358_create_waitlist_entries_table.php
+++ b/database/migrations/2026_06_30_225358_create_waitlist_entries_table.php
@@ -1,0 +1,60 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('waitlist_entries', function (Blueprint $table): void {
+            $table->id();
+            $table->string('nome');
+            $table->string('telefone', 32);
+            $table->string('telefone_normalizado', 32)->nullable();
+            $table->string('email')->nullable();
+            $table->char('sexo', 1);
+            $table->date('data_nascimento')->nullable();
+            $table->text('observacao')->nullable();
+            $table->string('status', 24)->default('aguardando');
+            $table->timestamp('accepted_privacy_at')->nullable();
+            $table->text('admin_notes')->nullable();
+            $table->string('invitation_token_hash', 64)->nullable()->unique();
+            $table->text('invitation_token_encrypted')->nullable();
+            $table->timestamp('invitation_generated_at')->nullable();
+            $table->foreignId('invitation_generated_by')
+                ->nullable()
+                ->constrained('users')
+                ->nullOnDelete();
+            $table->timestamp('invitation_expires_at')->nullable();
+            $table->timestamp('invitation_accepted_at')->nullable();
+            $table->timestamp('cancelled_at')->nullable();
+            $table->foreignId('cancelled_by')
+                ->nullable()
+                ->constrained('users')
+                ->nullOnDelete();
+            $table->foreignId('campista_id')
+                ->nullable()
+                ->constrained('campistas')
+                ->nullOnDelete();
+            $table->timestamps();
+
+            $table->index(['status', 'sexo', 'created_at']);
+            $table->index(['sexo', 'created_at']);
+            $table->index('telefone_normalizado');
+            $table->index('invitation_expires_at');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('waitlist_entries');
+    }
+};

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -24,6 +24,7 @@ class DatabaseSeeder extends Seeder
                 UserSeeder::class,
                 TriboSeeder::class,
                 CampistaSeeder::class,
+                WaitlistEntrySeeder::class,
                 EquipeTrabalhoSeeder::class,
                 LancamentoSeeder::class,
             ]);

--- a/database/seeders/WaitlistEntrySeeder.php
+++ b/database/seeders/WaitlistEntrySeeder.php
@@ -1,0 +1,214 @@
+<?php
+
+namespace Database\Seeders;
+
+use App\Enums\StatusInscricao;
+use App\Enums\WaitlistEntryStatus;
+use App\Models\Campista;
+use App\Models\User;
+use App\Models\WaitlistEntry;
+use App\Support\Campistas\WaitlistManager;
+use Database\Seeders\Support\DemoRegistrationData;
+use Illuminate\Database\Seeder;
+use Illuminate\Support\Facades\Crypt;
+use Illuminate\Support\Str;
+
+class WaitlistEntrySeeder extends Seeder
+{
+    private const DEMO_NOTE = 'Dados demonstrativos da fila de espera para testes e painel operacional.';
+
+    /**
+     * Run the database seeds.
+     */
+    public function run(): void
+    {
+        $manager = app(WaitlistManager::class);
+        $admin = $this->adminUser();
+
+        WaitlistEntry::query()
+            ->where('admin_notes', self::DEMO_NOTE)
+            ->orWhere('observacao', self::DEMO_NOTE)
+            ->delete();
+
+        $this->createWaitingEntries($manager);
+        $this->createInvitedEntry($manager, $admin);
+        $this->createExpiredEntry($manager, $admin);
+        $this->createInscribedEntry($manager, $admin);
+        $this->createInactiveEntries($manager, $admin);
+    }
+
+    private function createWaitingEntries(WaitlistManager $manager): void
+    {
+        foreach (range(1, 6) as $index) {
+            $entry = $manager->createPublicEntry([
+                'nome' => sprintf('Fila %s %03d', $index % 2 === 0 ? 'Masculina' : 'Feminina', $index),
+                'telefone' => $this->phone($index),
+                'email' => sprintf('fila%03d@example.com', $index),
+                'sexo' => $index % 2 === 0 ? 'M' : 'F',
+                'data_nascimento' => now()->subYears(14 + ($index % 4))->format('d/m/Y'),
+                'observacao' => self::DEMO_NOTE,
+            ]);
+
+            $entry->forceFill([
+                'admin_notes' => self::DEMO_NOTE,
+                'created_at' => now()->subDays(12 - $index),
+                'updated_at' => now()->subDays(12 - $index),
+            ])->save();
+        }
+    }
+
+    private function createInvitedEntry(WaitlistManager $manager, User $admin): void
+    {
+        $entry = $manager->createPublicEntry([
+            'nome' => 'Fila Convocada 001',
+            'telefone' => $this->phone(20),
+            'email' => 'fila-convocada@example.com',
+            'sexo' => 'F',
+            'data_nascimento' => now()->subYears(15)->format('d/m/Y'),
+            'observacao' => self::DEMO_NOTE,
+        ]);
+
+        $this->applyInvitationState(
+            entry: $entry,
+            admin: $admin,
+            status: WaitlistEntryStatus::Convocado,
+            expiresAt: now()->addHours(18),
+            generatedAt: now()->subHours(6),
+        );
+    }
+
+    private function createExpiredEntry(WaitlistManager $manager, User $admin): void
+    {
+        $entry = $manager->createPublicEntry([
+            'nome' => 'Fila Expirada 001',
+            'telefone' => $this->phone(21),
+            'email' => 'fila-expirada@example.com',
+            'sexo' => 'M',
+            'data_nascimento' => now()->subYears(16)->format('d/m/Y'),
+            'observacao' => self::DEMO_NOTE,
+        ]);
+
+        $this->applyInvitationState(
+            entry: $entry,
+            admin: $admin,
+            status: WaitlistEntryStatus::Expirado,
+            expiresAt: now()->subDay(),
+            generatedAt: now()->subDays(2),
+        );
+    }
+
+    private function createInscribedEntry(WaitlistManager $manager, User $admin): void
+    {
+        $entry = $manager->createPublicEntry([
+            'nome' => 'Fila Inscrita 001',
+            'telefone' => $this->phone(22),
+            'email' => 'fila-inscrita@example.com',
+            'sexo' => 'F',
+            'data_nascimento' => now()->subYears(15)->format('d/m/Y'),
+            'observacao' => self::DEMO_NOTE,
+        ]);
+
+        $campista = Campista::query()
+            ->where('observacoes', DemoRegistrationData::DEMO_OBSERVATION)
+            ->where('status', '<>', StatusInscricao::Cancelado->value)
+            ->where('form_data->sexo', 'F')
+            ->orderBy('id')
+            ->first();
+
+        $campista ??= Campista::factory()->create([
+            'nome' => $entry->nome,
+            'status' => StatusInscricao::Pago->value,
+            'observacoes' => DemoRegistrationData::DEMO_OBSERVATION,
+            'tribo_id' => null,
+            'user_id' => null,
+            'form_data' => array_replace(
+                Campista::factory()->make()->form_data ?? [],
+                [
+                    'sexo' => 'F',
+                    'telefone_campista' => $entry->telefone,
+                    'aceitar_politica_privacidade' => true,
+                ],
+            ),
+        ]);
+
+        $this->applyInvitationState(
+            entry: $entry,
+            admin: $admin,
+            status: WaitlistEntryStatus::Convocado,
+            expiresAt: now()->addHours(12),
+            generatedAt: now()->subHours(2),
+        );
+
+        $manager->markInscribed($entry->fresh(), $campista);
+
+        $entry->fresh()->forceFill([
+            'admin_notes' => self::DEMO_NOTE,
+            'updated_at' => now()->subHour(),
+        ])->save();
+    }
+
+    private function createInactiveEntries(WaitlistManager $manager, User $admin): void
+    {
+        foreach ([
+            ['status' => WaitlistEntryStatus::Desistiu, 'name' => 'Fila Desistente 001', 'sex' => 'M', 'phone' => 23],
+            ['status' => WaitlistEntryStatus::Cancelado, 'name' => 'Fila Cancelada 001', 'sex' => 'F', 'phone' => 24],
+        ] as $data) {
+            $entry = $manager->createPublicEntry([
+                'nome' => $data['name'],
+                'telefone' => $this->phone($data['phone']),
+                'email' => sprintf('fila-%s@example.com', Str::slug($data['name'])),
+                'sexo' => $data['sex'],
+                'data_nascimento' => now()->subYears(15)->format('d/m/Y'),
+                'observacao' => self::DEMO_NOTE,
+            ]);
+
+            $entry->forceFill([
+                'status' => $data['status'],
+                'admin_notes' => self::DEMO_NOTE,
+                'cancelled_at' => now()->subDays(3),
+                'cancelled_by' => $admin->getKey(),
+                'updated_at' => now()->subDays(3),
+            ])->save();
+        }
+    }
+
+    private function applyInvitationState(
+        WaitlistEntry $entry,
+        User $admin,
+        WaitlistEntryStatus $status,
+        mixed $expiresAt,
+        mixed $generatedAt,
+    ): void {
+        $token = Str::random(64);
+
+        $entry->forceFill([
+            'status' => $status,
+            'admin_notes' => self::DEMO_NOTE,
+            'invitation_token_hash' => hash('sha256', $token),
+            'invitation_token_encrypted' => Crypt::encryptString($token),
+            'invitation_generated_at' => $generatedAt,
+            'invitation_generated_by' => $admin->getKey(),
+            'invitation_expires_at' => $expiresAt,
+            'updated_at' => $generatedAt,
+        ])->save();
+    }
+
+    private function adminUser(): User
+    {
+        return User::query()
+            ->where('email', 'admin@admin.com')
+            ->orWhereHas('roles', fn ($query) => $query->where('name', 'Super Administrador'))
+            ->orderBy('id')
+            ->first()
+            ?? User::factory()->create([
+                'name' => 'Admin',
+                'email' => 'admin@admin.com',
+                'password' => bcrypt('admin'),
+            ]);
+    }
+
+    private function phone(int $index): string
+    {
+        return sprintf('(47) 9 %04d-%04d', 2000 + $index, 3000 + $index);
+    }
+}

--- a/database/settings/2026_06_30_225412_add_waitlist_invitation_hours_to_general_settings.php
+++ b/database/settings/2026_06_30_225412_add_waitlist_invitation_hours_to_general_settings.php
@@ -1,0 +1,21 @@
+<?php
+
+use Spatie\LaravelSettings\Migrations\SettingsBlueprint;
+use Spatie\LaravelSettings\Migrations\SettingsMigration;
+
+return new class extends SettingsMigration
+{
+    public function up(): void
+    {
+        $this->migrator->inGroup('general', function (SettingsBlueprint $blueprint): void {
+            $blueprint->add('waitlist_invitation_hours', 24);
+        });
+    }
+
+    public function down(): void
+    {
+        $this->migrator->inGroup('general', function (SettingsBlueprint $blueprint): void {
+            $blueprint->delete('waitlist_invitation_hours');
+        });
+    }
+};

--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -54,6 +54,24 @@
     overscroll-behavior: contain;
 }
 
+@media (max-width: 1023px) {
+    body.has-mobile-bottom-nav .fi-modal:not(.fi-modal-slide-over) > .fi-modal-window-ctn {
+        top: 0;
+        bottom: var(--juvenil-mobile-bottom-nav-space);
+        min-height: 0;
+        grid-template-rows: minmax(0.75rem, 1fr) auto minmax(0.75rem, 1fr);
+        padding: 0.75rem 1rem;
+    }
+
+    body.has-mobile-bottom-nav .fi-modal:not(.fi-modal-slide-over) > .fi-modal-window-ctn > .fi-modal-window.waitlist-entry-modal {
+        max-height: calc(100dvh - var(--juvenil-mobile-bottom-nav-space) - 1.5rem);
+    }
+
+    body.has-mobile-bottom-nav .fi-modal:not(.fi-modal-slide-over) > .fi-modal-window-ctn > .fi-modal-window.waitlist-entry-modal > .fi-modal-content {
+        padding-bottom: calc(1.25rem + env(safe-area-inset-bottom));
+    }
+}
+
 body:has(.fi-modal.fi-modal-open) :is([data-motion-card], .out, .filament-registration-shell, .fi-section, .fi-ta, .fi-wi-stats-overview-stat, .fi-in-entry-wrp) {
     transform: none !important;
     filter: none;
@@ -634,7 +652,9 @@ body.is-loading {
 
 @media (max-width: 1023px) {
     body.has-mobile-bottom-nav {
-        padding-bottom: calc(5.9rem + env(safe-area-inset-bottom));
+        --juvenil-mobile-bottom-nav-space: calc(5.9rem + env(safe-area-inset-bottom));
+
+        padding-bottom: var(--juvenil-mobile-bottom-nav-space);
     }
 }
 
@@ -730,7 +750,7 @@ html.gsap-scrolling body {
 
 @media (max-width: 1023px) {
     body.has-mobile-bottom-nav .js-cookie-consent {
-        bottom: calc(6.25rem + env(safe-area-inset-bottom)) !important;
+        bottom: var(--juvenil-mobile-bottom-nav-space) !important;
     }
 }
 

--- a/resources/views/livewire/campista-form.blade.php
+++ b/resources/views/livewire/campista-form.blade.php
@@ -21,7 +21,10 @@
     $registrationEndedByDate = $registrationStatus === App\Enums\LiberacaoInscricoesStatusEnum::LIBERADO
         && $registrationAvailability->registrationEnded();
     $registrationOpen = $registrationAvailability->registrationOpen();
+    $hasWaitlistInvitation = $this->hasWaitlistInvitation();
     $unavailableSexMessage = $registrationAvailability->unavailableSexMessage();
+    $unavailableSexes = $registrationAvailability->unavailableSexes();
+    $waitlistSex = count($unavailableSexes) === 1 ? $unavailableSexes[0] : null;
 @endphp
 
 <div>
@@ -159,7 +162,7 @@
                     </div>
                 </div>
             </section>
-        @elseif($registrationClosedByCapacity)
+        @elseif($registrationClosedByCapacity && ! $hasWaitlistInvitation)
             <section class="relative flex min-h-[34rem] flex-col items-center justify-center bg-[#052f35] p-6 text-white sm:p-10">
                 <div class="mx-auto max-w-screen-md text-center lg:px-2">
                     <p class="mb-0 text-2xl font-black uppercase tracking-[0.16em] text-[#f46b12]">Inscrições encerradas</p>
@@ -167,6 +170,7 @@
                     <p class="mx-4 mt-4 text-center text-sm text-[#d8f2fa] xl:text-xl">
                         As inscrições foram encerradas pelo número de vagas preenchidas.
                     </p>
+                    @livewire('campista-waitlist-form', ['sex' => $waitlistSex])
                     <div class="mt-10 flex justify-center">
                         <figure class="flex items-center justify-center rounded">
                             <img src="{{ asset('img/Campfire-bro.svg') }}" alt="" class="h-80 w-full rounded-2xl animate-spin-slow">
@@ -174,51 +178,60 @@
                     </div>
                 </div>
             </section>
-        @elseif($registrationOpen)
-            <form wire:submit.prevent="submitForm" class="space-y-6">
-                <div class="border border-[#9ddbef]/25 bg-[#052f35] p-4 text-[#d8f2fa]" data-registration-slots>
-                    <p class="text-sm font-black uppercase tracking-[0.14em] text-[#f46b12]">Inscrições abertas</p>
-                    @if($registrationAvailability->endsAtDisplay())
-                        <p class="mt-2 text-2xl font-black uppercase tracking-normal text-white">Falta para encerrar</p>
-                        <p class="mt-1 text-sm font-semibold text-[#9ddbef]">
-                            As inscrições encerram em {{ $registrationAvailability->endsAtDisplay() }}.
-                        </p>
-                        <div
-                            class="mt-5 grid grid-cols-2 gap-3 sm:grid-cols-4"
-                            data-registration-countdown
-                            data-target="{{ $registrationAvailability->endsAtIso() }}"
-                        >
-                            <div class="border border-[#9ddbef]/25 bg-[#03272c]/80 p-3 text-center">
-                                <span class="block text-3xl font-black text-[#f46b12]" data-countdown-days>--</span>
-                                <span class="mt-1 block text-[0.68rem] font-black uppercase tracking-[0.16em] text-[#9ddbef]">Dias</span>
+        @elseif($registrationOpen || $hasWaitlistInvitation)
+            <form
+                wire:submit.prevent="submitForm"
+                @class([
+                    'space-y-6',
+                    'light filament-registration-shell mx-auto max-w-5xl bg-white p-4 text-gray-950 shadow-[0_28px_90px_rgba(0,0,0,0.32)] ring-1 ring-[#f46b12]/35 sm:p-6 lg:p-8' => $hasWaitlistInvitation,
+                ])
+            >
+                @unless($hasWaitlistInvitation)
+                    <div class="border border-[#9ddbef]/25 bg-[#052f35] p-4 text-[#d8f2fa]" data-registration-slots>
+                        <p class="text-sm font-black uppercase tracking-[0.14em] text-[#f46b12]">Inscrições abertas</p>
+                        @if($registrationAvailability->endsAtDisplay())
+                            <p class="mt-2 text-2xl font-black uppercase tracking-normal text-white">Falta para encerrar</p>
+                            <p class="mt-1 text-sm font-semibold text-[#9ddbef]">
+                                As inscrições encerram em {{ $registrationAvailability->endsAtDisplay() }}.
+                            </p>
+                            <div
+                                class="mt-5 grid grid-cols-2 gap-3 sm:grid-cols-4"
+                                data-registration-countdown
+                                data-target="{{ $registrationAvailability->endsAtIso() }}"
+                            >
+                                <div class="border border-[#9ddbef]/25 bg-[#03272c]/80 p-3 text-center">
+                                    <span class="block text-3xl font-black text-[#f46b12]" data-countdown-days>--</span>
+                                    <span class="mt-1 block text-[0.68rem] font-black uppercase tracking-[0.16em] text-[#9ddbef]">Dias</span>
+                                </div>
+                                <div class="border border-[#9ddbef]/25 bg-[#03272c]/80 p-3 text-center">
+                                    <span class="block text-3xl font-black text-[#f46b12]" data-countdown-hours>--</span>
+                                    <span class="mt-1 block text-[0.68rem] font-black uppercase tracking-[0.16em] text-[#9ddbef]">Horas</span>
+                                </div>
+                                <div class="border border-[#9ddbef]/25 bg-[#03272c]/80 p-3 text-center">
+                                    <span class="block text-3xl font-black text-[#f46b12]" data-countdown-minutes>--</span>
+                                    <span class="mt-1 block text-[0.68rem] font-black uppercase tracking-[0.16em] text-[#9ddbef]">Minutos</span>
+                                </div>
+                                <div class="border border-[#9ddbef]/25 bg-[#03272c]/80 p-3 text-center">
+                                    <span class="block text-3xl font-black text-[#f46b12]" data-countdown-seconds>--</span>
+                                    <span class="mt-1 block text-[0.68rem] font-black uppercase tracking-[0.16em] text-[#9ddbef]">Segundos</span>
+                                </div>
                             </div>
-                            <div class="border border-[#9ddbef]/25 bg-[#03272c]/80 p-3 text-center">
-                                <span class="block text-3xl font-black text-[#f46b12]" data-countdown-hours>--</span>
-                                <span class="mt-1 block text-[0.68rem] font-black uppercase tracking-[0.16em] text-[#9ddbef]">Horas</span>
-                            </div>
-                            <div class="border border-[#9ddbef]/25 bg-[#03272c]/80 p-3 text-center">
-                                <span class="block text-3xl font-black text-[#f46b12]" data-countdown-minutes>--</span>
-                                <span class="mt-1 block text-[0.68rem] font-black uppercase tracking-[0.16em] text-[#9ddbef]">Minutos</span>
-                            </div>
-                            <div class="border border-[#9ddbef]/25 bg-[#03272c]/80 p-3 text-center">
-                                <span class="block text-3xl font-black text-[#f46b12]" data-countdown-seconds>--</span>
-                                <span class="mt-1 block text-[0.68rem] font-black uppercase tracking-[0.16em] text-[#9ddbef]">Segundos</span>
-                            </div>
-                        </div>
-                    @else
-                        <p class="mt-2 text-2xl font-black uppercase tracking-normal text-white">Inscrições abertas</p>
-                    @endif
-                    @if($registrationAvailability->availableSlotsMessage())
-                        <p class="mt-2 text-sm font-semibold text-[#9ddbef]">
-                            {{ $registrationAvailability->availableSlotsMessage() }} · {{ $registrationAvailability->activeRegistrationsMessage() }}
-                        </p>
-                    @endif
-                </div>
+                        @else
+                            <p class="mt-2 text-2xl font-black uppercase tracking-normal text-white">Inscrições abertas</p>
+                        @endif
+                        @if($registrationAvailability->availableSlotsMessage())
+                            <p class="mt-2 text-sm font-semibold text-[#9ddbef]">
+                                {{ $registrationAvailability->availableSlotsMessage() }} · {{ $registrationAvailability->activeRegistrationsMessage() }}
+                            </p>
+                        @endif
+                    </div>
+                @endunless
 
-                @if($unavailableSexMessage)
-                    <div class="border border-[#f46b12]/45 bg-[#f46b12]/10 p-4 text-[#d8f2fa]" role="alert">
+                @if(! $hasWaitlistInvitation && $unavailableSexMessage)
+                    <div class="border border-[#f46b12]/45 bg-[#f46b12]/10 p-4 text-[#052f35]" role="alert">
                         <p class="text-sm font-black uppercase tracking-[0.14em] text-[#f46b12]">Vagas indisponíveis</p>
                         <p class="mt-2 text-sm font-semibold">{{ $unavailableSexMessage }}</p>
+                        @livewire('campista-waitlist-form', ['sex' => $waitlistSex])
                     </div>
                 @endif
 

--- a/resources/views/livewire/campista-waitlist-form.blade.php
+++ b/resources/views/livewire/campista-waitlist-form.blade.php
@@ -1,0 +1,16 @@
+<div class="mt-4">
+    @if($generalPosition && $sexPosition)
+        <div class="mb-4 border border-[#9ddbef]/25 bg-[#052f35] p-4 text-left text-[#d8f2fa]">
+            <p class="text-sm font-black uppercase tracking-[0.14em] text-[#f46b12]">Fila registrada</p>
+            <p class="mt-2 text-sm font-semibold text-[#d8f2fa]">
+                Você está na posição geral {{ $generalPosition }} e na posição {{ $sexPosition }} da fila por sexo.
+            </p>
+        </div>
+    @endif
+
+    <div class="flex justify-center">
+        {{ $this->joinWaitlistAction }}
+    </div>
+
+    <x-filament-actions::modals />
+</div>

--- a/resources/views/waitlist-invitation.blade.php
+++ b/resources/views/waitlist-invitation.blade.php
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html lang="pt_BR">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Convite da fila de espera - {{ config('app.name') }}</title>
+    <link rel="icon" type="image/png" href="{{ asset('img/logo.png') }}">
+    @filamentStyles
+    @livewireStyles
+    @vite(['resources/css/app.css', 'resources/js/app.js'])
+</head>
+<body class="bg-[#052f35] font-primary text-white scrollbar-thin scrollbar-track-[#052f35] scrollbar-thumb-[#f46b12] scrollbar-thumb-rounded-full">
+    @livewire('notifications')
+
+    <main class="min-h-screen bg-[#052f35] px-4 py-10 text-white">
+        <section class="mx-auto max-w-5xl">
+            <div class="mb-8 border border-[#9ddbef]/25 bg-[#03272c]/80 p-5">
+                <p class="text-sm font-black uppercase tracking-[0.16em] text-[#f46b12]">Convite da fila de espera</p>
+                <h1 class="mt-3 text-3xl font-black uppercase tracking-normal text-white sm:text-5xl">Complete sua inscrição</h1>
+                <p class="mt-3 max-w-2xl text-sm font-semibold leading-7 text-[#d8f2fa]">
+                    Esta ficha foi liberada por um link único enviado pela organização. Preencha os dados restantes para concluir sua inscrição.
+                </p>
+            </div>
+
+            @livewire('campista-form', [
+                'waitlistEntry' => $waitlistEntry,
+                'token' => $token,
+            ])
+        </section>
+    </main>
+
+    @filamentScripts
+    @livewireScripts
+</body>
+</html>

--- a/routes/web.php
+++ b/routes/web.php
@@ -2,6 +2,7 @@
 
 use App\Http\Controllers\Admin\LancamentoReceiptController;
 use App\Http\Controllers\Admin\ReportExportFileController;
+use App\Models\WaitlistEntry;
 use App\Settings\GeneralSettings;
 use Illuminate\Support\Facades\Route;
 
@@ -13,6 +14,14 @@ $campistaRegistrationPage = function () {
 
 Route::get('/', $campistaRegistrationPage)->name('welcome');
 Route::get('/campista', $campistaRegistrationPage)->name('campista');
+
+Route::get('/campista/fila/{waitlistEntry}/{token}', function (WaitlistEntry $waitlistEntry, string $token) {
+    $settings = app(GeneralSettings::class);
+
+    return view('waitlist-invitation', compact('settings', 'waitlistEntry', 'token'));
+})
+    ->middleware('signed')
+    ->name('waitlist.invitation.show');
 
 Route::get('/politica-privacidade', function () {
     return view('politica-privacidade');

--- a/tests/Feature/CampistaRegistrationPageTest.php
+++ b/tests/Feature/CampistaRegistrationPageTest.php
@@ -401,7 +401,9 @@ it('alerts and disables a sex option when its campista vacancies are full', func
         ->assertDontSee('As inscrições foram encerradas pelo número de vagas preenchidas.');
 
     expect(campistaSexOptionIsDisabled($html, 'F'))->toBeTrue()
-        ->and(campistaSexOptionIsDisabled($html, 'M'))->toBeFalse();
+        ->and(campistaSexOptionIsDisabled($html, 'M'))->toBeFalse()
+        ->and($html)->toContain('role="alert"')
+        ->and($html)->toContain('text-[#052f35]');
 });
 
 it('closes campista registration when all sex-specific vacancies are full', function () {
@@ -502,6 +504,7 @@ function seedGeneralRegistrationSettings(array $overrides = []): void
         'qtd_max_vagas' => null,
         'qtd_max_vagas_feminino' => null,
         'qtd_max_vagas_masculino' => null,
+        'waitlist_invitation_hours' => 24,
         'data_inicio_inscricoes' => null,
         'data_final_inscricoes' => null,
         'pix_copia_cola' => null,

--- a/tests/Feature/GeneralSettingsPageTest.php
+++ b/tests/Feature/GeneralSettingsPageTest.php
@@ -33,6 +33,7 @@ it('renders the general settings page with registration payment controls', funct
         ->assertSee('Documento do termo')
         ->assertSee('Limite de Campistas Homens')
         ->assertSee('Limite de Campistas Mulheres')
+        ->assertSee('Validade do convite da fila')
         ->assertSee('Início das Inscrições')
         ->assertSee('Fim das Inscrições')
         ->assertDontSee('Mensagem de Bloqueio')
@@ -182,6 +183,7 @@ it('saves registration status settings as scalar values', function () {
             'qtd_max_vagas' => 120,
             'qtd_max_vagas_feminino' => 60,
             'qtd_max_vagas_masculino' => 60,
+            'waitlist_invitation_hours' => 36,
             'data_inicio_inscricoes' => '2026-06-10 19:00:00',
             'data_final_inscricoes' => '2026-06-20 19:30:00',
             'pix_copia_cola' => null,
@@ -219,6 +221,10 @@ it('saves registration status settings as scalar values', function () {
             ->where('group', 'general')
             ->where('name', 'valor_equipe_trabalho_externa')
             ->value('payload'))->toBe('8000')
+        ->and(DB::table('settings')
+            ->where('group', 'general')
+            ->where('name', 'waitlist_invitation_hours')
+            ->value('payload'))->toBe('36')
         ->and(DB::table('settings')
             ->where('group', 'general')
             ->where('name', 'liberacao_inscricoes_equipe_trabalho_status')

--- a/tests/Feature/LancamentoItemsTest.php
+++ b/tests/Feature/LancamentoItemsTest.php
@@ -22,7 +22,49 @@ it('moves financial classification from lancamentos to lancamento items', functi
         ->and(Schema::hasColumn('lancamento_items', 'registration_id'))->toBeTrue()
         ->and(Schema::hasColumn('lancamentos', 'batch_code'))->toBeTrue()
         ->and(Schema::hasColumn('lancamentos', 'categoria_lancamento_id'))->toBeFalse()
-        ->and(Schema::hasTable('financial_entry_registrations'))->toBeFalse();
+        ->and(Schema::hasTable('financial_entry_registrations'))->toBeFalse()
+        ->and(lancamentoItemIndexColumns('lancamento_items_registration_category_unique'))->toBe([
+            'lancamento_id',
+            'registration_type',
+            'registration_id',
+            'categoria_lancamento_id',
+        ])
+        ->and(lancamentoItemIndexColumns('lancamento_items_lancamento_id_index'))->toBe([]);
+});
+
+it('allows the same registration to be linked to different launch item categories', function () {
+    $campista = Campista::factory()->create([
+        'tribo_id' => null,
+        'user_id' => null,
+    ]);
+
+    $lancamento = lancamentoItemEntry();
+
+    $inscricao = CategoriaLancamento::factory()->create([
+        'tipo' => TipoLacamento::Receita->value,
+    ]);
+
+    $contribuicao = CategoriaLancamento::factory()->create([
+        'tipo' => TipoLacamento::Receita->value,
+    ]);
+
+    $lancamento->items()->create([
+        'nome' => 'Inscrição',
+        'valor' => 10000,
+        'categoria_lancamento_id' => $inscricao->id,
+        'registration_type' => $campista::class,
+        'registration_id' => $campista->id,
+    ]);
+
+    $lancamento->items()->create([
+        'nome' => 'Contribuição',
+        'valor' => 5000,
+        'categoria_lancamento_id' => $contribuicao->id,
+        'registration_type' => $campista::class,
+        'registration_id' => $campista->id,
+    ]);
+
+    expect($lancamento->items()->count())->toBe(2);
 });
 
 it('syncs launch totals from items and marks paid registrations from paid item values', function () {
@@ -117,4 +159,13 @@ function lancamentoItemEntry(array $overrides = []): Lancamento
         'comprovante' => [],
         'user_id' => null,
     ], $overrides));
+}
+
+/**
+ * @return list<string>
+ */
+function lancamentoItemIndexColumns(string $indexName): array
+{
+    return collect(Schema::getIndexes('lancamento_items'))
+        ->firstWhere('name', $indexName)['columns'] ?? [];
 }

--- a/tests/Feature/PublicFilamentAssetsTest.php
+++ b/tests/Feature/PublicFilamentAssetsTest.php
@@ -31,6 +31,9 @@ it('keeps Filament modals viewport scoped across public registration surfaces', 
         ->toContain('.fi-modal > .fi-modal-window-ctn {')
         ->toContain('min-height: 100dvh;')
         ->toContain('grid-template-rows: minmax(1rem, 1fr) auto minmax(1rem, 1fr);')
+        ->toContain('body.has-mobile-bottom-nav .fi-modal:not(.fi-modal-slide-over) > .fi-modal-window-ctn {')
+        ->toContain('bottom: var(--juvenil-mobile-bottom-nav-space);')
+        ->toContain('max-height: calc(100dvh - var(--juvenil-mobile-bottom-nav-space) - 1.5rem);')
         ->toContain('body:has(.fi-modal.fi-modal-open) :is([data-motion-card], .out, .filament-registration-shell, .fi-section, .fi-ta, .fi-wi-stats-overview-stat, .fi-in-entry-wrp) {')
         ->toContain('transform: none !important;')
         ->toContain('backdrop-filter: none;');
@@ -279,6 +282,8 @@ it('ships the public GSAP motion layer and custom loader asset', function () {
         ->toContain('.juvenil-page-loader')
         ->toContain('.juvenil-mobile-bottom-nav')
         ->toContain('env(safe-area-inset-bottom)')
+        ->toContain('--juvenil-mobile-bottom-nav-space: calc(5.9rem + env(safe-area-inset-bottom));')
+        ->toContain('padding-bottom: var(--juvenil-mobile-bottom-nav-space);')
         ->toContain('@media (min-width: 1024px)')
         ->toContain('.campfire-loader-progress')
         ->toContain('html.gsap-scrolling')

--- a/tests/Feature/WaitlistFeatureTest.php
+++ b/tests/Feature/WaitlistFeatureTest.php
@@ -1,0 +1,416 @@
+<?php
+
+use App\Enums\LiberacaoInscricoesEquipeTrabalhoStatusEnum;
+use App\Enums\LiberacaoInscricoesStatusEnum;
+use App\Enums\StatusInscricao;
+use App\Enums\WaitlistEntryStatus;
+use App\Livewire\CampistaForm;
+use App\Livewire\CampistaWaitlistForm;
+use App\Models\Campista;
+use App\Models\User;
+use App\Models\WaitlistEntry;
+use App\Support\Campistas\WaitlistManager;
+use Database\Seeders\CampistaSeeder;
+use Database\Seeders\ShieldSeeder;
+use Database\Seeders\WaitlistEntrySeeder;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Crypt;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Storage;
+use Livewire\Livewire;
+
+uses(RefreshDatabase::class);
+
+it('shows the waitlist form when campista capacity is full', function () {
+    seedWaitlistSettings([
+        'qtd_max_vagas_masculino' => 1,
+        'qtd_max_vagas_feminino' => 1,
+    ]);
+
+    createWaitlistCampistaForSex('M', StatusInscricao::Pago);
+    createWaitlistCampistaForSex('F', StatusInscricao::Pago);
+
+    Livewire::test(CampistaForm::class)
+        ->assertSee('Limite de inscrições atingido')
+        ->assertSee('Entrar na fila')
+        ->assertDontSee('Inscrever-se');
+});
+
+it('centers the public waitlist action across viewports', function () {
+    $view = file_get_contents(resource_path('views/livewire/campista-waitlist-form.blade.php'));
+
+    expect($view)
+        ->toContain('<div class="flex justify-center">')
+        ->not->toContain('<div class="mt-4 text-left">');
+});
+
+it('stores public waitlist entries with general and sex positions', function () {
+    seedWaitlistSettings([
+        'qtd_max_vagas_feminino' => 1,
+    ]);
+
+    createWaitlistCampistaForSex('F', StatusInscricao::Pago);
+
+    Livewire::test(CampistaWaitlistForm::class)
+        ->fillForm([
+            'nome' => 'Ana da Silva',
+            'telefone' => '(47) 9 1111-2222',
+            'email' => 'ana@example.com',
+            'data_nascimento' => '10/05/2011',
+            'sexo' => 'F',
+            'observacao' => 'Pode ser avisada pelo WhatsApp.',
+            'aceitar_politica_privacidade' => true,
+        ])
+        ->call('submit')
+        ->assertNotified('Você entrou na fila de espera')
+        ->assertSee('Você está na posição geral 1')
+        ->assertSee('posição 1 da fila por sexo');
+
+    $entry = WaitlistEntry::query()->firstOrFail();
+
+    expect($entry->nome)
+        ->toBe('Ana da Silva')
+        ->and($entry->telefone_normalizado)
+        ->toBe('5547911112222')
+        ->and($entry->sexo)
+        ->toBe('F')
+        ->and($entry->status)
+        ->toBe(WaitlistEntryStatus::Aguardando)
+        ->and($entry->accepted_privacy_at)
+        ->not->toBeNull();
+});
+
+it('keeps a single unavailable sex fixed in the waitlist action', function () {
+    seedWaitlistSettings([
+        'qtd_max_vagas_masculino' => 1,
+        'qtd_max_vagas_feminino' => 1,
+    ]);
+
+    createWaitlistCampistaForSex('F', StatusInscricao::Pago);
+
+    Livewire::test(CampistaWaitlistForm::class, ['sex' => 'F'])
+        ->mountAction('joinWaitlist')
+        ->assertSchemaStateSet(['sexo' => 'F'])
+        ->fillForm([
+            'nome' => 'Ana da Silva',
+            'telefone' => '(47) 9 1111-2222',
+            'email' => 'ana@example.com',
+            'data_nascimento' => '10/05/2011',
+            'sexo' => 'M',
+            'observacao' => null,
+            'aceitar_politica_privacidade' => true,
+        ])
+        ->callMountedAction()
+        ->assertHasFormErrors(['sexo']);
+
+    expect(WaitlistEntry::query()->count())->toBe(0);
+
+    Livewire::test(CampistaWaitlistForm::class, ['sex' => 'F'])
+        ->callAction('joinWaitlist', data: [
+            'nome' => 'Ana da Silva',
+            'telefone' => '(47) 9 1111-2222',
+            'email' => 'ana@example.com',
+            'data_nascimento' => '10/05/2011',
+            'sexo' => 'F',
+            'observacao' => null,
+            'aceitar_politica_privacidade' => true,
+        ])
+        ->assertHasNoFormErrors()
+        ->assertNotified('Você entrou na fila de espera');
+
+    expect(WaitlistEntry::query()->firstOrFail()->sexo)->toBe('F');
+});
+
+it('shows waitlist action validation errors on invalid birthdate and duplicated phone', function () {
+    seedWaitlistSettings([
+        'qtd_max_vagas_feminino' => 1,
+    ]);
+
+    createWaitlistCampistaForSex('F', StatusInscricao::Pago);
+
+    Livewire::test(CampistaWaitlistForm::class, ['sex' => 'F'])
+        ->callAction('joinWaitlist', data: [
+            'nome' => 'Ana da Silva',
+            'telefone' => '(47) 9 1111-2222',
+            'email' => 'ana@example.com',
+            'data_nascimento' => '29/02/96',
+            'sexo' => 'F',
+            'observacao' => null,
+            'aceitar_politica_privacidade' => true,
+        ])
+        ->assertHasFormErrors(['data_nascimento']);
+
+    WaitlistEntry::factory()->create([
+        'telefone' => '(47) 9 1111-2222',
+        'telefone_normalizado' => '5547911112222',
+        'sexo' => 'F',
+        'status' => WaitlistEntryStatus::Aguardando,
+    ]);
+
+    Livewire::test(CampistaWaitlistForm::class, ['sex' => 'F'])
+        ->callAction('joinWaitlist', data: [
+            'nome' => 'Ana da Silva',
+            'telefone' => '(47) 9 1111-2222',
+            'email' => 'ana@example.com',
+            'data_nascimento' => '10/05/2011',
+            'sexo' => 'F',
+            'observacao' => null,
+            'aceitar_politica_privacidade' => true,
+        ])
+        ->assertHasFormErrors(['telefone']);
+});
+
+it('keeps public registration closed for a sex that has people waiting after a cancellation', function () {
+    seedWaitlistSettings([
+        'qtd_max_vagas_masculino' => 1,
+        'qtd_max_vagas_feminino' => 1,
+    ]);
+
+    createWaitlistCampistaForSex('F', StatusInscricao::Cancelado);
+
+    WaitlistEntry::factory()->create([
+        'sexo' => 'F',
+        'status' => WaitlistEntryStatus::Aguardando,
+        'created_at' => now()->subMinute(),
+    ]);
+
+    Livewire::test(CampistaForm::class)
+        ->set('data.form_data.sexo', 'F')
+        ->assertSee('Não há vagas disponíveis para o sexo feminino.')
+        ->assertSee('campista-waitlist-form');
+});
+
+it('generates a signed invitation link and completes a campista registration from it', function () {
+    Storage::fake('public');
+
+    seedWaitlistSettings([
+        'qtd_max_vagas_masculino' => 1,
+        'qtd_max_vagas_feminino' => 1,
+        'waitlist_invitation_hours' => 24,
+    ]);
+
+    $this->seed(ShieldSeeder::class);
+
+    $user = User::factory()->create();
+    $user->assignRole('Super Administrador');
+    $this->actingAs($user);
+
+    $entry = WaitlistEntry::factory()->create([
+        'nome' => 'Ana Convocada',
+        'telefone' => '(47) 9 2222-3333',
+        'telefone_normalizado' => '5547922223333',
+        'sexo' => 'F',
+        'status' => WaitlistEntryStatus::Aguardando,
+    ]);
+
+    $url = app(WaitlistManager::class)->generateInvitation($entry, $user);
+    $entry->refresh();
+
+    createWaitlistCampistaForSex('M', StatusInscricao::Pago);
+    createWaitlistCampistaForSex('F', StatusInscricao::Pago);
+
+    $this->withoutVite();
+
+    $this->get($url)
+        ->assertOk()
+        ->assertSee('Convite da fila de espera')
+        ->assertSee('Ana Convocada')
+        ->assertSee('Inscrever-se')
+        ->assertSee('filament-registration-shell', false)
+        ->assertDontSee('Inscrições abertas')
+        ->assertDontSee('Limite de inscrições atingido');
+
+    Livewire::test(CampistaForm::class, [
+        'waitlistEntry' => $entry,
+        'token' => decryptWaitlistToken($entry),
+    ])
+        ->set('data', waitlistCampistaPayload([
+            'nome' => 'Nome Alterado',
+            'avatar_url' => ['campista.png' => 'foto-formulario/campista.png'],
+            'form_data' => [
+                'sexo' => 'M',
+                'telefone_campista' => '(47) 9 9999-9999',
+            ],
+        ]))
+        ->call('submitForm')
+        ->assertHasNoFormErrors()
+        ->assertNotified('Registramos a sua inscrição');
+
+    $entry->refresh();
+    $campista = Campista::query()->findOrFail($entry->campista_id);
+
+    expect($campista->nome)
+        ->toBe('Ana Convocada')
+        ->and(data_get($campista->form_data, 'sexo'))
+        ->toBe('F')
+        ->and(data_get($campista->form_data, 'telefone_campista'))
+        ->toBe('(47) 9 2222-3333')
+        ->and($entry->status)
+        ->toBe(WaitlistEntryStatus::Inscrito)
+        ->and($entry->campista_id)
+        ->toBe($campista->getKey());
+});
+
+it('renders the administrative waitlist page with queue entries', function () {
+    seedWaitlistSettings();
+    $this->seed(ShieldSeeder::class);
+
+    $user = User::factory()->create();
+    $user->assignRole('Super Administrador');
+
+    WaitlistEntry::factory()->create([
+        'nome' => 'Primeira Mulher',
+        'sexo' => 'F',
+        'status' => WaitlistEntryStatus::Aguardando,
+        'created_at' => now()->subMinute(),
+    ]);
+
+    WaitlistEntry::factory()->create([
+        'nome' => 'Primeiro Homem',
+        'sexo' => 'M',
+        'status' => WaitlistEntryStatus::Aguardando,
+    ]);
+
+    $this->actingAs($user)
+        ->get(route('filament.admin.resources.waitlist-entries.index'))
+        ->assertOk()
+        ->assertSee('Fila de espera')
+        ->assertSee('Primeira Mulher')
+        ->assertSee('Primeiro Homem');
+});
+
+it('offers invitation sharing from one modal instead of a standalone whatsapp action', function () {
+    $table = file_get_contents(app_path('Filament/Resources/WaitlistEntries/Tables/WaitlistEntriesTable.php'));
+
+    expect($table)
+        ->toContain("Action::make('sendInvitationLink')")
+        ->toContain("->label('Enviar link de inscrição')")
+        ->toContain("Action::make('copyInvitationLink')")
+        ->toContain("->label('Copiar link')")
+        ->toContain("Action::make('sendInvitationWhatsapp')")
+        ->toContain("->label('Enviar via WhatsApp')")
+        ->not->toContain("Action::make('openWhatsapp')");
+});
+
+it('seeds coherent waitlist demo data without duplicating active queue entries', function () {
+    $this->seed(CampistaSeeder::class);
+    $this->seed(WaitlistEntrySeeder::class);
+    $this->seed(WaitlistEntrySeeder::class);
+
+    $entries = WaitlistEntry::query()
+        ->where('admin_notes', 'Dados demonstrativos da fila de espera para testes e painel operacional.')
+        ->get();
+
+    $activeDuplicates = $entries
+        ->whereIn('status', [WaitlistEntryStatus::Aguardando, WaitlistEntryStatus::Convocado])
+        ->groupBy(fn (WaitlistEntry $entry): string => $entry->sexo.'|'.$entry->telefone_normalizado)
+        ->filter(fn ($group): bool => $group->count() > 1);
+
+    $invited = $entries->firstWhere('status', WaitlistEntryStatus::Convocado);
+    $expired = $entries->firstWhere('status', WaitlistEntryStatus::Expirado);
+    $inscribed = $entries->firstWhere('status', WaitlistEntryStatus::Inscrito);
+
+    expect($entries)->toHaveCount(11)
+        ->and($entries->where('status', WaitlistEntryStatus::Aguardando))->toHaveCount(6)
+        ->and($entries->pluck('telefone_normalizado')->filter())->toHaveCount(11)
+        ->and($activeDuplicates)->toBeEmpty()
+        ->and($invited?->invitation_token_hash)->not->toBeNull()
+        ->and($invited?->invitation_expires_at?->isFuture())->toBeTrue()
+        ->and($expired?->invitation_token_hash)->not->toBeNull()
+        ->and($expired?->invitation_expires_at?->isPast())->toBeTrue()
+        ->and($inscribed?->campista_id)->not->toBeNull()
+        ->and($inscribed?->invitation_accepted_at)->not->toBeNull();
+});
+
+function seedWaitlistSettings(array $overrides = []): void
+{
+    $settings = array_merge([
+        'telefone_atendente' => '(47) 9 9999-9999',
+        'valor_acampamento' => null,
+        'idade_minima' => 0,
+        'idade_maxima' => 0,
+        'qtd_max_vagas' => null,
+        'qtd_max_vagas_feminino' => null,
+        'qtd_max_vagas_masculino' => null,
+        'waitlist_invitation_hours' => 24,
+        'data_inicio_inscricoes' => null,
+        'data_final_inscricoes' => null,
+        'pix_copia_cola' => null,
+        'pix_qr_code' => null,
+        'termo_responsabilidade' => null,
+        'atendentes' => [],
+        'liberacao_inscricoes_status' => LiberacaoInscricoesStatusEnum::LIBERADO->value,
+        'liberacao_inscricoes_equipe_trabalho_status' => LiberacaoInscricoesEquipeTrabalhoStatusEnum::LIBERADO->value,
+        'liberacao_inscricoes_bloco' => null,
+    ], $overrides);
+
+    foreach ($settings as $name => $payload) {
+        DB::table('settings')->updateOrInsert(
+            [
+                'group' => 'general',
+                'name' => $name,
+            ],
+            [
+                'payload' => json_encode($payload),
+            ],
+        );
+    }
+}
+
+function createWaitlistCampistaForSex(string $sex, StatusInscricao $status): Campista
+{
+    return Campista::factory()->create([
+        'status' => $status->value,
+        'tribo_id' => null,
+        'user_id' => null,
+        'form_data' => [
+            'sexo' => $sex,
+        ],
+    ]);
+}
+
+function decryptWaitlistToken(WaitlistEntry $entry): string
+{
+    return Crypt::decryptString((string) $entry->invitation_token_encrypted);
+}
+
+/**
+ * @param  array<string, mixed>  $overrides
+ * @return array<string, mixed>
+ */
+function waitlistCampistaPayload(array $overrides = []): array
+{
+    $payload = [
+        'nome' => 'Ana Convocada',
+        'avatar_url' => ['campista.png' => 'foto-formulario/campista.png'],
+        'form_data' => [
+            'data_nacimento' => '10/05/2011',
+            'sexo' => 'F',
+            'altura' => 160,
+            'peso' => 55,
+            'rede_social' => '@ana',
+            'telefone_campista' => '(47) 9 2222-3333',
+            'telefone_reponsavel_1' => '(47) 9 4444-5555',
+            'telefone_reponsavel_nome_1' => 'Responsável Ana',
+            'toma_remedio' => 0,
+            'tem_recomendacao' => 0,
+            'tamanho_camiseta' => 'M',
+            'cep' => '88375-000',
+            'rua' => 'Rua Teste',
+            'numero' => '123',
+            'ponto_referencia' => 'Casa',
+            'bairro' => 'Centro',
+            'cidade' => 'Navegantes',
+            'estado' => 'SC',
+            'paroquia' => 2,
+            'comunidade' => 'Comunidade Teste',
+            'ja_participou_retiro' => 0,
+            'algum_parente' => 0,
+            'declaro' => 1,
+            'aceite_termo_inscricao' => true,
+            'aceitar_politica_privacidade' => true,
+        ],
+    ];
+
+    return array_replace_recursive($payload, $overrides);
+}


### PR DESCRIPTION
## Summary
- Adds a campista waitlist domain model, status enum, migration, factory, seeder, policy, and domain context glossary.
- Adds public waitlist signup through Livewire when registration capacity or sex-specific capacity is unavailable, including duplicate phone checks, age validation, privacy acceptance, and queue position feedback.
- Adds signed invitation links for waitlisted campistas, reserves capacity while invitations are active, and lets invited users complete registration with locked waitlist identity fields.
- Adds a Filament waitlist resource with list/create/view/edit pages, queue positions, filters, invitation generation, copy/share modal, WhatsApp sharing, and withdrawn status handling.
- Adds configurable waitlist invitation validity to General Settings.
- Updates registration availability to account for active waitlist demand and active invitation reservations.
- Adjusts public modal/mobile bottom-nav CSS for waitlist modals.
- Updates launch item uniqueness so the same registration can be linked to different launch item categories.

## Testing
- Added `tests/Feature/WaitlistFeatureTest.php` covering public waitlist signup, validation, fixed sex waitlist flow, invitation generation/use, admin listing, sharing UI, and demo seeding.
- Updated registration, settings, public asset, and launch item feature tests for the new waitlist and category uniqueness behavior.