### PR TITLE
Allow multiple category filters for lançamentos

### DIFF
--- a/app/Filament/Resources/LancamentoResource.php
+++ b/app/Filament/Resources/LancamentoResource.php
@@ -254,15 +254,38 @@ class LancamentoResource extends Resource
                 SelectFilter::make('categoria_lancamento_id')
                     ->label('Categoria')
                     ->options(fn (): array => self::categoryFilterOptions())
-                    ->query(fn (Builder $query, array $data): Builder => blank($data['value'] ?? null)
-                        ? $query
-                        : $query->whereHas('items', fn (Builder $query): Builder => $query->where('categoria_lancamento_id', $data['value'])))
+                    ->multiple()
+                    ->query(function (Builder $query, array $data): Builder {
+                        $categoryIds = collect($data['values'] ?? [])
+                            ->filter(fn (mixed $value): bool => filled($value))
+                            ->map(fn (mixed $value): int => (int) $value)
+                            ->values()
+                            ->all();
+
+                        return $categoryIds === []
+                            ? $query
+                            : $query->whereHas('items', fn (Builder $query): Builder => $query->whereIn('categoria_lancamento_id', $categoryIds));
+                    })
                     ->searchable()
                     ->native(false)
                     ->modifyFormFieldUsing(fn (Select $field): Select => $field->allowHtml())
-                    ->indicateUsing(fn (array $state): array => blank($state['value'] ?? null)
-                        ? []
-                        : ['Categoria: '.(CategoriaLancamento::query()->whereKey($state['value'])->value('nome') ?? $state['value'])])
+                    ->indicateUsing(function (array $state): array {
+                        $categoryIds = collect($state['values'] ?? [])
+                            ->filter(fn (mixed $value): bool => filled($value))
+                            ->map(fn (mixed $value): int => (int) $value)
+                            ->values();
+
+                        if ($categoryIds->isEmpty()) {
+                            return [];
+                        }
+
+                        return CategoriaLancamento::query()
+                            ->whereKey($categoryIds->all())
+                            ->orderBy('nome')
+                            ->pluck('nome')
+                            ->map(fn (string $name): string => 'Categoria: '.$name)
+                            ->all();
+                    })
                     ->preload(),
                 SelectFilter::make('batch_code')
                     ->label('Lote')

--- a/resources/css/filament/admin/theme.css
+++ b/resources/css/filament/admin/theme.css
@@ -778,6 +778,10 @@ body.fi-panel-admin:not(.juvenil-admin-auth-body) .juvenil-lancamento-table .fi-
     overflow-x: auto;
 }
 
+body.fi-panel-admin:not(.juvenil-admin-auth-body) .juvenil-lancamento-table .fi-ta-content-ctn:has(.fi-ta-cell-registration-payments-summary .juvenil-lancamento-table__registrations:is(:hover, :focus-within)) {
+    overflow: visible;
+}
+
 body.fi-panel-admin:not(.juvenil-admin-auth-body) .juvenil-lancamento-table .fi-ta-table {
     min-width: 84rem;
     table-layout: fixed;

--- a/tests/Feature/CategoriaLancamentoResourceTest.php
+++ b/tests/Feature/CategoriaLancamentoResourceTest.php
@@ -362,6 +362,8 @@ it('exposes the category field on the financial entry form and table', function 
         ->toContain('IconBadge::tile($category')
         ->toContain('->modifyFormFieldUsing(fn (Select $field): Select => $field->allowHtml())')
         ->toContain('->native(false)')
+        ->toContain('->multiple()')
         ->toContain("whereHas('items'")
+        ->toContain("whereIn('categoria_lancamento_id'")
         ->toContain("Group::make('batch_code')");
 });

--- a/tests/Feature/LancamentoViewPageTest.php
+++ b/tests/Feature/LancamentoViewPageTest.php
@@ -135,6 +135,7 @@ it('uses a compact readable layout for the launch table columns', function () {
         ->toContain('Itens deste lançamento')
         ->and($theme)
         ->toContain('.juvenil-lancamento-table .fi-ta-table')
+        ->toContain('.juvenil-lancamento-table .fi-ta-content-ctn:has(.fi-ta-cell-registration-payments-summary .juvenil-lancamento-table__registrations:is(:hover, :focus-within))')
         ->toContain('min-width: 84rem;')
         ->toContain('.juvenil-lancamento-table__category-stack')
         ->toContain('.juvenil-lancamento-table__category-stack-extra')


### PR DESCRIPTION
## Summary
- Updated the lançamentos category table filter to support selecting multiple categories.
- Applies the filter with `whereIn` across lançamento items and renders one indicator per selected category.
- Adjusted admin table CSS so registration payment summaries can overflow visibly on hover/focus.

## Testing
- Updated feature coverage in `CategoriaLancamentoResourceTest` and `LancamentoViewPageTest` to assert the multi-select filter and CSS behavior.