### PR TITLE
Render campista registrations as compact launch cards

### DIFF
--- a/app/Filament/Resources/LancamentoResource/Forms/LancamentoForm.php
+++ b/app/Filament/Resources/LancamentoResource/Forms/LancamentoForm.php
@@ -8,6 +8,7 @@ use App\Enums\TipoEquipeTrabalho;
 use App\Enums\TipoLacamento;
 use App\Filament\Resources\LancamentoResource\Tables\LancamentoItemCampistasTable;
 use App\Filament\Resources\LancamentoResource\Tables\LancamentoItemEquipeTrabalhoTable;
+use App\Models\Campista;
 use App\Models\CategoriaLancamento;
 use App\Models\EquipeTrabalho;
 use App\Models\Lancamento;
@@ -824,6 +825,16 @@ abstract class LancamentoForm
 
             return $registration
                 ? LancamentoRegistrationCard::forTeam($registration)
+                : self::registrationName($registrationType, $registrationId);
+        }
+
+        if ($registrationType === Campista::class) {
+            $registration = Campista::query()
+                ->with('tribo')
+                ->find($registrationId);
+
+            return $registration
+                ? LancamentoRegistrationCard::forCampista($registration)
                 : self::registrationName($registrationType, $registrationId);
         }
 

--- a/app/Filament/Resources/LancamentoResource/Pages/ViewLancamento.php
+++ b/app/Filament/Resources/LancamentoResource/Pages/ViewLancamento.php
@@ -349,6 +349,10 @@ class ViewLancamento extends ViewRecord
             return LancamentoRegistrationCard::forTeam($registration);
         }
 
+        if ($registration instanceof Campista) {
+            return LancamentoRegistrationCard::forCampista($registration);
+        }
+
         $type = class_basename((string) $item->registration_type);
         $name = (string) ($registration?->getAttribute('nome') ?? 'Inscrição removida');
 

--- a/app/Support/Financeiro/LancamentoRegistrationCard.php
+++ b/app/Support/Financeiro/LancamentoRegistrationCard.php
@@ -2,14 +2,41 @@
 
 namespace App\Support\Financeiro;
 
+use App\Enums\StatusInscricao;
 use App\Enums\StatusInscricaoEquipeTrabalho;
 use App\Enums\TipoEquipeTrabalho;
+use App\Models\Campista;
 use App\Models\EquipeTrabalho;
 use Illuminate\Support\Facades\Storage;
 use Illuminate\Support\HtmlString;
 
 final class LancamentoRegistrationCard
 {
+    public static function forCampista(Campista $registration): HtmlString
+    {
+        $registration->loadMissing('tribo');
+
+        $status = $registration->status instanceof StatusInscricao
+            ? $registration->status
+            : StatusInscricao::tryFrom((int) $registration->status);
+
+        $name = (string) ($registration->nome ?: 'Inscrição removida');
+        $tribe = (string) ($registration->tribo?->cor ?: 'Sem tribo');
+        $photoUrl = self::photoUrl($registration->avatar_url);
+        $initials = self::initials($name);
+        $statusColor = self::statusColor($status?->getColor());
+
+        return self::render(
+            id: 'Campista #'.((string) $registration->getKey()),
+            name: $name,
+            status: $status?->getLabel() ?? 'Sem status',
+            statusColor: $statusColor,
+            photoUrl: $photoUrl,
+            initials: $initials,
+            meta: [$tribe],
+        );
+    }
+
     public static function forTeam(EquipeTrabalho $registration): HtmlString
     {
         $registration->loadMissing('tribo');
@@ -29,9 +56,29 @@ final class LancamentoRegistrationCard
         $statusColor = self::statusColor($status?->getColor());
         $typeLabel = $teamType?->getLabel() ?? 'Tipo não definido';
 
+        return self::render(
+            id: 'Equipe #'.((string) $registration->getKey()),
+            name: $name,
+            status: $status?->getLabel() ?? 'Sem status',
+            statusColor: $statusColor,
+            photoUrl: $photoUrl,
+            initials: $initials,
+            meta: [$team, $typeLabel],
+        );
+    }
+
+    /**
+     * @param  array<int, string>  $meta
+     */
+    private static function render(string $id, string $name, string $status, string $statusColor, ?string $photoUrl, string $initials, array $meta): HtmlString
+    {
         $photo = $photoUrl
             ? '<img src="'.e($photoUrl).'" alt="Foto de '.e($name).'" onerror="this.onerror=null;this.hidden=true;this.nextElementSibling.hidden=false;">'
             : '';
+        $metaHtml = collect($meta)
+            ->filter(fn (string $item): bool => filled($item))
+            ->map(fn (string $item): string => '<span>'.e($item).'</span>')
+            ->implode('');
 
         return new HtmlString(
             '<div class="juvenil-launch-registration-card">'
@@ -41,13 +88,12 @@ final class LancamentoRegistrationCard
                 .'</div>'
                 .'<div class="juvenil-launch-registration-card__body">'
                     .'<div class="juvenil-launch-registration-card__topline">'
-                        .'<span class="juvenil-launch-registration-card__id">Equipe #'.e((string) $registration->getKey()).'</span>'
-                        .'<span class="juvenil-launch-registration-card__status juvenil-launch-registration-card__status--'.e($statusColor).'">'.e($status?->getLabel() ?? 'Sem status').'</span>'
+                        .'<span class="juvenil-launch-registration-card__id">'.e($id).'</span>'
+                        .'<span class="juvenil-launch-registration-card__status juvenil-launch-registration-card__status--'.e($statusColor).'">'.e($status).'</span>'
                     .'</div>'
                     .'<strong class="juvenil-launch-registration-card__name">'.e($name).'</strong>'
                     .'<div class="juvenil-launch-registration-card__meta">'
-                        .'<span>'.e($team).'</span>'
-                        .'<span>'.e($typeLabel).'</span>'
+                        .$metaHtml
                     .'</div>'
                 .'</div>'
             .'</div>',

--- a/tests/Feature/FinancialEntryItemsTest.php
+++ b/tests/Feature/FinancialEntryItemsTest.php
@@ -512,6 +512,7 @@ it('exposes item links in the financial entry form and table', function () {
         ->not->toContain("Textarea::make('descricao')\n                                ->toolbarButtons")
         ->toContain('RegistrationPaymentAllocator::registrationTypeOptions')
         ->toContain('registrationOptions')
+        ->toContain('LancamentoRegistrationCard::forCampista')
         ->toContain('LancamentoRegistrationCard::forTeam')
         ->not->toContain('registrationSearchResults')
         ->toContain("Textarea::make('observacao')")
@@ -562,6 +563,43 @@ it('exposes item links in the financial entry form and table', function () {
     expect(Schema::getColumnType('lancamentos', 'descricao'))->toBe('text');
 });
 
+it('renders selected campista registration as a compact card on the edit form', function () {
+    $this->seed(ShieldSeeder::class);
+
+    $user = User::factory()->create();
+    $user->assignRole('Super Administrador');
+
+    $campista = Campista::factory()->create([
+        'nome' => 'Maria Selecionada Edit',
+        'avatar_url' => 'foto-formulario/maria-edit.png',
+        'status' => StatusInscricao::Pago,
+    ]);
+
+    $category = CategoriaLancamento::factory()->create([
+        'nome' => 'Inscrição Edit',
+        'tipo' => TipoLacamento::Receita,
+        'ativo' => true,
+    ]);
+
+    $lancamento = financialItemEntry([
+        'nome' => 'Lançamento campista selecionada',
+        'tipo' => TipoLacamento::Receita,
+    ]);
+    $lancamento->items()->create(financialItemPayload($category, $campista, [
+        'valor' => 35000,
+    ]));
+
+    $this->actingAs($user)
+        ->get(route('filament.admin.resources.lancamentos.edit', ['record' => $lancamento]))
+        ->assertOk()
+        ->assertSee('<div class="juvenil-launch-registration-card">', false)
+        ->assertSee('Campista #'.$campista->id)
+        ->assertSee('Maria Selecionada Edit')
+        ->assertSee('Pago')
+        ->assertSee('/storage/foto-formulario/maria-edit.png', false)
+        ->assertDontSee('Campista #'.$campista->id.' - Maria Selecionada Edit');
+});
+
 it('renders selected team work registration as a compact card on the edit form', function () {
     $this->seed(ShieldSeeder::class);
 
@@ -593,8 +631,7 @@ it('renders selected team work registration as a compact card on the edit form',
     $this->actingAs($user)
         ->get(route('filament.admin.resources.lancamentos.edit', ['record' => $lancamento]))
         ->assertOk()
-        ->assertSee('juvenil-launch-registration-card', false)
-        ->assertDontSee('&lt;div class=&quot;juvenil-launch-registration-card&quot;', false)
+        ->assertSee('<div class="juvenil-launch-registration-card">', false)
         ->assertSee('Equipe #'.$member->id)
         ->assertSee('Servo Selecionado Edit')
         ->assertSee('Liturgia')

--- a/tests/Feature/LancamentoViewPageTest.php
+++ b/tests/Feature/LancamentoViewPageTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use App\Enums\FormaPagamento;
+use App\Enums\StatusInscricao;
 use App\Enums\StatusInscricaoEquipeTrabalho;
 use App\Enums\StatusLacamento;
 use App\Enums\TipoEquipeTrabalho;
@@ -244,6 +245,8 @@ it('links linked registrations from launch items', function () {
 
     $campista = Campista::factory()->create([
         'nome' => 'Vitória Costa 119',
+        'avatar_url' => 'foto-formulario/vitoria-view.png',
+        'status' => StatusInscricao::Pago,
     ]);
 
     $category = CategoriaLancamento::factory()->create([
@@ -272,7 +275,12 @@ it('links linked registrations from launch items', function () {
     $this->actingAs($user)
         ->get(route('filament.admin.resources.lancamentos.view', ['record' => $lancamento]))
         ->assertOk()
-        ->assertSee('Campista #'.$campista->id.' - Vitória Costa 119')
+        ->assertSee('<div class="juvenil-launch-registration-card">', false)
+        ->assertSee('Campista #'.$campista->id)
+        ->assertSee('Vitória Costa 119')
+        ->assertSee('Pago')
+        ->assertSee('/storage/foto-formulario/vitoria-view.png', false)
+        ->assertDontSee('Campista #'.$campista->id.' - Vitória Costa 119')
         ->assertSee('Visualizar inscrição')
         ->assertSee(route('filament.admin.resources.campistas.view', ['record' => $campista]), false);
 });
@@ -317,7 +325,7 @@ it('links team work registrations from launch items to a view page', function ()
     $this->actingAs($user)
         ->get(route('filament.admin.resources.lancamentos.view', ['record' => $lancamento]))
         ->assertOk()
-        ->assertSee('juvenil-launch-registration-card', false)
+        ->assertSee('<div class="juvenil-launch-registration-card">', false)
         ->assertSee('Equipe #'.$member->id)
         ->assertSee('Servo Equipe View')
         ->assertSee('Cozinha')


### PR DESCRIPTION
## Summary
- Adds compact registration card rendering for campista registrations in lancamento edit forms and view pages.
- Reuses the existing launch registration card component for both campistas and equipe trabalho entries.
- Includes campista status, tribe metadata, initials/photo handling, and storage-backed avatar URLs.

## Testing
- Updated feature coverage in `FinancialEntryItemsTest` and `LancamentoViewPageTest` for campista card rendering and existing team card rendering assertions.