### PR TITLE
Fix public waitlist button layering

### DIFF
--- a/app/Livewire/CampistaWaitlistForm.php
+++ b/app/Livewire/CampistaWaitlistForm.php
@@ -64,6 +64,9 @@ class CampistaWaitlistForm extends Component implements HasActions, HasForms
             ->modalHeading('Entrar na fila de espera')
             ->modalDescription('Deixe seu contato para ser chamado caso uma vaga compatível seja liberada por desistência.')
             ->modalSubmitActionLabel('Cadastrar na fila')
+            ->extraAttributes([
+                'class' => 'relative z-20',
+            ], merge: true)
             ->extraModalWindowAttributes(['class' => 'waitlist-entry-modal'], merge: true)
             ->fillForm(fn (): array => $this->sex === null ? [] : ['sexo' => $this->sex])
             ->schema($this->waitlistSchema())

--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -254,8 +254,8 @@ function initCountdown() {
         return;
     }
 
-    jQuery('#clockForm').countdown('2024/08/23 19:00', function (event) {
-        jQuery(this).html(event.strftime('' +
+    window.jQuery('#clockForm').countdown('2024/08/23 19:00', function (event) {
+        window.jQuery(this).html(event.strftime('' +
             '<div style="margin: 0px; padding: 0px; width: 85px;" class="time-entry days"><span>%-D</span> Dia(s)</div> ' +
             '<div style="margin-top: 50px; padding: 0px; width: 85px;" class="time-entry hours"><span>%H</span> Hora(s)</div> ' +
             '<div style="margin-top: 50px; padding: 0px; width: 85px;" class="time-entry minutes"><span>%M</span> Minuto(s)</div> ' +

--- a/tests/Feature/PublicFilamentAssetsTest.php
+++ b/tests/Feature/PublicFilamentAssetsTest.php
@@ -278,6 +278,8 @@ it('ships the public GSAP motion layer and custom loader asset', function () {
         ->toContain('data-mobile-nav-item')
         ->toContain('gsap-scrolling')
         ->toContain('scrollToTarget')
+        ->toContain('window.jQuery')
+        ->not->toContain("\n    jQuery(")
         ->and($css)
         ->toContain('.juvenil-page-loader')
         ->toContain('.juvenil-mobile-bottom-nav')

--- a/tests/Feature/WaitlistFeatureTest.php
+++ b/tests/Feature/WaitlistFeatureTest.php
@@ -38,10 +38,13 @@ it('shows the waitlist form when campista capacity is full', function () {
 
 it('centers the public waitlist action across viewports', function () {
     $view = file_get_contents(resource_path('views/livewire/campista-waitlist-form.blade.php'));
+    $component = file_get_contents(app_path('Livewire/CampistaWaitlistForm.php'));
 
     expect($view)
         ->toContain('<div class="flex justify-center">')
-        ->not->toContain('<div class="mt-4 text-left">');
+        ->not->toContain('<div class="mt-4 text-left">')
+        ->and($component)
+        ->toContain("'class' => 'relative z-20'");
 });
 
 it('stores public waitlist entries with general and sex positions', function () {


### PR DESCRIPTION
## Summary
- Adds a relative z-index class to the public waitlist action so the button remains clickable above overlapping page layers.
- Updates countdown initialization to reference `window.jQuery` explicitly.
- Extends feature coverage for waitlist button layering and public asset output.

## Testing
- Updated `tests/Feature/PublicFilamentAssetsTest.php` and `tests/Feature/WaitlistFeatureTest.php`.