### PR TITLE
Enhance financial dashboard exports and permissions

### DIFF
--- a/app/Filament/Pages/FinancialDashboard.php
+++ b/app/Filament/Pages/FinancialDashboard.php
@@ -8,6 +8,7 @@ use App\Enums\TipoLacamento;
 use App\Filament\Widgets\Financial\FinancialCategoryChart;
 use App\Filament\Widgets\Financial\FinancialDailyFlowChart;
 use App\Filament\Widgets\Financial\FinancialOverviewStats;
+use App\Filament\Widgets\Financial\FinancialPaymentMethodChart;
 use App\Filament\Widgets\Financial\RecentFinancialEntriesTable;
 use App\Models\CategoriaLancamento;
 use BezhanSalleh\FilamentShield\Traits\HasPageShield;
@@ -85,6 +86,7 @@ class FinancialDashboard extends FilamentDashboard
             FinancialOverviewStats::class,
             FinancialDailyFlowChart::class,
             FinancialCategoryChart::class,
+            FinancialPaymentMethodChart::class,
             RecentFinancialEntriesTable::class,
         ];
     }

--- a/app/Filament/Resources/EquipeTrabalhoResource.php
+++ b/app/Filament/Resources/EquipeTrabalhoResource.php
@@ -8,6 +8,7 @@ use App\Filament\Resources\EquipeTrabalhoResource\EquipeTrabalhoTable;
 use App\Filament\Resources\EquipeTrabalhoResource\Pages;
 use App\Filament\Resources\EquipeTrabalhoResource\Widgets\EquipeTrabalhoStatsWidget;
 use App\Models\EquipeTrabalho;
+use BezhanSalleh\FilamentShield\Contracts\HasShieldPermissions;
 use Carbon\Carbon;
 use Filament\Actions\EditAction;
 use Filament\Actions\ExportBulkAction;
@@ -16,7 +17,7 @@ use Filament\Resources\Resource;
 use Filament\Schemas\Schema;
 use Filament\Tables\Table;
 
-class EquipeTrabalhoResource extends Resource
+class EquipeTrabalhoResource extends Resource implements HasShieldPermissions
 {
     protected static ?string $model = EquipeTrabalho::class;
 
@@ -54,6 +55,7 @@ class EquipeTrabalhoResource extends Resource
             ])
             ->toolbarActions([
                 ExportBulkAction::make()
+                    ->visible(fn (): bool => auth()->user()->can('export', EquipeTrabalho::class))
                     ->exporter(EquipeTrabalhoExporter::class)
                     ->fileName(fn (Export $export): string => 'equipe-trabalho-'.Carbon::now()->format('YmdHis').'-'.$export->getKey())
                     ->label('Exportar'),
@@ -74,6 +76,25 @@ class EquipeTrabalhoResource extends Resource
             'create' => Pages\CreateEquipeTrabalho::route('/create'),
             'view' => Pages\ViewEquipeTrabalho::route('/{record}'),
             'edit' => Pages\EditEquipeTrabalho::route('/{record}/edit'),
+        ];
+    }
+
+    public static function getPermissionPrefixes(): array
+    {
+        return [
+            'view_any',
+            'view',
+            'create',
+            'update',
+            'delete',
+            'delete_any',
+            'restore',
+            'force_delete',
+            'force_delete_any',
+            'restore_any',
+            'replicate',
+            'reorder',
+            'export',
         ];
     }
 

--- a/app/Filament/Resources/LancamentoResource.php
+++ b/app/Filament/Resources/LancamentoResource.php
@@ -282,6 +282,7 @@ class LancamentoResource extends Resource
             ->toolbarActions([
                 ExportBulkAction::make()
                     ->exporter(LancamentoExporter::class)
+                    ->modifyQueryUsing(fn (Builder $query): Builder => $query->with(['items.categoria', 'items.registration']))
                     ->fileName(fn (Export $export): string => 'lancamento-financeiro-'.Carbon::now()->format('YmdHis').'-'.$export->getKey())
                     ->label('Exportar'),
             ]);

--- a/app/Filament/Resources/LancamentoResource/LancamentoExport.php
+++ b/app/Filament/Resources/LancamentoResource/LancamentoExport.php
@@ -2,7 +2,19 @@
 
 namespace App\Filament\Resources\LancamentoResource;
 
+use App\Enums\FormaPagamento;
+use App\Enums\StatusLacamento;
+use App\Enums\TipoLacamento;
+use App\Filament\Resources\LancamentoResource\Forms\LancamentoForm;
+use App\Models\Campista;
+use App\Models\EquipeTrabalho;
+use App\Models\Lancamento;
+use App\Models\LancamentoItem;
+use Carbon\Carbon;
 use Filament\Actions\Exports\ExportColumn;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Str;
 
 abstract class LancamentoExport
 {
@@ -16,50 +28,249 @@ abstract class LancamentoExport
                 ->label('Nome do Lançamento'),
 
             ExportColumn::make('valor')
-                ->label('Valor'),
+                ->label('Valor')
+                ->formatStateUsing(fn (mixed $state, Lancamento $record): string => self::money(self::signedAmount($record))),
 
             ExportColumn::make('comprador')
                 ->label('Comprador'),
 
             ExportColumn::make('data')
-                ->label('Data de Pagamento'),
+                ->label('Data de Pagamento')
+                ->formatStateUsing(fn (mixed $state): ?string => filled($state) ? Carbon::parse($state)->format('d/m/Y') : null),
 
             ExportColumn::make('tipo')
                 ->label('Tipo de Lançamento')
-                ->formatStateUsing(fn ($state) => match ($state->value) {
-                    0 => 'Receita',
-                    1 => 'Despesa',
-                    2 => 'Doação',
-                    default => 'Indefinido',
-                }),
+                ->formatStateUsing(fn (mixed $state): string => self::enumLabel($state, TipoLacamento::class)),
 
             ExportColumn::make('categories_summary')
                 ->label('Categorias'),
+
+            ExportColumn::make('items_summary')
+                ->label('Itens')
+                ->state(fn (Lancamento $record): string => self::itemsSummary($record)),
+
+            ExportColumn::make('item_values_summary')
+                ->label('Valores dos itens')
+                ->state(fn (Lancamento $record): string => self::itemValuesSummary($record)),
+
+            ExportColumn::make('item_descriptions_summary')
+                ->label('Descrições dos itens')
+                ->state(fn (Lancamento $record): string => self::itemDescriptionsSummary($record)),
+
+            ExportColumn::make('registration_payments_summary')
+                ->label('Inscrições vinculadas')
+                ->state(fn (Lancamento $record): string => self::registrationsSummary($record)),
 
             ExportColumn::make('batch_code')
                 ->label('Lote'),
 
             ExportColumn::make('status')
                 ->label('Status')
-                ->formatStateUsing(fn ($state) => match ($state->value) {
-                    0 => 'Pendente',
-                    1 => 'Pago',
-                    2 => 'Cancelado',
-                    default => 'Indefinido',
-                }),
+                ->formatStateUsing(fn (mixed $state): string => self::enumLabel($state, StatusLacamento::class)),
 
             ExportColumn::make('forma_pagamento')
                 ->label('Forma de Pagamento')
-                ->formatStateUsing(fn ($state) => match ($state->value) {
-                    1 => 'Pix',
-                    2 => 'Dinheiro',
-                    3 => 'Cartão',
-                    4 => 'Não Pago',
-                    default => 'Indefinido',
-                }),
+                ->formatStateUsing(fn (mixed $state): string => self::enumLabel($state, FormaPagamento::class)),
 
             ExportColumn::make('descricao')
-                ->label('Descrição'),
+                ->label('Descrição')
+                ->formatStateUsing(fn (mixed $state): ?string => self::plainText($state)),
+
+            ExportColumn::make('comprovantes_summary')
+                ->label('Comprovantes')
+                ->state(fn (Lancamento $record): string => self::comprovantesSummary($record)),
+
+            ExportColumn::make('comprovante_observacoes_summary')
+                ->label('Observações dos comprovantes')
+                ->state(fn (Lancamento $record): string => self::comprovanteObservationsSummary($record)),
+
+            ExportColumn::make('origin')
+                ->label('Origem')
+                ->formatStateUsing(fn (mixed $state): string => self::originLabel($state)),
+
+            ExportColumn::make('origin_context')
+                ->label('Contexto da origem')
+                ->formatStateUsing(fn (mixed $state): string => self::originContextLabel($state)),
+
+            ExportColumn::make('created_at')
+                ->label('Criado em')
+                ->formatStateUsing(fn (mixed $state): ?string => filled($state) ? Carbon::parse($state)->format('d/m/Y H:i') : null),
+
+            ExportColumn::make('updated_at')
+                ->label('Atualizado em')
+                ->formatStateUsing(fn (mixed $state): ?string => filled($state) ? Carbon::parse($state)->format('d/m/Y H:i') : null),
         ];
+    }
+
+    public static function plainText(mixed $value): ?string
+    {
+        if ($value === null) {
+            return null;
+        }
+
+        $text = html_entity_decode((string) Str::of((string) $value)
+            ->replace(['</p>', '</li>', '<br>', '<br/>', '<br />'], "\n")
+            ->stripTags(), ENT_QUOTES | ENT_HTML5, 'UTF-8');
+
+        $text = preg_replace("/[ \t]+/", ' ', $text) ?? $text;
+        $text = preg_replace("/\n{3,}/", "\n\n", $text) ?? $text;
+
+        return trim($text);
+    }
+
+    public static function itemsSummary(Lancamento $record): string
+    {
+        return self::items($record)
+            ->map(fn (LancamentoItem $item): string => sprintf(
+                '%s (%s)',
+                self::plainText($item->nome) ?: 'Item sem nome',
+                $item->categoria?->nome ?: 'Sem categoria',
+            ))
+            ->implode('; ');
+    }
+
+    public static function itemValuesSummary(Lancamento $record): string
+    {
+        return self::items($record)
+            ->map(fn (LancamentoItem $item): string => sprintf(
+                '%s: %s',
+                self::plainText($item->nome) ?: 'Item sem nome',
+                self::money((int) $item->valor),
+            ))
+            ->implode('; ');
+    }
+
+    public static function itemDescriptionsSummary(Lancamento $record): string
+    {
+        return self::items($record)
+            ->map(fn (LancamentoItem $item): ?string => filled(self::plainText($item->descricao))
+                ? sprintf('%s: %s', self::plainText($item->nome) ?: 'Item sem nome', self::plainText($item->descricao))
+                : null)
+            ->filter()
+            ->implode('; ');
+    }
+
+    public static function registrationsSummary(Lancamento $record): string
+    {
+        return self::items($record)
+            ->filter(fn (LancamentoItem $item): bool => filled($item->registration_type) && filled($item->registration_id))
+            ->map(function (LancamentoItem $item): string {
+                $registration = $item->registration;
+
+                return sprintf(
+                    '%s #%s - %s (%s)',
+                    self::registrationTypeLabel($item->registration_type),
+                    $item->registration_id,
+                    self::registrationName($registration),
+                    self::money((int) $item->valor),
+                );
+            })
+            ->implode('; ');
+    }
+
+    public static function comprovantesSummary(Lancamento $record): string
+    {
+        return collect(LancamentoForm::normalizeComprovanteState(self::comprovanteState($record)))
+            ->flatMap(fn (array $block): array => data_get($block, 'data.url', []))
+            ->filter(fn (mixed $file): bool => is_string($file) && filled($file))
+            ->map(fn (string $file): string => basename(parse_url($file, PHP_URL_PATH) ?: $file))
+            ->implode('; ');
+    }
+
+    public static function comprovanteObservationsSummary(Lancamento $record): string
+    {
+        return collect(LancamentoForm::normalizeComprovanteState(self::comprovanteState($record)))
+            ->map(fn (array $block): ?string => self::plainText(data_get($block, 'data.observacao')))
+            ->filter()
+            ->implode('; ');
+    }
+
+    private static function enumLabel(mixed $state, string $enumClass): string
+    {
+        if (blank($state)) {
+            return 'Indefinido';
+        }
+
+        if ($state instanceof $enumClass) {
+            return $state->getLabel() ?? 'Indefinido';
+        }
+
+        $enum = $enumClass::tryFrom((int) $state);
+
+        return $enum?->getLabel() ?? 'Indefinido';
+    }
+
+    private static function signedAmount(Lancamento $record): int
+    {
+        $amount = abs((int) $record->valor);
+
+        return $record->tipo === TipoLacamento::Despesa ? -$amount : $amount;
+    }
+
+    private static function money(int $amount): string
+    {
+        $sign = $amount < 0 ? '-' : '';
+
+        return $sign.'R$ '.number_format(abs($amount) / 100, 2, ',', '.');
+    }
+
+    /**
+     * @return Collection<int, LancamentoItem>
+     */
+    private static function items(Lancamento $record): Collection
+    {
+        return $record->relationLoaded('items')
+            ? $record->items
+            : $record->items()->with(['categoria', 'registration'])->get();
+    }
+
+    private static function registrationTypeLabel(?string $registrationType): string
+    {
+        return match ($registrationType) {
+            Campista::class => 'Campista',
+            EquipeTrabalho::class => 'Equipe de trabalho',
+            default => 'Cadastro',
+        };
+    }
+
+    private static function registrationName(?Model $registration): string
+    {
+        return (string) ($registration?->getAttribute('nome') ?? 'Inscrição removida');
+    }
+
+    private static function comprovanteState(Lancamento $record): mixed
+    {
+        if (filled($record->comprovante)) {
+            return $record->comprovante;
+        }
+
+        $raw = $record->getRawOriginal('comprovante');
+
+        if (! is_string($raw) || blank($raw)) {
+            return [];
+        }
+
+        $decoded = json_decode($raw, true);
+
+        return json_last_error() === JSON_ERROR_NONE ? $decoded : $raw;
+    }
+
+    private static function originLabel(mixed $state): string
+    {
+        return match ($state) {
+            Lancamento::ORIGIN_AUTO_REGISTRATION => 'Automático',
+            null, '' => 'Manual',
+            default => (string) $state,
+        };
+    }
+
+    private static function originContextLabel(mixed $state): string
+    {
+        return match ($state) {
+            Lancamento::ORIGIN_CONTEXT_OBSERVER => 'Observador da inscrição',
+            Lancamento::ORIGIN_CONTEXT_DAILY_RECONCILIATION => 'Regularização diária',
+            null, '' => 'Manual',
+            default => (string) $state,
+        };
     }
 }

--- a/app/Filament/Widgets/Financial/FinancialPaymentMethodChart.php
+++ b/app/Filament/Widgets/Financial/FinancialPaymentMethodChart.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace App\Filament\Widgets\Financial;
+
+use App\Filament\Widgets\Financial\Concerns\UsesFinancialDashboardData;
+use Filament\Support\RawJs;
+use Leandrocfe\FilamentApexCharts\Widgets\ApexChartWidget;
+
+class FinancialPaymentMethodChart extends ApexChartWidget
+{
+    use UsesFinancialDashboardData;
+
+    protected static ?string $chartId = 'financialPaymentMethodChart';
+
+    protected static ?int $sort = 4;
+
+    protected function getHeading(): ?string
+    {
+        return 'Saldo por forma de pagamento';
+    }
+
+    protected function getOptions(): array
+    {
+        $data = $this->emptyChartData($this->financialData()->paymentMethodBalances());
+
+        return [
+            'chart' => [
+                'type' => 'pie',
+                'height' => 320,
+                'toolbar' => ['show' => false],
+            ],
+            'labels' => array_keys($data),
+            'series' => array_values($data),
+            'legend' => [
+                'position' => 'bottom',
+                'horizontalAlign' => 'center',
+            ],
+            'dataLabels' => [
+                'enabled' => true,
+            ],
+            'colors' => [
+                '#14b8a6',
+                '#22c55e',
+                '#f97316',
+                '#8b5cf6',
+                '#0ea5e9',
+                '#f43f5e',
+                '#eab308',
+                '#64748b',
+            ],
+            'stroke' => [
+                'width' => 2,
+            ],
+        ];
+    }
+
+    protected function extraJsOptions(): ?RawJs
+    {
+        return $this->currencyPieJsOptions();
+    }
+}

--- a/app/Policies/EquipeTrabalhoPolicy.php
+++ b/app/Policies/EquipeTrabalhoPolicy.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 
 namespace App\Policies;
 
-use Illuminate\Foundation\Auth\User as AuthUser;
 use App\Models\EquipeTrabalho;
 use Illuminate\Auth\Access\HandlesAuthorization;
+use Illuminate\Foundation\Auth\User as AuthUser;
 
 class EquipeTrabalhoPolicy
 {
@@ -72,4 +72,8 @@ class EquipeTrabalhoPolicy
         return $authUser->can('reorder_equipe_trabalho');
     }
 
+    public function export(AuthUser $authUser): bool
+    {
+        return $authUser->can('export_equipe_trabalho');
+    }
 }

--- a/app/Support/Dashboard/FinancialDashboardData.php
+++ b/app/Support/Dashboard/FinancialDashboardData.php
@@ -2,6 +2,7 @@
 
 namespace App\Support\Dashboard;
 
+use App\Enums\FormaPagamento;
 use App\Enums\TipoLacamento;
 use App\Models\Lancamento;
 use App\Models\LancamentoItem;
@@ -91,6 +92,16 @@ class FinancialDashboardDataSet
             ->all();
     }
 
+    public function paymentMethodBalances(): array
+    {
+        return $this->records
+            ->groupBy(fn (Lancamento $lancamento): string => $this->paymentMethodLabel($lancamento))
+            ->map(fn (Collection $records): int => $this->flowFor($records)['balance'])
+            ->filter(fn (int $balance): bool => $balance !== 0)
+            ->sortDesc()
+            ->all();
+    }
+
     public function recentEntries(int $limit = 8): Collection
     {
         return $this->records->take($limit)->values();
@@ -132,6 +143,17 @@ class FinancialDashboardDataSet
         }
 
         return abs((int) $lancamento->valor);
+    }
+
+    private function paymentMethodLabel(Lancamento $lancamento): string
+    {
+        if ($lancamento->forma_pagamento instanceof FormaPagamento) {
+            return $lancamento->forma_pagamento->getLabel() ?? 'Não informado';
+        }
+
+        $paymentMethod = FormaPagamento::tryFrom((int) $lancamento->forma_pagamento);
+
+        return $paymentMethod?->getLabel() ?? 'Não informado';
     }
 
     private function categoryItems(Lancamento $lancamento): Collection

--- a/config/filament-shield.php
+++ b/config/filament-shield.php
@@ -2,6 +2,9 @@
 
 declare(strict_types=1);
 
+use App\Filament\Resources\CampistaResource;
+use App\Filament\Resources\EquipeTrabalhoResource;
+use App\Filament\Resources\TriboResource;
 use BezhanSalleh\FilamentShield\Resources\Roles\RoleResource;
 use Filament\Pages\Dashboard;
 use Filament\Widgets\AccountWidget;
@@ -16,7 +19,7 @@ return [
             'pages' => true,
             'widgets' => true,
             'resources' => true,
-            'custom_permissions' => false,
+            'custom_permissions' => true,
         ],
     ],
 
@@ -78,12 +81,26 @@ return [
     'resources' => [
         'subject' => 'model',
         'manage' => [
+            CampistaResource::class => [
+                'audit',
+                'export',
+                'restoreAudit',
+                'updateTribo',
+                'viewSensitiveHealth',
+            ],
+            EquipeTrabalhoResource::class => [
+                'export',
+            ],
             RoleResource::class => [
                 'viewAny',
                 'view',
                 'create',
                 'update',
                 'delete',
+            ],
+            TriboResource::class => [
+                'audit',
+                'restoreAudit',
             ],
         ],
         'exclude' => [],
@@ -106,7 +123,12 @@ return [
         ],
     ],
 
-    'custom_permissions' => [],
+    'custom_permissions' => [
+        'print_mission_contacts_report' => 'Imprimir relatório de contatos e endereços',
+        'print_registration_fichas_report' => 'Imprimir fichas de inscrição',
+        'print_sensitive_health_report' => 'Imprimir relatório médico da enfermaria',
+        'print_tribe_quadrant_report' => 'Imprimir quadrante por tribo',
+    ],
 
     'discovery' => [
         'discover_all_resources' => false,

--- a/database/seeders/ShieldSeeder.php
+++ b/database/seeders/ShieldSeeder.php
@@ -235,18 +235,8 @@ class ShieldSeeder extends Seeder
 
     protected static function customPermissionNames(): array
     {
-        return [
-            'audit_campista',
-            'audit_tribo',
-            'export_campista',
-            self::MISSION_CONTACTS_REPORT_PERMISSION,
-            self::REGISTRATION_FICHAS_REPORT_PERMISSION,
-            'restoreAudit_campista',
-            'restoreAudit_tribo',
-            self::SENSITIVE_HEALTH_REPORT_PERMISSION,
-            self::TRIBE_QUADRANT_REPORT_PERMISSION,
-            'updateTribo_campista',
-            self::SENSITIVE_HEALTH_PERMISSION,
-        ];
+        return collect(config('filament-shield.custom_permissions', []))
+            ->keys()
+            ->all();
     }
 }

--- a/tests/Feature/EquipeTrabalhoGroupsPageTest.php
+++ b/tests/Feature/EquipeTrabalhoGroupsPageTest.php
@@ -9,6 +9,7 @@ use Database\Seeders\ShieldSeeder;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\DB;
 use Livewire\Livewire;
+use Spatie\Permission\Models\Permission;
 use Spatie\Permission\Models\Role;
 
 uses(RefreshDatabase::class);
@@ -33,6 +34,13 @@ it('grants the team work groups page permission to camp administrators', functio
 
     expect(Role::findByName('Administrador')->hasPermissionTo('page_equipe_trabalho_groups'))->toBeTrue()
         ->and(Role::findByName('Financeiro')->hasPermissionTo('page_equipe_trabalho_groups'))->toBeFalse();
+});
+
+it('registers the team work export permission for permission groups', function () {
+    $this->seed(ShieldSeeder::class);
+
+    expect(Permission::query()->where('name', 'export_equipe_trabalho')->exists())->toBeTrue()
+        ->and(Role::findByName('Super Administrador')->hasPermissionTo('export_equipe_trabalho'))->toBeTrue();
 });
 
 it('renders work team groups with their value rule and configured reference amount', function () {

--- a/tests/Feature/FinancialDashboardDataTest.php
+++ b/tests/Feature/FinancialDashboardDataTest.php
@@ -156,8 +156,39 @@ it('applies financial dashboard filters to totals charts and recent entries', fu
             'Inscrição' => 25000,
             'Alimentação' => 4000,
         ])
+        ->and($data->paymentMethodBalances())->toBe([
+            'Pix' => 21000,
+        ])
         ->and($data->recentEntries()->pluck('nome')->all())->toBe([
             'Despesa filtrada',
             'PIX filtrado',
         ]);
+});
+
+it('summarizes financial balances by payment method', function () {
+    makeFinancialDashboardEntry([
+        'nome' => 'Receita Pix',
+        'valor' => 25000,
+        'tipo' => TipoLacamento::Receita->value,
+        'forma_pagamento' => FormaPagamento::Pix->value,
+    ]);
+    makeFinancialDashboardEntry([
+        'nome' => 'Despesa Pix',
+        'valor' => 4000,
+        'tipo' => TipoLacamento::Despesa->value,
+        'forma_pagamento' => FormaPagamento::Pix->value,
+    ]);
+    makeFinancialDashboardEntry([
+        'nome' => 'Doação dinheiro',
+        'valor' => 10000,
+        'tipo' => TipoLacamento::Doacao->value,
+        'forma_pagamento' => FormaPagamento::Dinheiro->value,
+    ]);
+
+    $balances = app(FinancialDashboardData::class)->forFilters([])->paymentMethodBalances();
+
+    expect($balances)->toBe([
+        'Pix' => 21000,
+        'Dinheiro' => 10000,
+    ]);
 });

--- a/tests/Feature/FinancialDashboardWidgetsTest.php
+++ b/tests/Feature/FinancialDashboardWidgetsTest.php
@@ -6,6 +6,7 @@ use App\Filament\Pages\FinancialDashboard;
 use App\Filament\Widgets\Financial\FinancialCategoryChart;
 use App\Filament\Widgets\Financial\FinancialDailyFlowChart;
 use App\Filament\Widgets\Financial\FinancialOverviewStats;
+use App\Filament\Widgets\Financial\FinancialPaymentMethodChart;
 use App\Filament\Widgets\Financial\RecentFinancialEntriesTable;
 use App\Models\CategoriaLancamento;
 use App\Models\Lancamento;
@@ -68,6 +69,7 @@ it('registers a financial dashboard page in the finance navigation group with gl
         FinancialOverviewStats::class,
         FinancialDailyFlowChart::class,
         FinancialCategoryChart::class,
+        FinancialPaymentMethodChart::class,
         RecentFinancialEntriesTable::class,
     ])
         ->and(FinancialDashboard::getRoutePath(filament()->getPanel('admin')))->toBe('/financeiro')
@@ -95,16 +97,20 @@ it('renders the financial dashboard route for administrators', function () {
 it('configures financial Apex charts with currency formatters', function () {
     $dailyOptions = financialDashboardChartOptions(FinancialDailyFlowChart::class);
     $categoryOptions = financialDashboardChartOptions(FinancialCategoryChart::class);
+    $paymentMethodOptions = financialDashboardChartOptions(FinancialPaymentMethodChart::class);
 
     expect($dailyOptions['chart']['type'])->toBe('bar')
         ->and($dailyOptions['series'])->toHaveCount(4)
         ->and($categoryOptions['chart']['type'])->toBe('pie')
+        ->and($paymentMethodOptions['chart']['type'])->toBe('pie')
+        ->and($paymentMethodOptions)->toHaveKey('labels')
         ->and($categoryOptions)->toHaveKey('labels')
         ->and($categoryOptions)->not->toHaveKey('xaxis')
         ->and($categoryOptions)->not->toHaveKey('plotOptions')
         ->and(financialDashboardChartExtraJs(FinancialDailyFlowChart::class))->toContain('Intl.NumberFormat')
         ->and(financialDashboardChartExtraJs(FinancialCategoryChart::class))->toContain('Intl.NumberFormat')
-        ->and(financialDashboardChartExtraJs(FinancialCategoryChart::class))->toContain('options.w.config.series');
+        ->and(financialDashboardChartExtraJs(FinancialCategoryChart::class))->toContain('options.w.config.series')
+        ->and(financialDashboardChartExtraJs(FinancialPaymentMethodChart::class))->toContain('options.w.config.series');
 });
 
 it('renders financial category values as pie chart slices', function () {
@@ -127,6 +133,30 @@ it('renders financial category values as pie chart slices', function () {
     expect($options['chart']['type'])->toBe('pie')
         ->and($options['labels'])->toBe(['Mercado'])
         ->and($options['series'])->toBe([560]);
+});
+
+it('renders financial balances by payment method as pie chart slices', function () {
+    makeFinancialDashboardWidgetEntry([
+        'valor' => 25000,
+        'tipo' => TipoLacamento::Receita->value,
+        'forma_pagamento' => 1,
+    ]);
+    makeFinancialDashboardWidgetEntry([
+        'valor' => 4000,
+        'tipo' => TipoLacamento::Despesa->value,
+        'forma_pagamento' => 1,
+    ]);
+    makeFinancialDashboardWidgetEntry([
+        'valor' => 10000,
+        'tipo' => TipoLacamento::Doacao->value,
+        'forma_pagamento' => 2,
+    ]);
+
+    $options = financialDashboardChartOptions(FinancialPaymentMethodChart::class);
+
+    expect($options['chart']['type'])->toBe('pie')
+        ->and($options['labels'])->toBe(['Pix', 'Dinheiro'])
+        ->and($options['series'])->toBe([21000, 10000]);
 });
 
 it('keeps the daily financial flow y axis able to show negative balances', function () {

--- a/tests/Feature/LancamentoExportTest.php
+++ b/tests/Feature/LancamentoExportTest.php
@@ -1,0 +1,97 @@
+<?php
+
+use App\Enums\FormaPagamento;
+use App\Enums\StatusInscricao;
+use App\Enums\StatusLacamento;
+use App\Enums\TipoLacamento;
+use App\Filament\Resources\LancamentoResource\LancamentoExport;
+use App\Models\Campista;
+use App\Models\CategoriaLancamento;
+use App\Models\Lancamento;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+uses(RefreshDatabase::class);
+
+function lancamentoExportCategory(string $name, TipoLacamento $type): CategoriaLancamento
+{
+    return CategoriaLancamento::query()->firstOrCreate(
+        [
+            'nome' => $name,
+            'tipo' => $type->value,
+        ],
+        [
+            'cor' => '#f46b12',
+            'icone' => 'heroicon-o-banknotes',
+            'ativo' => true,
+        ],
+    );
+}
+
+it('exports updated financial entry columns', function () {
+    $columnNames = collect(LancamentoExport::getExportColumns())
+        ->map(fn ($column): string => $column->getName())
+        ->all();
+
+    expect($columnNames)->toContain(
+        'items_summary',
+        'item_values_summary',
+        'item_descriptions_summary',
+        'registration_payments_summary',
+        'comprovantes_summary',
+        'comprovante_observacoes_summary',
+        'origin',
+        'origin_context',
+        'created_at',
+        'updated_at',
+    );
+});
+
+it('exports launch rich text and item summaries as plain text', function () {
+    $category = lancamentoExportCategory('Inscrição', TipoLacamento::Receita);
+    $campista = Campista::factory()->create([
+        'nome' => 'João Exportação',
+        'status' => StatusInscricao::Pago->value,
+    ]);
+    $lancamento = Lancamento::query()->create([
+        'nome' => 'Lançamento exportável',
+        'descricao' => '<p>Pagamento <strong>confirmado</strong></p><ul><li>Sem HTML</li></ul>',
+        'comprador' => null,
+        'data' => '2026-07-03',
+        'valor' => 25000,
+        'tipo' => TipoLacamento::Receita->value,
+        'status' => StatusLacamento::Pago->value,
+        'forma_pagamento' => FormaPagamento::Pix->value,
+        'comprovante' => [
+            [
+                'type' => 'anexar_comprovante',
+                'data' => [
+                    'url' => ['comprovantes/pix-exportacao.pdf'],
+                    'observacao' => '<p>Recebido <strong>via Pix</strong></p>',
+                ],
+            ],
+        ],
+        'batch_code' => 'LOTE-EXPORT',
+        'origin' => Lancamento::ORIGIN_AUTO_REGISTRATION,
+        'origin_context' => Lancamento::ORIGIN_CONTEXT_DAILY_RECONCILIATION,
+        'user_id' => null,
+    ]);
+
+    $lancamento->items()->create([
+        'nome' => 'Parcela inscrição',
+        'descricao' => '<p>Item <em>principal</em></p>',
+        'valor' => 25000,
+        'categoria_lancamento_id' => $category->id,
+        'registration_type' => Campista::class,
+        'registration_id' => $campista->id,
+    ]);
+
+    $lancamento->load(['items.categoria', 'items.registration']);
+
+    expect(LancamentoExport::plainText($lancamento->descricao))->toBe("Pagamento confirmado\nSem HTML")
+        ->and(LancamentoExport::itemsSummary($lancamento))->toBe('Parcela inscrição (Inscrição)')
+        ->and(LancamentoExport::itemValuesSummary($lancamento))->toBe('Parcela inscrição: R$ 250,00')
+        ->and(LancamentoExport::itemDescriptionsSummary($lancamento))->toBe('Parcela inscrição: Item principal')
+        ->and(LancamentoExport::registrationsSummary($lancamento))->toBe('Campista #'.$campista->id.' - João Exportação (R$ 250,00)')
+        ->and(LancamentoExport::comprovantesSummary($lancamento))->toBe('pix-exportacao.pdf')
+        ->and(LancamentoExport::comprovanteObservationsSummary($lancamento))->toBe('Recebido via Pix');
+});

--- a/tests/Feature/ReportsPageTest.php
+++ b/tests/Feature/ReportsPageTest.php
@@ -148,6 +148,8 @@ it('seeds report permissions with least privilege by role', function () {
     $this->seed(ShieldSeeder::class);
 
     expect(Permission::query()->where('name', 'page_reports_page')->exists())->toBeTrue()
+        ->and(config('filament-shield.shield_resource.tabs.custom_permissions'))->toBeTrue()
+        ->and(config('filament-shield.custom_permissions.print_registration_fichas_report'))->toBe('Imprimir fichas de inscrição')
         ->and(Permission::query()->where('name', 'print_registration_fichas_report')->exists())->toBeTrue()
         ->and(Permission::query()->where('name', 'print_tribe_quadrant_report')->exists())->toBeTrue()
         ->and(Permission::query()->where('name', 'print_mission_contacts_report')->exists())->toBeTrue()


### PR DESCRIPTION
## Summary
- Adds a financial dashboard pie chart for balances grouped by payment method.
- Expands financial entry exports with formatted amounts, dates, enum labels, item summaries, registration links, receipt filenames/observations, origin context, and timestamps.
- Eager-loads export relationships to avoid per-row item/category/registration lookups.
- Adds Shield export permission support for work team resources and moves custom Shield permissions into configuration.

## Testing
- Added/updated feature coverage for financial dashboard payment method balances and widget options.
- Added `LancamentoExportTest` for new export columns and plain-text summary formatting.
- Updated Shield/report permission tests for configured custom permissions and team export permission registration.