### PR TITLE
Localize waitlist create action label

### DIFF
--- a/app/Filament/Resources/WaitlistEntries/Pages/ListWaitlistEntries.php
+++ b/app/Filament/Resources/WaitlistEntries/Pages/ListWaitlistEntries.php
@@ -13,7 +13,8 @@ class ListWaitlistEntries extends ListRecords
     protected function getHeaderActions(): array
     {
         return [
-            CreateAction::make(),
+            CreateAction::make()
+                ->label('Adicionar na Fila de Espera'),
         ];
     }
 }

--- a/tests/Feature/WaitlistFeatureTest.php
+++ b/tests/Feature/WaitlistFeatureTest.php
@@ -274,7 +274,7 @@ it('renders the administrative waitlist page with queue entries', function () {
     $this->actingAs($user)
         ->get(route('filament.admin.resources.waitlist-entries.index'))
         ->assertOk()
-        ->assertSee('Fila de espera')
+        ->assertSee('Adicionar na Fila de Espera')
         ->assertSee('Primeira Mulher')
         ->assertSee('Primeiro Homem');
 });


### PR DESCRIPTION
## Summary
- Updates the waitlist entries list page create action label to Portuguese: `Adicionar na Fila de Espera`.
- Adjusts the waitlist feature test to assert the localized action text appears on the index page.

## Testing
- Updated `tests/Feature/WaitlistFeatureTest.php` to cover the new label.