### PR TITLE
Capture Filament notifications in Tracefy tracker

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -11773,16 +11773,16 @@
         },
         {
             "name": "webtechnologyltda/tracefy-sdk",
-            "version": "v2.0.0",
+            "version": "v2.0.1",
             "source": {
                 "type": "git",
                 "url": "git@github.com:webtechnologyltda/tracefy-sdk.git",
-                "reference": "4ed6707e1bd05b651c459be775a190ea0c5a52f9"
+                "reference": "55f03889e7729569c09f12a1031b3f2c1eaffe68"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/webtechnologyltda/tracefy-sdk/zipball/4ed6707e1bd05b651c459be775a190ea0c5a52f9",
-                "reference": "4ed6707e1bd05b651c459be775a190ea0c5a52f9",
+                "url": "https://api.github.com/repos/webtechnologyltda/tracefy-sdk/zipball/55f03889e7729569c09f12a1031b3f2c1eaffe68",
+                "reference": "55f03889e7729569c09f12a1031b3f2c1eaffe68",
                 "shasum": ""
             },
             "require": {
@@ -11837,10 +11837,10 @@
             ],
             "description": "Tracefy SDK package for sending application errors to the central error monitoring service.",
             "support": {
-                "source": "https://github.com/webtechnologyltda/tracefy-sdk/tree/v2.0.0",
+                "source": "https://github.com/webtechnologyltda/tracefy-sdk/tree/v2.0.1",
                 "issues": "https://github.com/webtechnologyltda/tracefy-sdk/issues"
             },
-            "time": "2026-06-24T04:26:35+00:00"
+            "time": "2026-07-02T01:48:12+00:00"
         }
     ],
     "packages-dev": [

--- a/public/vendor/tracefy-sdk/tracefy-js-tracker.js
+++ b/public/vendor/tracefy-sdk/tracefy-js-tracker.js
@@ -5,7 +5,16 @@
   var Tracefy = window.Tracefy || {};
   var config = null;
   var isStarted = false;
+  var patchedDispatchEvent = false;
+  var seenNotificationEvents = typeof WeakSet === "function" ? new WeakSet() : null;
   var DEFAULT_PROXY_ENDPOINT = "/tracefy-sdk/events/js";
+  var FILAMENT_NOTIFICATION_EVENTS = [
+    "notificationsSent",
+    "notificationSent",
+    "filament-notifications-sent",
+    "filament-notification-sent",
+    "notify"
+  ];
 
   function nowIso() {
     return new Date().toISOString();
@@ -33,6 +42,20 @@
         user_agent: window.navigator.userAgent
       },
       error: details
+    };
+  }
+
+  function buildNotificationPayload(kind, details) {
+    return {
+      captured_at: nowIso(),
+      source: "frontend",
+      kind: kind,
+      environment: (config && config.environment) || "production",
+      page: {
+        url: window.location.href,
+        user_agent: window.navigator.userAgent
+      },
+      notification: details
     };
   }
 
@@ -74,6 +97,29 @@
     });
   }
 
+  function normalizeNotification(value) {
+    var detail = value && value.detail !== undefined ? value.detail : value;
+    var first = Array.isArray(detail) ? detail[0] : detail;
+    var notification = first && first.notification ? first.notification : first;
+
+    if (!notification || typeof notification !== "object") {
+      return {
+        title: safeString(notification),
+        raw: safeString(detail)
+      };
+    }
+
+    return {
+      id: notification.id || notification.key || null,
+      title: notification.title || notification.message || null,
+      body: notification.body || null,
+      status: notification.status || notification.type || null,
+      icon: notification.icon || null,
+      duration: notification.duration || null,
+      raw: safeString(detail)
+    };
+  }
+
   function onError(event) {
     var details = {
       message: event.message || "Unknown JS error",
@@ -100,6 +146,56 @@
     send(buildPayload("unhandledrejection", details));
   }
 
+  function onFilamentNotification(event) {
+    if (config && config.captureFilamentNotifications === false) {
+      return;
+    }
+
+    if (seenNotificationEvents && event && typeof event === "object") {
+      if (seenNotificationEvents.has(event)) {
+        return;
+      }
+
+      seenNotificationEvents.add(event);
+    }
+
+    send(buildNotificationPayload("filament_notification", normalizeNotification(event)));
+  }
+
+  function isFilamentNotificationEvent(event) {
+    if (!event || typeof event.type !== "string") {
+      return false;
+    }
+
+    if (FILAMENT_NOTIFICATION_EVENTS.indexOf(event.type) !== -1) {
+      return true;
+    }
+
+    return event.type.indexOf("filament") !== -1 && event.type.indexOf("notification") !== -1;
+  }
+
+  function patchDispatchEvent() {
+    if (patchedDispatchEvent || !window.EventTarget || !window.EventTarget.prototype) {
+      return;
+    }
+
+    var originalDispatchEvent = window.EventTarget.prototype.dispatchEvent;
+
+    if (typeof originalDispatchEvent !== "function") {
+      return;
+    }
+
+    window.EventTarget.prototype.dispatchEvent = function dispatchEvent(event) {
+      if (this === window && isFilamentNotificationEvent(event)) {
+        onFilamentNotification(event);
+      }
+
+      return originalDispatchEvent.apply(this, arguments);
+    };
+
+    patchedDispatchEvent = true;
+  }
+
   Tracefy.init = function init(options) {
     config = options || {};
 
@@ -109,6 +205,12 @@
 
     window.addEventListener("error", onError);
     window.addEventListener("unhandledrejection", onUnhandledRejection);
+
+    FILAMENT_NOTIFICATION_EVENTS.forEach(function (eventName) {
+      window.addEventListener(eventName, onFilamentNotification);
+    });
+
+    patchDispatchEvent();
     isStarted = true;
   };
 


### PR DESCRIPTION
## Summary
- Updates `webtechnologyltda/tracefy-sdk` from v2.0.0 to v2.0.1.
- Adds frontend Tracefy tracking for Filament notification events.
- Normalizes notification payloads and sends them as `filament_notification` events, with duplicate event protection and an opt-out via `captureFilamentNotifications: false`.

## Testing
- Not run; no test evidence provided.