### PR TITLE
Add registration payment report

### DIFF
--- a/app/Actions/Reports/EnsureReportExportAction.php
+++ b/app/Actions/Reports/EnsureReportExportAction.php
@@ -119,7 +119,7 @@ class EnsureReportExportAction
         $query = $filters;
         $query['_template_version'] = $this->templateVersionFor($type);
 
-        foreach (['status', 'tribo_id'] as $key) {
+        foreach (['status', 'payment_status', 'tribo_id'] as $key) {
             if (isset($query[$key]) && is_array($query[$key])) {
                 sort($query[$key]);
             }

--- a/app/Filament/Pages/ReportsPage.php
+++ b/app/Filament/Pages/ReportsPage.php
@@ -3,9 +3,12 @@
 namespace App\Filament\Pages;
 
 use App\Enums\StatusInscricao;
+use App\Enums\StatusLacamento;
 use App\Support\Reports\CampistaReportData;
+use App\Support\Reports\CampistaReportType;
 use BezhanSalleh\FilamentShield\Traits\HasPageShield;
 use Filament\Actions\Action;
+use Filament\Facades\Filament;
 use Filament\Forms\Components\Checkbox;
 use Filament\Forms\Components\Select;
 use Filament\Forms\Components\TextInput;
@@ -46,6 +49,10 @@ class ReportsPage extends Page
             StatusInscricao::Pendente->value,
             StatusInscricao::Pago->value,
         ],
+        'payment_status' => [
+            StatusLacamento::Pendente->value,
+            StatusLacamento::Pago->value,
+        ],
         'tribo_id' => [],
         'presenca' => null,
         'search' => null,
@@ -57,6 +64,15 @@ class ReportsPage extends Page
     public static function getRoutePath(Panel $panel): string
     {
         return '/relatorios';
+    }
+
+    public static function canAccess(): bool
+    {
+        $user = Filament::auth()?->user();
+
+        return $user !== null
+            && ($user->can(CampistaReportType::PAGE_PERMISSION)
+                || $user->can(CampistaReportType::RegistrationPayments->permission()));
     }
 
     public function mount(): void
@@ -114,7 +130,7 @@ class ReportsPage extends Page
 
                                 TextInput::make('search')
                                     ->label('Busca')
-                                    ->placeholder('Nome, responsável, bairro ou cidade')
+                                    ->placeholder('Nome, responsável, bairro, cidade ou lançamento')
                                     ->prefixIcon('heroicon-o-magnifying-glass')
                                     ->live(debounce: 500)
                                     ->columnSpan([
@@ -130,6 +146,21 @@ class ReportsPage extends Page
                                     ->native(false)
                                     ->live()
                                     ->placeholder('Pendente e Pago')
+                                    ->visible(fn (Get $get): bool => ! $this->isRegistrationPaymentReport($get('type')))
+                                    ->columnSpan([
+                                        'default' => 'full',
+                                        'md' => 1,
+                                        'xl' => 4,
+                                    ]),
+
+                                Select::make('payment_status')
+                                    ->label('Status do pagamento')
+                                    ->multiple()
+                                    ->options(fn (): array => $this->paymentStatusOptions())
+                                    ->native(false)
+                                    ->live()
+                                    ->placeholder('Pendente e Pago')
+                                    ->visible(fn (Get $get): bool => $this->isRegistrationPaymentReport($get('type')))
                                     ->columnSpan([
                                         'default' => 'full',
                                         'md' => 1,
@@ -145,6 +176,7 @@ class ReportsPage extends Page
                                     ->preload()
                                     ->live()
                                     ->placeholder('Todas')
+                                    ->visible(fn (Get $get): bool => ! $this->isRegistrationPaymentReport($get('type')))
                                     ->columnSpan([
                                         'default' => 'full',
                                         'md' => 1,
@@ -160,6 +192,7 @@ class ReportsPage extends Page
                                     ->native(false)
                                     ->live()
                                     ->placeholder('Todas')
+                                    ->visible(fn (Get $get): bool => ! $this->isRegistrationPaymentReport($get('type')))
                                     ->columnSpan([
                                         'default' => 'full',
                                         'md' => 1,
@@ -175,7 +208,8 @@ class ReportsPage extends Page
                                             $set('confirm_sensitive_health', false);
                                         }
                                     })
-                                    ->visible(fn (): bool => $this->canUseSensitiveHealthFilter())
+                                    ->visible(fn (Get $get): bool => $this->canUseSensitiveHealthFilter()
+                                        && ! $this->isRegistrationPaymentReport($get('type')))
                                     ->columnSpan([
                                         'default' => 'full',
                                         'md' => 1,
@@ -186,7 +220,8 @@ class ReportsPage extends Page
                                     ->label('Exibir dados de pagamento')
                                     ->helperText('Por padrão, dados de pagamento permanecem ocultos nos relatórios.')
                                     ->live()
-                                    ->visible(fn (): bool => $this->canUsePaymentDataFilter())
+                                    ->visible(fn (Get $get): bool => $this->canUsePaymentDataFilter()
+                                        && ! $this->isRegistrationPaymentReport($get('type')))
                                     ->columnSpan([
                                         'default' => 'full',
                                         'md' => 1,
@@ -199,7 +234,9 @@ class ReportsPage extends Page
                                         <span>Ao exibir estes dados, trate as informações com cuidado. Elas não devem ser compartilhadas fora das pessoas responsáveis pelo cuidado e pela operação do acampamento.</span>
                                     </div>'
                                 ))
-                                    ->visible(fn (Get $get): bool => $this->canUseSensitiveHealthFilter() && (bool) $get('show_sensitive_health'))
+                                    ->visible(fn (Get $get): bool => $this->canUseSensitiveHealthFilter()
+                                        && ! $this->isRegistrationPaymentReport($get('type'))
+                                        && (bool) $get('show_sensitive_health'))
                                     ->columnSpanFull(),
 
                                 Checkbox::make('confirm_sensitive_health')
@@ -207,7 +244,9 @@ class ReportsPage extends Page
                                     ->helperText('A impressão só exibirá os dados médicos após esta confirmação.')
                                     ->accepted()
                                     ->live()
-                                    ->visible(fn (Get $get): bool => $this->canUseSensitiveHealthFilter() && (bool) $get('show_sensitive_health'))
+                                    ->visible(fn (Get $get): bool => $this->canUseSensitiveHealthFilter()
+                                        && ! $this->isRegistrationPaymentReport($get('type'))
+                                        && (bool) $get('show_sensitive_health'))
                                     ->columnSpanFull(),
                             ]),
                     ])
@@ -234,6 +273,11 @@ class ReportsPage extends Page
         return app(CampistaReportData::class)->statusOptions();
     }
 
+    public function paymentStatusOptions(): array
+    {
+        return app(CampistaReportData::class)->paymentStatusOptions();
+    }
+
     public function tribeOptions(): array
     {
         return app(CampistaReportData::class)->tribeOptions();
@@ -241,7 +285,13 @@ class ReportsPage extends Page
 
     public function previewQuery(): array
     {
-        $query = collect($this->filters)
+        $query = collect($this->filters);
+
+        $query = $this->isRegistrationPaymentReport($this->filters['type'] ?? null)
+            ? $query->only(['type', 'payment_status', 'search'])
+            : $query->except('payment_status');
+
+        $query = $query
             ->filter(fn (mixed $value): bool => $value !== null && $value !== '' && $value !== [] && $value !== false)
             ->all();
 
@@ -266,7 +316,8 @@ class ReportsPage extends Page
 
     private function missingSensitiveHealthConfirmation(): bool
     {
-        return $this->canUseSensitiveHealthFilter()
+        return ! $this->isRegistrationPaymentReport($this->filters['type'] ?? null)
+            && $this->canUseSensitiveHealthFilter()
             && (bool) ($this->filters['show_sensitive_health'] ?? false)
             && ! (bool) ($this->filters['confirm_sensitive_health'] ?? false);
     }
@@ -286,6 +337,10 @@ class ReportsPage extends Page
 
         if (array_key_exists('status', $query)) {
             $filters['status'] = $this->integerList($query['status']);
+        }
+
+        if (array_key_exists('payment_status', $query)) {
+            $filters['payment_status'] = $this->integerList($query['payment_status']);
         }
 
         if (array_key_exists('tribo_id', $query)) {
@@ -325,5 +380,10 @@ class ReportsPage extends Page
     private function truthy(mixed $value): bool
     {
         return filter_var($value, FILTER_VALIDATE_BOOLEAN);
+    }
+
+    private function isRegistrationPaymentReport(mixed $type): bool
+    {
+        return $type === CampistaReportType::RegistrationPayments->value;
     }
 }

--- a/app/Filament/Pages/ViewReport.php
+++ b/app/Filament/Pages/ViewReport.php
@@ -42,11 +42,13 @@ class ViewReport extends Page
 
     /**
      * @param  array<int, int>|null  $status
+     * @param  array<int, int>|null  $payment_status
      * @param  array<int, int>|null  $tribo_id
      */
     public function mount(
         ?string $type = null,
         ?array $status = null,
+        ?array $payment_status = null,
         ?array $tribo_id = null,
         ?string $presenca = null,
         ?string $search = null,
@@ -60,6 +62,7 @@ class ViewReport extends Page
         $merged = array_merge($queryParams, array_filter([
             'type' => $type,
             'status' => $status,
+            'payment_status' => $payment_status,
             'tribo_id' => $tribo_id,
             'presenca' => $presenca,
             'search' => $search,
@@ -216,6 +219,7 @@ class ViewReport extends Page
         return collect([
             'type' => $this->reportType,
             'status' => $this->integerList($query['status'] ?? []),
+            'payment_status' => $this->integerList($query['payment_status'] ?? []),
             'tribo_id' => $this->integerList($query['tribo_id'] ?? []),
             'presenca' => array_key_exists('presenca', $query) && $query['presenca'] !== ''
                 ? (string) (int) $query['presenca']

--- a/app/Filament/Resources/CampistaResource.php
+++ b/app/Filament/Resources/CampistaResource.php
@@ -8,12 +8,14 @@ use App\Filament\Resources\CampistaResource\CampistaForm;
 use App\Filament\Resources\CampistaResource\CampistaTable;
 use App\Filament\Resources\CampistaResource\Pages;
 use App\Models\Campista;
+use App\Support\Financeiro\FinancialFilterOptions;
 use BezhanSalleh\FilamentShield\Contracts\HasShieldPermissions;
 use Carbon\Carbon;
 use Filament\Actions\Action;
 use Filament\Actions\EditAction;
 use Filament\Actions\ExportBulkAction;
 use Filament\Actions\Exports\Models\Export;
+use Filament\Forms\Components\Select;
 use Filament\Forms\Components\Textarea;
 use Filament\Resources\Resource;
 use Filament\Schemas\Schema;
@@ -21,6 +23,7 @@ use Filament\Tables;
 use Filament\Tables\Filters\SelectFilter;
 use Filament\Tables\Grouping\Group;
 use Filament\Tables\Table;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
 use Tapp\FilamentAuditing\RelationManagers\AuditsRelationManager;
 
@@ -65,6 +68,44 @@ class CampistaResource extends Resource implements HasShieldPermissions
                     ->selectablePlaceholder('Sem tribo definida')
                     ->label('Tribo')
                     ->relationship('tribo', 'cor'),
+                SelectFilter::make('payment_status')
+                    ->label('Status do pagamento')
+                    ->options(fn (): array => FinancialFilterOptions::paymentStatuses())
+                    ->multiple()
+                    ->query(function (Builder $query, array $data): Builder {
+                        $statuses = FinancialFilterOptions::selectedIntegerValues($data);
+
+                        return $statuses === []
+                            ? $query
+                            : $query->whereHas(
+                                'lancamentoItems.lancamento',
+                                fn (Builder $query): Builder => $query->whereIn('status', $statuses),
+                            );
+                    })
+                    ->searchable()
+                    ->preload()
+                    ->native(false)
+                    ->modifyFormFieldUsing(fn (Select $field): Select => $field->allowHtml())
+                    ->indicateUsing(fn (array $state): array => FinancialFilterOptions::paymentStatusIndicators($state)),
+                SelectFilter::make('categoria_lancamento_id')
+                    ->label('Categoria')
+                    ->options(fn (): array => FinancialFilterOptions::categories())
+                    ->multiple()
+                    ->query(function (Builder $query, array $data): Builder {
+                        $categoryIds = FinancialFilterOptions::selectedIntegerValues($data);
+
+                        return $categoryIds === []
+                            ? $query
+                            : $query->whereHas(
+                                'lancamentoItems',
+                                fn (Builder $query): Builder => $query->whereIn('categoria_lancamento_id', $categoryIds),
+                            );
+                    })
+                    ->searchable()
+                    ->preload()
+                    ->native(false)
+                    ->modifyFormFieldUsing(fn (Select $field): Select => $field->allowHtml())
+                    ->indicateUsing(fn (array $state): array => FinancialFilterOptions::categoryIndicators($state)),
                 Tables\Filters\TernaryFilter::make('presenca')
                     ->label('Presença')
                     ->placeholder('Todos')

--- a/app/Filament/Resources/EquipeTrabalhoResource/EquipeTrabalhoTable.php
+++ b/app/Filament/Resources/EquipeTrabalhoResource/EquipeTrabalhoTable.php
@@ -5,12 +5,15 @@ namespace App\Filament\Resources\EquipeTrabalhoResource;
 use App\Enums\StatusInscricaoEquipeTrabalho;
 use App\Enums\TipoEquipeTrabalho;
 use App\Models\EquipeTrabalho;
+use App\Support\Financeiro\FinancialFilterOptions;
 use Carbon\Carbon;
+use Filament\Forms\Components\Select;
 use Filament\Support\Colors\Color;
 use Filament\Tables\Columns\ImageColumn;
 use Filament\Tables\Columns\SelectColumn;
 use Filament\Tables\Columns\TextColumn;
 use Filament\Tables\Filters\SelectFilter;
+use Illuminate\Database\Eloquent\Builder;
 use Throwable;
 
 abstract class EquipeTrabalhoTable
@@ -120,6 +123,46 @@ abstract class EquipeTrabalhoTable
             SelectFilter::make('tipo_equipe')
                 ->label('Tipo da equipe')
                 ->options(TipoEquipeTrabalho::class),
+
+            SelectFilter::make('payment_status')
+                ->label('Status do pagamento')
+                ->options(fn (): array => FinancialFilterOptions::paymentStatuses())
+                ->multiple()
+                ->query(function (Builder $query, array $data): Builder {
+                    $statuses = FinancialFilterOptions::selectedIntegerValues($data);
+
+                    return $statuses === []
+                        ? $query
+                        : $query->whereHas(
+                            'lancamentoItems.lancamento',
+                            fn (Builder $query): Builder => $query->whereIn('status', $statuses),
+                        );
+                })
+                ->searchable()
+                ->preload()
+                ->native(false)
+                ->modifyFormFieldUsing(fn (Select $field): Select => $field->allowHtml())
+                ->indicateUsing(fn (array $state): array => FinancialFilterOptions::paymentStatusIndicators($state)),
+
+            SelectFilter::make('categoria_lancamento_id')
+                ->label('Categoria')
+                ->options(fn (): array => FinancialFilterOptions::categories())
+                ->multiple()
+                ->query(function (Builder $query, array $data): Builder {
+                    $categoryIds = FinancialFilterOptions::selectedIntegerValues($data);
+
+                    return $categoryIds === []
+                        ? $query
+                        : $query->whereHas(
+                            'lancamentoItems',
+                            fn (Builder $query): Builder => $query->whereIn('categoria_lancamento_id', $categoryIds),
+                        );
+                })
+                ->searchable()
+                ->preload()
+                ->native(false)
+                ->modifyFormFieldUsing(fn (Select $field): Select => $field->allowHtml())
+                ->indicateUsing(fn (array $state): array => FinancialFilterOptions::categoryIndicators($state)),
         ];
     }
 

--- a/app/Filament/Resources/LancamentoResource.php
+++ b/app/Filament/Resources/LancamentoResource.php
@@ -13,6 +13,7 @@ use App\Models\EquipeTrabalho;
 use App\Models\Lancamento;
 use App\Models\LancamentoItem;
 use App\Support\EnumOptionBadge;
+use App\Support\Financeiro\FinancialFilterOptions;
 use App\Support\IconBadge;
 use Carbon\Carbon;
 use Filament\Actions\EditAction;
@@ -154,6 +155,15 @@ class LancamentoResource extends Resource
                     ->indicateUsing(fn (array $state): array => blank($state['value'] ?? null)
                         ? []
                         : ['Tipo: '.(TipoLacamento::tryFrom((int) $state['value'])?->getLabel() ?? $state['value'])]),
+                SelectFilter::make('status')
+                    ->label('Status do pagamento')
+                    ->options(fn (): array => FinancialFilterOptions::paymentStatuses())
+                    ->multiple()
+                    ->searchable()
+                    ->preload()
+                    ->native(false)
+                    ->modifyFormFieldUsing(fn (Select $field): Select => $field->allowHtml())
+                    ->indicateUsing(fn (array $state): array => FinancialFilterOptions::paymentStatusIndicators($state)),
                 Filter::make('registration_link')
                     ->label('Cadastro vinculado')
                     ->form([
@@ -269,23 +279,7 @@ class LancamentoResource extends Resource
                     ->searchable()
                     ->native(false)
                     ->modifyFormFieldUsing(fn (Select $field): Select => $field->allowHtml())
-                    ->indicateUsing(function (array $state): array {
-                        $categoryIds = collect($state['values'] ?? [])
-                            ->filter(fn (mixed $value): bool => filled($value))
-                            ->map(fn (mixed $value): int => (int) $value)
-                            ->values();
-
-                        if ($categoryIds->isEmpty()) {
-                            return [];
-                        }
-
-                        return CategoriaLancamento::query()
-                            ->whereKey($categoryIds->all())
-                            ->orderBy('nome')
-                            ->pluck('nome')
-                            ->map(fn (string $name): string => 'Categoria: '.$name)
-                            ->all();
-                    })
+                    ->indicateUsing(fn (array $state): array => FinancialFilterOptions::categoryIndicators($state))
                     ->preload(),
                 SelectFilter::make('batch_code')
                     ->label('Lote')
@@ -354,15 +348,12 @@ class LancamentoResource extends Resource
         return '%'.str_replace(['\\', '%', '_'], ['\\\\', '\\%', '\\_'], $search).'%';
     }
 
+    /**
+     * @return array<int, string>
+     */
     private static function categoryFilterOptions(): array
     {
-        return CategoriaLancamento::query()
-            ->orderBy('nome')
-            ->get()
-            ->mapWithKeys(fn (CategoriaLancamento $category): array => [
-                $category->id => (string) IconBadge::tile($category, $category->nome, fallbackIcon: 'heroicon-o-tag'),
-            ])
-            ->all();
+        return FinancialFilterOptions::categories();
     }
 
     private static function categoryBadges(Lancamento $record): HtmlString

--- a/app/Livewire/CampistaForm.php
+++ b/app/Livewire/CampistaForm.php
@@ -104,6 +104,12 @@ class CampistaForm extends Component implements HasActions, HasForms
                                 'xl' => 2,
                             ])
                             ->image()
+                            ->imageAspectRatio('1:1')
+                            ->automaticallyCropImagesToAspectRatio()
+                            ->automaticallyResizeImagesMode('cover')
+                            ->automaticallyResizeImagesToWidth('500')
+                            ->automaticallyResizeImagesToHeight('500')
+                            ->automaticallyUpscaleImagesWhenResizing(false)
                             ->acceptedFileTypes([
                                 'image/jpeg',
                                 'image/png',

--- a/app/Support/Financeiro/FinancialFilterOptions.php
+++ b/app/Support/Financeiro/FinancialFilterOptions.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace App\Support\Financeiro;
+
+use App\Enums\StatusLacamento;
+use App\Models\CategoriaLancamento;
+use App\Support\EnumOptionBadge;
+use App\Support\IconBadge;
+
+final class FinancialFilterOptions
+{
+    /**
+     * @return array<int, string>
+     */
+    public static function categories(): array
+    {
+        return CategoriaLancamento::query()
+            ->orderBy('nome')
+            ->get(['id', 'nome', 'cor', 'icone'])
+            ->mapWithKeys(fn (CategoriaLancamento $category): array => [
+                $category->getKey() => (string) IconBadge::tile(
+                    $category,
+                    $category->nome,
+                    fallbackIcon: 'heroicon-o-tag',
+                ),
+            ])
+            ->all();
+    }
+
+    /**
+     * @return array<int, string>
+     */
+    public static function paymentStatuses(): array
+    {
+        return EnumOptionBadge::options(StatusLacamento::class);
+    }
+
+    /**
+     * @param  array<string, mixed>  $state
+     * @return array<int, string>
+     */
+    public static function categoryIndicators(array $state): array
+    {
+        $categoryIds = self::selectedIntegerValues($state);
+
+        if ($categoryIds === []) {
+            return [];
+        }
+
+        return CategoriaLancamento::query()
+            ->whereKey($categoryIds)
+            ->orderBy('nome')
+            ->pluck('nome')
+            ->map(fn (string $name): string => 'Categoria: '.$name)
+            ->all();
+    }
+
+    /**
+     * @param  array<string, mixed>  $state
+     * @return array<int, string>
+     */
+    public static function paymentStatusIndicators(array $state): array
+    {
+        return collect(self::selectedIntegerValues($state))
+            ->map(fn (int $value): string => 'Status do pagamento: '.(StatusLacamento::tryFrom($value)?->getLabel() ?? (string) $value))
+            ->all();
+    }
+
+    /**
+     * @param  array<string, mixed>  $state
+     * @return array<int, int>
+     */
+    public static function selectedIntegerValues(array $state): array
+    {
+        return collect($state['values'] ?? [$state['value'] ?? null])
+            ->filter(fn (mixed $value): bool => filled($value))
+            ->map(fn (mixed $value): int => (int) $value)
+            ->unique()
+            ->values()
+            ->all();
+    }
+}

--- a/app/Support/Reports/CampistaReportData.php
+++ b/app/Support/Reports/CampistaReportData.php
@@ -12,11 +12,15 @@ use App\Support\Tribes\TribeColor;
 use Carbon\Carbon;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Support\Collection;
-use Illuminate\Support\Facades\Storage;
 use Illuminate\Support\Str;
 
 class CampistaReportData
 {
+    public function __construct(
+        private readonly PrintableReportImage $printableReportImage,
+        private readonly RegistrationPaymentReportData $registrationPayments,
+    ) {}
+
     /**
      * @return array<int, array{value: string, label: string, title: string, description: string, sensitive: bool}>
      */
@@ -37,7 +41,10 @@ class CampistaReportData
 
     public function payload(CampistaReportType $type, array $filters, User $user): array
     {
-        $records = $this->records($filters);
+        $records = $type->isFinancial() ? collect() : $this->records($filters);
+        $registrationPaymentRows = $type === CampistaReportType::RegistrationPayments
+            ? $this->registrationPayments->rows($filters)
+            : [];
         $canUseSensitiveHealth = $user->can('view_sensitive_health_campista');
         $showSensitiveHealth = $this->canExposeSensitiveHealth($filters, $user);
         $showPaymentData = $this->canExposePaymentData($filters, $user);
@@ -51,10 +58,14 @@ class CampistaReportData
             'title' => $type->title(),
             'description' => $type->description(),
             'generatedAt' => now()->format('d/m/Y H:i'),
-            'filters' => $this->filterSummary($filters),
+            'filters' => $type === CampistaReportType::RegistrationPayments
+                ? $this->registrationPayments->filterSummary($filters)
+                : $this->filterSummary($filters),
             'canUseSensitiveHealth' => $canUseSensitiveHealth,
             'showSensitiveHealth' => $showSensitiveHealth,
-            'recordsCount' => $records->count(),
+            'recordsCount' => $type === CampistaReportType::RegistrationPayments
+                ? count($registrationPaymentRows)
+                : $records->count(),
             'fichas' => $type === CampistaReportType::RegistrationFichas
                 ? $records->map(fn (Campista $campista): array => $this->ficha($campista, $showSensitiveHealth, $showPaymentData))->all()
                 : [],
@@ -67,6 +78,7 @@ class CampistaReportData
             'missionRows' => $type === CampistaReportType::MissionContacts
                 ? $records->map(fn (Campista $campista): array => $this->missionRow($campista))->all()
                 : [],
+            'registrationPaymentRows' => $registrationPaymentRows,
         ];
     }
 
@@ -75,6 +87,11 @@ class CampistaReportData
         return collect(StatusInscricao::cases())
             ->mapWithKeys(fn (StatusInscricao $status): array => [$status->value => $status->getLabel()])
             ->all();
+    }
+
+    public function paymentStatusOptions(): array
+    {
+        return $this->registrationPayments->statusOptions();
     }
 
     public function tribeOptions(): array
@@ -434,9 +451,7 @@ class CampistaReportData
             return null;
         }
 
-        return Str::startsWith($avatar, ['http://', 'https://', '/'])
-            ? $avatar
-            : Storage::disk('public')->url($avatar);
+        return $this->printableReportImage->url($avatar);
     }
 
     private function responsibleName(Campista $campista): ?string

--- a/app/Support/Reports/CampistaReportType.php
+++ b/app/Support/Reports/CampistaReportType.php
@@ -10,6 +10,7 @@ enum CampistaReportType: string
     case TribeQuadrant = 'tribe_quadrant';
     case SensitiveHealth = 'sensitive_health';
     case MissionContacts = 'mission_contacts';
+    case RegistrationPayments = 'registration_payments';
 
     public const PAGE_PERMISSION = 'page_reports_page';
 
@@ -20,6 +21,7 @@ enum CampistaReportType: string
             self::TribeQuadrant => 'Quadrante por tribo',
             self::SensitiveHealth => 'Lista médica da enfermaria',
             self::MissionContacts => 'Contatos e endereços',
+            self::RegistrationPayments => 'Pagamentos de inscrições',
         };
     }
 
@@ -30,6 +32,7 @@ enum CampistaReportType: string
             self::TribeQuadrant => 'Quadrante das inscrições por tribo',
             self::SensitiveHealth => 'Lista médica da enfermaria',
             self::MissionContacts => 'Contatos e endereços para missão',
+            self::RegistrationPayments => 'Pagamentos de campistas e equipe de trabalho',
         };
     }
 
@@ -40,6 +43,7 @@ enum CampistaReportType: string
             self::TribeQuadrant => 'Distribuição dos campistas agrupada por tribo.',
             self::SensitiveHealth => 'Dados restritos para triagem e cuidados da enfermaria.',
             self::MissionContacts => 'Responsáveis, telefones e endereços para visitas missionárias.',
+            self::RegistrationPayments => 'Situação dos lançamentos vinculados a campistas e integrantes da equipe de trabalho.',
         };
     }
 
@@ -50,6 +54,7 @@ enum CampistaReportType: string
             self::TribeQuadrant => 'print_tribe_quadrant_report',
             self::SensitiveHealth => 'print_sensitive_health_report',
             self::MissionContacts => 'print_mission_contacts_report',
+            self::RegistrationPayments => 'print_registration_payments_report',
         };
     }
 
@@ -58,9 +63,14 @@ enum CampistaReportType: string
         return $this === self::SensitiveHealth;
     }
 
+    public function isFinancial(): bool
+    {
+        return $this === self::RegistrationPayments;
+    }
+
     public function canBeAccessedBy(User $user): bool
     {
-        if ($this->isSensitive()) {
+        if ($this->isSensitive() || $this->isFinancial()) {
             return $user->can($this->permission());
         }
 

--- a/app/Support/Reports/PrintableReportImage.php
+++ b/app/Support/Reports/PrintableReportImage.php
@@ -1,0 +1,107 @@
+<?php
+
+namespace App\Support\Reports;
+
+use GdImage;
+use Illuminate\Filesystem\FilesystemAdapter;
+use Illuminate\Support\Facades\Storage;
+use Illuminate\Support\Str;
+use Throwable;
+
+class PrintableReportImage
+{
+    private const int MAX_DIMENSION = 320;
+
+    private const int JPEG_QUALITY = 82;
+
+    public function url(?string $path): ?string
+    {
+        if (blank($path)) {
+            return null;
+        }
+
+        if (Str::startsWith($path, ['http://', 'https://', '/'])) {
+            return $path;
+        }
+
+        $disk = Storage::disk('public');
+        $originalUrl = $disk->url($path);
+
+        if (! function_exists('imagecreatefromstring') || ! $disk->exists($path)) {
+            return $originalUrl;
+        }
+
+        $thumbnailPath = $this->thumbnailPath($path);
+
+        try {
+            if (! $this->isFresh($disk, $path, $thumbnailPath)) {
+                $thumbnail = $this->thumbnail($disk->get($path));
+
+                if ($thumbnail === null || ! $disk->put($thumbnailPath, $thumbnail, ['visibility' => 'public'])) {
+                    return $originalUrl;
+                }
+            }
+        } catch (Throwable) {
+            return $originalUrl;
+        }
+
+        return $disk->url($thumbnailPath);
+    }
+
+    public function thumbnailPath(string $path): string
+    {
+        return 'report-thumbnails/'.sha1($path).'.jpg';
+    }
+
+    private function isFresh(FilesystemAdapter $disk, string $originalPath, string $thumbnailPath): bool
+    {
+        return $disk->exists($thumbnailPath)
+            && $disk->size($thumbnailPath) > 0
+            && $disk->lastModified($thumbnailPath) >= $disk->lastModified($originalPath);
+    }
+
+    private function thumbnail(string $contents): ?string
+    {
+        $source = @imagecreatefromstring($contents);
+
+        if (! $source instanceof GdImage) {
+            return null;
+        }
+
+        $sourceWidth = imagesx($source);
+        $sourceHeight = imagesy($source);
+        $scale = min(1, self::MAX_DIMENSION / max($sourceWidth, $sourceHeight));
+        $targetWidth = max(1, (int) round($sourceWidth * $scale));
+        $targetHeight = max(1, (int) round($sourceHeight * $scale));
+        $target = imagecreatetruecolor($targetWidth, $targetHeight);
+
+        if (! $target instanceof GdImage) {
+            unset($source);
+
+            return null;
+        }
+
+        $background = imagecolorallocate($target, 255, 255, 255);
+        imagefill($target, 0, 0, $background);
+        imagecopyresampled(
+            $target,
+            $source,
+            0,
+            0,
+            0,
+            0,
+            $targetWidth,
+            $targetHeight,
+            $sourceWidth,
+            $sourceHeight,
+        );
+
+        ob_start();
+        $encoded = @imagejpeg($target, null, self::JPEG_QUALITY);
+        $thumbnail = ob_get_clean();
+
+        unset($target, $source);
+
+        return $encoded && is_string($thumbnail) ? $thumbnail : null;
+    }
+}

--- a/app/Support/Reports/RegistrationPaymentReportData.php
+++ b/app/Support/Reports/RegistrationPaymentReportData.php
@@ -1,0 +1,143 @@
+<?php
+
+namespace App\Support\Reports;
+
+use App\Enums\StatusLacamento;
+use App\Models\Campista;
+use App\Models\EquipeTrabalho;
+use App\Models\LancamentoItem;
+use Carbon\Carbon;
+use Illuminate\Database\Eloquent\Builder;
+
+class RegistrationPaymentReportData
+{
+    /**
+     * @return array<int, array{
+     *     registration_type: string,
+     *     registration_name: string,
+     *     launch_name: string,
+     *     category: string,
+     *     date: string,
+     *     amount: string,
+     *     payment_method: string,
+     *     status: array{label: string, icon: string, color: string}
+     * }>
+     */
+    public function rows(array $filters): array
+    {
+        $search = trim((string) ($filters['search'] ?? ''));
+
+        return LancamentoItem::query()
+            ->with([
+                'categoria:id,nome',
+                'lancamento:id,nome,data,status,forma_pagamento',
+                'registration',
+            ])
+            ->whereIn('registration_type', [Campista::class, EquipeTrabalho::class])
+            ->whereHas('lancamento', fn (Builder $query): Builder => $query->whereIn('status', $this->statusValues($filters)))
+            ->whereHasMorph('registration', [Campista::class, EquipeTrabalho::class])
+            ->when(filled($search), function (Builder $query) use ($search): void {
+                $query->where(function (Builder $query) use ($search): void {
+                    $query
+                        ->whereHasMorph(
+                            'registration',
+                            [Campista::class, EquipeTrabalho::class],
+                            fn (Builder $query): Builder => $query->where('nome', 'like', "%{$search}%"),
+                        )
+                        ->orWhere('nome', 'like', "%{$search}%")
+                        ->orWhereHas('lancamento', fn (Builder $query): Builder => $query->where('nome', 'like', "%{$search}%"));
+                });
+            })
+            ->get()
+            ->map(fn (LancamentoItem $item): array => $this->row($item))
+            ->sortBy([
+                ['registration_type', 'asc'],
+                ['registration_name', 'asc'],
+                ['date', 'asc'],
+            ])
+            ->values()
+            ->all();
+    }
+
+    /** @return array<int, string> */
+    public function statusOptions(): array
+    {
+        return collect($this->allowedStatuses())
+            ->mapWithKeys(fn (StatusLacamento $status): array => [$status->value => $status->getLabel()])
+            ->all();
+    }
+
+    /** @return array<string, string> */
+    public function filterSummary(array $filters): array
+    {
+        return [
+            'Status do pagamento' => collect($this->statusValues($filters))
+                ->map(fn (int $status): ?string => StatusLacamento::tryFrom($status)?->getLabel())
+                ->filter()
+                ->join(', '),
+            'Busca' => filled($filters['search'] ?? null)
+                ? trim((string) $filters['search'])
+                : 'Sem busca',
+        ];
+    }
+
+    /**
+     * @return array{
+     *     registration_type: string,
+     *     registration_name: string,
+     *     launch_name: string,
+     *     category: string,
+     *     date: string,
+     *     amount: string,
+     *     payment_method: string,
+     *     status: array{label: string, icon: string, color: string}
+     * }
+     */
+    private function row(LancamentoItem $item): array
+    {
+        $registration = $item->registration;
+        $launch = $item->lancamento;
+        $status = $launch?->status;
+
+        return [
+            'registration_type' => $registration instanceof Campista ? 'Campista' : 'Equipe de trabalho',
+            'registration_name' => (string) ($registration?->getAttribute('nome') ?? 'Inscrição removida'),
+            'launch_name' => $launch?->nome ?? 'Lançamento removido',
+            'category' => $item->categoria?->nome ?? 'Sem categoria',
+            'date' => filled($launch?->data) ? Carbon::parse($launch->data)->format('d/m/Y') : 'Sem data',
+            'amount' => 'R$ '.number_format(abs($item->valor) / 100, 2, ',', '.'),
+            'payment_method' => $launch?->forma_pagamento?->getLabel() ?? 'Não informado',
+            'status' => [
+                'label' => $status?->getLabel() ?? 'Sem status',
+                'icon' => $status?->getIcon() ?? 'heroicon-o-question-mark-circle',
+                'color' => is_string($status?->getColor()) ? $status->getColor() : 'gray',
+            ],
+        ];
+    }
+
+    /** @return array<int, int> */
+    private function statusValues(array $filters): array
+    {
+        $allowedValues = collect($this->allowedStatuses())
+            ->map(fn (StatusLacamento $status): int => $status->value);
+
+        $values = collect($filters['payment_status'] ?? [])
+            ->filter(fn (mixed $value): bool => $value !== null && $value !== '')
+            ->map(fn (mixed $value): int => (int) $value)
+            ->intersect($allowedValues)
+            ->unique()
+            ->values()
+            ->all();
+
+        return $values !== [] ? $values : $allowedValues->all();
+    }
+
+    /** @return array<int, StatusLacamento> */
+    private function allowedStatuses(): array
+    {
+        return [
+            StatusLacamento::Pendente,
+            StatusLacamento::Pago,
+        ];
+    }
+}

--- a/config/filament-shield.php
+++ b/config/filament-shield.php
@@ -125,6 +125,7 @@ return [
 
     'custom_permissions' => [
         'print_mission_contacts_report' => 'Imprimir relatório de contatos e endereços',
+        'print_registration_payments_report' => 'Imprimir relatório de pagamentos de inscrições',
         'print_registration_fichas_report' => 'Imprimir fichas de inscrição',
         'print_sensitive_health_report' => 'Imprimir relatório médico da enfermaria',
         'print_tribe_quadrant_report' => 'Imprimir quadrante por tribo',

--- a/config/reports.php
+++ b/config/reports.php
@@ -10,6 +10,7 @@ return [
             'tribe_quadrant' => '2026-06-23-html-export-v1',
             'sensitive_health' => '2026-06-23-html-export-v1',
             'mission_contacts' => '2026-06-23-html-export-v1',
+            'registration_payments' => '2026-07-13-html-export-v1',
         ],
     ],
 ];

--- a/database/seeders/ShieldSeeder.php
+++ b/database/seeders/ShieldSeeder.php
@@ -28,6 +28,8 @@ class ShieldSeeder extends Seeder
 
     protected const SENSITIVE_HEALTH_REPORT_PERMISSION = 'print_sensitive_health_report';
 
+    protected const REGISTRATION_PAYMENTS_REPORT_PERMISSION = 'print_registration_payments_report';
+
     public function run(): void
     {
         static::syncRolesAndPermissions();
@@ -166,6 +168,9 @@ class ShieldSeeder extends Seeder
                 || str_contains($permission, 'operational')
                 || str_contains($permission, 'campista')
                 || str_contains($permission, 'tribo'))
+            ->merge([
+                self::REGISTRATION_PAYMENTS_REPORT_PERMISSION,
+            ])
             ->values()
             ->all();
     }

--- a/resources/views/admin/reports/partials/registration-payments.blade.php
+++ b/resources/views/admin/reports/partials/registration-payments.blade.php
@@ -1,0 +1,41 @@
+@if (count($rows))
+    <section class="report-section">
+        <table class="report-table report-payment-table">
+            <thead>
+                <tr>
+                    <th>Inscrição</th>
+                    <th>Lançamento</th>
+                    <th>Data</th>
+                    <th>Valor</th>
+                    <th>Forma</th>
+                    <th>Status do pagamento</th>
+                </tr>
+            </thead>
+            <tbody>
+                @foreach ($rows as $row)
+                    <tr>
+                        <td>
+                            <span class="report-payment-table__type">{{ $row['registration_type'] }}</span>
+                            <strong>{{ $row['registration_name'] }}</strong>
+                        </td>
+                        <td>
+                            <strong>{{ $row['launch_name'] }}</strong>
+                            <span class="report-payment-table__detail">{{ $row['category'] }}</span>
+                        </td>
+                        <td>{{ $row['date'] }}</td>
+                        <td><strong>{{ $row['amount'] }}</strong></td>
+                        <td>{{ $row['payment_method'] }}</td>
+                        <td>
+                            <span class="report-badge report-badge--{{ $row['status']['color'] }}">
+                                @svg($row['status']['icon'], 'report-badge__icon', ['aria-hidden' => 'true'])
+                                {{ $row['status']['label'] }}
+                            </span>
+                        </td>
+                    </tr>
+                @endforeach
+            </tbody>
+        </table>
+    </section>
+@else
+    <p class="report-empty">Nenhum pagamento de campista ou equipe de trabalho encontrado com os filtros informados.</p>
+@endif

--- a/resources/views/admin/reports/print.blade.php
+++ b/resources/views/admin/reports/print.blade.php
@@ -668,6 +668,19 @@
             background: #f9fcfc;
         }
 
+        .report-payment-table__type,
+        .report-payment-table__detail {
+            display: block;
+            color: var(--muted);
+            font-size: .7rem;
+        }
+
+        .report-payment-table__type {
+            font-weight: 800;
+            letter-spacing: .06em;
+            text-transform: uppercase;
+        }
+
         .report-empty {
             border: 1px dashed var(--line);
             color: var(--muted);
@@ -857,6 +870,10 @@
 
                 @case('mission_contacts')
                     @include('admin.reports.partials.mission-contacts', ['rows' => $report['missionRows']])
+                    @break
+
+                @case('registration_payments')
+                    @include('admin.reports.partials.registration-payments', ['rows' => $report['registrationPaymentRows']])
                     @break
             @endswitch
         </section>

--- a/resources/views/filament/pages/partials/reports-help.blade.php
+++ b/resources/views/filament/pages/partials/reports-help.blade.php
@@ -27,6 +27,11 @@
             'tone' => 'operacional',
             'description' => 'Use para preparar visitas missionárias com responsável, telefone, endereço, bairro, cidade e ponto de referência.',
         ],
+        'registration_payments' => [
+            'title' => 'Pagamentos de campistas e equipe de trabalho',
+            'tone' => 'financeiro',
+            'description' => 'Use para conferir, em uma única lista, os lançamentos pagos ou pendentes vinculados a campistas e integrantes da equipe de trabalho.',
+        ],
     ])
         ->filter(fn (array $item, string $key): bool => $key === 'usage' || in_array($key, $availableValues, true));
 @endphp

--- a/tests/Feature/CategoriaLancamentoResourceTest.php
+++ b/tests/Feature/CategoriaLancamentoResourceTest.php
@@ -359,11 +359,14 @@ it('exposes the category field on the financial entry form and table', function 
         ->toContain("TextColumn::make('categories_summary')")
         ->toContain("SelectFilter::make('categoria_lancamento_id')")
         ->toContain('categoryFilterOptions')
-        ->toContain('IconBadge::tile($category')
+        ->toContain('FinancialFilterOptions::categories()')
         ->toContain('->modifyFormFieldUsing(fn (Select $field): Select => $field->allowHtml())')
         ->toContain('->native(false)')
         ->toContain('->multiple()')
         ->toContain("whereHas('items'")
         ->toContain("whereIn('categoria_lancamento_id'")
         ->toContain("Group::make('batch_code')");
+
+    expect(file_get_contents(app_path('Support/Financeiro/FinancialFilterOptions.php')))
+        ->toContain('IconBadge::tile(');
 });

--- a/tests/Feature/PrintableReportImageTest.php
+++ b/tests/Feature/PrintableReportImageTest.php
@@ -1,0 +1,62 @@
+<?php
+
+use App\Support\Reports\PrintableReportImage;
+use Illuminate\Support\Facades\Storage;
+
+it('creates and reuses a small cached thumbnail for printable reports', function (): void {
+    Storage::fake('public');
+
+    $source = imagecreatetruecolor(2400, 1800);
+    $orange = imagecolorallocate($source, 244, 107, 18);
+    imagefill($source, 0, 0, $orange);
+    ob_start();
+    imagejpeg($source, null, 100);
+    $original = ob_get_clean();
+    unset($source);
+
+    expect($original)->toBeString();
+
+    $originalPath = 'foto-formulario/foto-grande.jpg';
+    Storage::disk('public')->put($originalPath, $original);
+
+    $printableImage = app(PrintableReportImage::class);
+    $thumbnailPath = $printableImage->thumbnailPath($originalPath);
+    $url = $printableImage->url($originalPath);
+
+    Storage::disk('public')->assertExists($thumbnailPath);
+
+    $dimensions = getimagesizefromstring(Storage::disk('public')->get($thumbnailPath));
+
+    expect($url)
+        ->toEndWith('/storage/'.$thumbnailPath)
+        ->and($dimensions)->toBeArray()
+        ->and(max($dimensions[0], $dimensions[1]))->toBeLessThanOrEqual(320)
+        ->and(Storage::disk('public')->size($thumbnailPath))->toBeLessThan(strlen($original));
+
+    $lastModified = Storage::disk('public')->lastModified($thumbnailPath);
+
+    expect($printableImage->url($originalPath))->toBe($url)
+        ->and(Storage::disk('public')->lastModified($thumbnailPath))->toBe($lastModified);
+});
+
+it('keeps external and missing image URLs compatible', function (): void {
+    Storage::fake('public');
+
+    $printableImage = app(PrintableReportImage::class);
+
+    expect($printableImage->url('https://example.com/foto.jpg'))
+        ->toBe('https://example.com/foto.jpg')
+        ->and($printableImage->url('foto-formulario/inexistente.jpg'))
+        ->toEndWith('/storage/foto-formulario/inexistente.jpg')
+        ->and($printableImage->url(null))->toBeNull();
+});
+
+it('resizes new public registration photos before storing them', function (): void {
+    expect(file_get_contents(app_path('Livewire/CampistaForm.php')))
+        ->toContain("->imageAspectRatio('1:1')")
+        ->toContain("->automaticallyResizeImagesMode('cover')")
+        ->toContain("->automaticallyResizeImagesToWidth('500')")
+        ->toContain("->automaticallyResizeImagesToHeight('500')")
+        ->toContain('->automaticallyUpscaleImagesWhenResizing(false)')
+        ->toContain('->automaticallyCropImagesToAspectRatio()');
+});

--- a/tests/Feature/RegistrationFinancialFiltersTest.php
+++ b/tests/Feature/RegistrationFinancialFiltersTest.php
@@ -1,0 +1,152 @@
+<?php
+
+use App\Enums\StatusInscricao;
+use App\Enums\StatusLacamento;
+use App\Enums\TipoLacamento;
+use App\Filament\Resources\CampistaResource\Pages\ListCampistas;
+use App\Filament\Resources\EquipeTrabalhoResource\Pages\ListEquipeTrabalhos;
+use App\Filament\Resources\LancamentoResource\Pages\ListLancamentos;
+use App\Models\Campista;
+use App\Models\CategoriaLancamento;
+use App\Models\EquipeTrabalho;
+use App\Models\Lancamento;
+use App\Models\User;
+use App\Support\Financeiro\FinancialFilterOptions;
+use Database\Seeders\ShieldSeeder;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Livewire\Livewire;
+
+uses(RefreshDatabase::class);
+
+beforeEach(function (): void {
+    $this->seed(ShieldSeeder::class);
+
+    $user = User::factory()->create();
+    $user->assignRole('Super Administrador');
+
+    $this->actingAs($user);
+});
+
+it('filters campista registrations by payment status and financial category', function (): void {
+    $paidCategory = registrationFilterCategory('Categoria paga', '#123456', 'heroicon-o-star');
+    $pendingCategory = registrationFilterCategory('Categoria pendente', '#abcdef', 'heroicon-o-clock');
+    $paidCampista = Campista::factory()->create([
+        'nome' => 'Campista pago',
+        'status' => StatusInscricao::Pendente->value,
+        'tribo_id' => null,
+        'user_id' => null,
+    ]);
+    $pendingCampista = Campista::factory()->create([
+        'nome' => 'Campista pendente',
+        'status' => StatusInscricao::Pendente->value,
+        'tribo_id' => null,
+        'user_id' => null,
+    ]);
+
+    registrationFilterLaunch($paidCampista, $paidCategory, StatusLacamento::Pago);
+    registrationFilterLaunch($pendingCampista, $pendingCategory, StatusLacamento::Pendente);
+
+    Livewire::test(ListCampistas::class)
+        ->loadTable()
+        ->assertTableFilterExists('payment_status')
+        ->assertTableFilterExists('categoria_lancamento_id')
+        ->filterTable('payment_status', [StatusLacamento::Pago->value])
+        ->assertCanSeeTableRecords([$paidCampista])
+        ->assertCanNotSeeTableRecords([$pendingCampista]);
+
+    Livewire::test(ListCampistas::class)
+        ->loadTable()
+        ->filterTable('categoria_lancamento_id', [$pendingCategory->getKey()])
+        ->assertCanSeeTableRecords([$pendingCampista])
+        ->assertCanNotSeeTableRecords([$paidCampista]);
+});
+
+it('filters team registrations by payment status and financial category', function (): void {
+    $paidCategory = registrationFilterCategory('Equipe paga', '#334455', 'heroicon-o-banknotes');
+    $pendingCategory = registrationFilterCategory('Equipe pendente', '#bbccdd', 'heroicon-o-clock');
+    $paidRegistration = EquipeTrabalho::factory()->create(['nome' => 'Equipe paga']);
+    $pendingRegistration = EquipeTrabalho::factory()->create(['nome' => 'Equipe pendente']);
+
+    registrationFilterLaunch($paidRegistration, $paidCategory, StatusLacamento::Pago);
+    registrationFilterLaunch($pendingRegistration, $pendingCategory, StatusLacamento::Pendente);
+
+    Livewire::test(ListEquipeTrabalhos::class)
+        ->assertTableFilterExists('payment_status')
+        ->assertTableFilterExists('categoria_lancamento_id')
+        ->filterTable('payment_status', [StatusLacamento::Pago->value])
+        ->assertCanSeeTableRecords([$paidRegistration])
+        ->assertCanNotSeeTableRecords([$pendingRegistration]);
+
+    Livewire::test(ListEquipeTrabalhos::class)
+        ->filterTable('categoria_lancamento_id', [$pendingCategory->getKey()])
+        ->assertCanSeeTableRecords([$pendingRegistration])
+        ->assertCanNotSeeTableRecords([$paidRegistration]);
+});
+
+it('filters financial entries by payment status', function (): void {
+    $category = registrationFilterCategory('Inscrições', '#f46b12', 'heroicon-o-ticket');
+    $paidRegistration = Campista::factory()->create([
+        'nome' => 'Pagamento confirmado',
+        'tribo_id' => null,
+        'user_id' => null,
+    ]);
+    $pendingRegistration = Campista::factory()->create([
+        'nome' => 'Pagamento pendente',
+        'tribo_id' => null,
+        'user_id' => null,
+    ]);
+    $paidLaunch = registrationFilterLaunch($paidRegistration, $category, StatusLacamento::Pago);
+    $pendingLaunch = registrationFilterLaunch($pendingRegistration, $category, StatusLacamento::Pendente);
+
+    Livewire::test(ListLancamentos::class)
+        ->assertTableFilterExists('status')
+        ->filterTable('status', [StatusLacamento::Pago->value])
+        ->assertCanSeeTableRecords([$paidLaunch])
+        ->assertCanNotSeeTableRecords([$pendingLaunch]);
+});
+
+it('renders category filter options with the configured icon color and name', function (): void {
+    $category = registrationFilterCategory('Categoria visual', '#123456', 'heroicon-o-star');
+
+    $option = FinancialFilterOptions::categories()[$category->getKey()];
+
+    expect($option)
+        ->toContain('Categoria visual')
+        ->toContain('data-icon="heroicon-o-star"')
+        ->toContain('background-color: #123456');
+});
+
+function registrationFilterCategory(string $name, string $color, string $icon): CategoriaLancamento
+{
+    return CategoriaLancamento::factory()->create([
+        'nome' => $name,
+        'tipo' => TipoLacamento::Receita->value,
+        'cor' => $color,
+        'icone' => $icon,
+    ]);
+}
+
+function registrationFilterLaunch(
+    Model $registration,
+    CategoriaLancamento $category,
+    StatusLacamento $status,
+): Lancamento {
+    $launch = Lancamento::factory()->create([
+        'nome' => 'Pagamento '.$registration->getAttribute('nome'),
+        'status' => $status->value,
+        'tipo' => TipoLacamento::Receita->value,
+        'comprovante' => [],
+        'user_id' => null,
+    ]);
+
+    $launch->items()->create([
+        'nome' => (string) $registration->getAttribute('nome'),
+        'valor' => 25000,
+        'categoria_lancamento_id' => $category->getKey(),
+        'registration_type' => $registration::class,
+        'registration_id' => $registration->getKey(),
+    ]);
+
+    return $launch;
+}

--- a/tests/Feature/ReportsPageTest.php
+++ b/tests/Feature/ReportsPageTest.php
@@ -9,6 +9,7 @@ use App\Enums\TipoLacamento;
 use App\Jobs\GenerateReportExport;
 use App\Models\Campista;
 use App\Models\CategoriaLancamento;
+use App\Models\EquipeTrabalho;
 use App\Models\Lancamento;
 use App\Models\ReportExport;
 use App\Models\Tribo;
@@ -94,6 +95,39 @@ function reportCampistaLinkedPayment(Campista $campista): Lancamento
     return $lancamento;
 }
 
+function reportRegistrationLinkedPayment(
+    Campista|EquipeTrabalho $registration,
+    StatusLacamento $status,
+    int $amount,
+): Lancamento {
+    $category = CategoriaLancamento::factory()->create([
+        'nome' => 'Inscrições '.str($registration::class)->afterLast('\\')->lower().' '.$registration->getKey(),
+        'tipo' => TipoLacamento::Receita,
+    ]);
+
+    $lancamento = Lancamento::factory()->create([
+        'nome' => 'Pagamento de '.$registration->nome,
+        'data' => '2026-07-13 10:00:00',
+        'valor' => $amount,
+        'tipo' => TipoLacamento::Receita,
+        'status' => $status,
+        'forma_pagamento' => $status === StatusLacamento::Pago
+            ? FormaPagamento::Pix
+            : FormaPagamento::NaoPago,
+        'user_id' => null,
+    ]);
+
+    $lancamento->items()->create([
+        'nome' => 'Inscrição de '.$registration->nome,
+        'valor' => $amount,
+        'categoria_lancamento_id' => $category->id,
+        'registration_type' => $registration::class,
+        'registration_id' => $registration->getKey(),
+    ]);
+
+    return $lancamento;
+}
+
 function reportHtml(string $type, array $filters, User $user): string
 {
     $filters = [
@@ -150,7 +184,9 @@ it('seeds report permissions with least privilege by role', function () {
     expect(Permission::query()->where('name', 'page_reports_page')->exists())->toBeTrue()
         ->and(config('filament-shield.shield_resource.tabs.custom_permissions'))->toBeTrue()
         ->and(config('filament-shield.custom_permissions.print_registration_fichas_report'))->toBe('Imprimir fichas de inscrição')
+        ->and(config('filament-shield.custom_permissions.print_registration_payments_report'))->toBe('Imprimir relatório de pagamentos de inscrições')
         ->and(Permission::query()->where('name', 'print_registration_fichas_report')->exists())->toBeTrue()
+        ->and(Permission::query()->where('name', 'print_registration_payments_report')->exists())->toBeTrue()
         ->and(Permission::query()->where('name', 'print_tribe_quadrant_report')->exists())->toBeTrue()
         ->and(Permission::query()->where('name', 'print_mission_contacts_report')->exists())->toBeTrue()
         ->and(Permission::query()->where('name', 'print_sensitive_health_report')->exists())->toBeTrue()
@@ -158,11 +194,13 @@ it('seeds report permissions with least privilege by role', function () {
         ->and(Role::findByName('Administrador')->hasPermissionTo('print_registration_fichas_report'))->toBeTrue()
         ->and(Role::findByName('Administrador')->hasPermissionTo('print_tribe_quadrant_report'))->toBeTrue()
         ->and(Role::findByName('Administrador')->hasPermissionTo('print_mission_contacts_report'))->toBeTrue()
+        ->and(Role::findByName('Administrador')->hasPermissionTo('print_registration_payments_report'))->toBeFalse()
         ->and(Role::findByName('Administrador')->hasPermissionTo('print_sensitive_health_report'))->toBeFalse()
         ->and(Role::findByName('Enfermaria')->hasPermissionTo('page_reports_page'))->toBeTrue()
         ->and(Role::findByName('Enfermaria')->hasPermissionTo('print_sensitive_health_report'))->toBeTrue()
         ->and(Role::findByName('Enfermaria')->hasPermissionTo('print_mission_contacts_report'))->toBeFalse()
-        ->and(Role::findByName('Financeiro')->hasPermissionTo('page_reports_page'))->toBeFalse();
+        ->and(Role::findByName('Financeiro')->hasPermissionTo('page_reports_page'))->toBeFalse()
+        ->and(Role::findByName('Financeiro')->hasPermissionTo('print_registration_payments_report'))->toBeTrue();
 });
 
 it('renders the reports launcher only for authorized operational users', function () {
@@ -178,11 +216,17 @@ it('renders the reports launcher only for authorized operational users', functio
         ->assertSee('Fichas de inscrição')
         ->assertSee('Quadrante por tribo')
         ->assertSee('Contatos e endereços')
+        ->assertDontSee('Pagamentos de inscrições')
         ->assertDontSee('Lista médica da enfermaria');
 
     $this->actingAs($finance)
         ->get(route('filament.admin.pages.reports-page'))
-        ->assertForbidden();
+        ->assertOk()
+        ->assertSee('Pagamentos de inscrições')
+        ->assertSee('Status do pagamento')
+        ->assertDontSee('Fichas de inscrição')
+        ->assertDontSee('Quadrante por tribo')
+        ->assertDontSee('Contatos e endereços');
 });
 
 it('uses the reports page permission to expose standard operational reports', function () {
@@ -264,6 +308,8 @@ it('builds the report filters with native Filament form components', function ()
         ->toContain("view('filament.pages.partials.reports-help'")
         ->toContain("Select::make('type')")
         ->toContain("Select::make('status')")
+        ->toContain("Select::make('payment_status')")
+        ->toContain('Status do pagamento')
         ->toContain("Select::make('tribo_id')")
         ->toContain("Select::make('presenca')")
         ->toContain("Toggle::make('show_sensitive_health')")
@@ -293,7 +339,76 @@ it('builds the report filters with native Filament form components', function ()
         ->toContain('Fichas de inscrição')
         ->toContain('Quadrante das inscrições por tribo')
         ->toContain('Lista médica da enfermaria')
-        ->toContain('Contatos e endereços para missão');
+        ->toContain('Contatos e endereços para missão')
+        ->toContain('Pagamentos de campistas e equipe de trabalho');
+});
+
+it('reports paid and pending campista and team registrations with financial access', function () {
+    $this->seed(ShieldSeeder::class);
+
+    Queue::fake();
+
+    $pendingCampista = reportCampista([
+        'nome' => 'Campista Pendente Relatório',
+        'status' => StatusInscricao::Pendente,
+    ]);
+    $paidTeamMember = EquipeTrabalho::factory()->create([
+        'nome' => 'Equipe Paga Relatório',
+    ]);
+    $cancelledCampista = reportCampista([
+        'nome' => 'Campista Cancelado Relatório',
+        'status' => StatusInscricao::Cancelado,
+    ]);
+
+    reportRegistrationLinkedPayment($pendingCampista, StatusLacamento::Pendente, 25000);
+    reportRegistrationLinkedPayment($paidTeamMember, StatusLacamento::Pago, 18000);
+    reportRegistrationLinkedPayment($cancelledCampista, StatusLacamento::Cancelado, 20000);
+
+    $finance = reportUserWithRole('Financeiro');
+    $administrator = reportUserWithRole('Administrador');
+
+    $this->actingAs($finance)
+        ->get(route('filament.admin.pages.view-report', [
+            'type' => CampistaReportType::RegistrationPayments->value,
+            'payment_status' => [
+                StatusLacamento::Pendente->value,
+                StatusLacamento::Pago->value,
+            ],
+        ]))
+        ->assertOk()
+        ->assertSee('Pagamentos de campistas e equipe de trabalho');
+
+    $this->actingAs($administrator)
+        ->get(route('filament.admin.pages.view-report', [
+            'type' => CampistaReportType::RegistrationPayments->value,
+        ]))
+        ->assertForbidden();
+
+    $html = reportHtml(CampistaReportType::RegistrationPayments->value, [
+        'payment_status' => [
+            StatusLacamento::Pendente->value,
+            StatusLacamento::Pago->value,
+        ],
+    ], $finance);
+
+    expect($html)
+        ->toContain('Pagamentos de campistas e equipe de trabalho')
+        ->toContain('Campista Pendente Relatório')
+        ->toContain('Equipe Paga Relatório')
+        ->toContain('Campista')
+        ->toContain('Equipe de trabalho')
+        ->toContain('R$ 250,00')
+        ->toContain('R$ 180,00')
+        ->toContain('Pendente')
+        ->toContain('Pago')
+        ->not->toContain('Campista Cancelado Relatório');
+
+    expect(reportHtml(CampistaReportType::RegistrationPayments->value, [
+        'payment_status' => [StatusLacamento::Pago->value],
+    ], $finance))
+        ->toContain('Equipe Paga Relatório')
+        ->not->toContain('Campista Pendente Relatório')
+        ->not->toContain('Campista Cancelado Relatório');
 });
 
 it('renders generated report exports as printable HTML in the same tab', function () {
@@ -392,6 +507,35 @@ it('renders the campista photo in printable registration fichas', function () {
     expect($html)
         ->toContain('Foto de Ana Maria Juvenil')
         ->toContain('/storage/foto-formulario/ana.png');
+});
+
+it('renders cached thumbnails instead of full size campista photos', function () {
+    Storage::fake('public');
+    $this->seed(ShieldSeeder::class);
+
+    $source = imagecreatetruecolor(1600, 1200);
+    $orange = imagecolorallocate($source, 244, 107, 18);
+    imagefill($source, 0, 0, $orange);
+    ob_start();
+    imagejpeg($source, null, 100);
+    $original = ob_get_clean();
+    unset($source);
+
+    Storage::disk('public')->put('foto-formulario/ana-grande.jpg', $original);
+
+    reportCampista([
+        'avatar_url' => 'foto-formulario/ana-grande.jpg',
+    ]);
+
+    $administrator = reportUserWithRole('Administrador');
+    $thumbnailPath = 'report-thumbnails/'.sha1('foto-formulario/ana-grande.jpg').'.jpg';
+    $html = reportHtml('registration_fichas', [], $administrator);
+
+    Storage::disk('public')->assertExists($thumbnailPath);
+
+    expect($html)
+        ->toContain('/storage/'.$thumbnailPath)
+        ->not->toContain('/storage/foto-formulario/ana-grande.jpg');
 });
 
 it('applies ficha visual styling and keeps linked payments hidden by default on printable registration reports', function () {


### PR DESCRIPTION
## Summary
- Added a finance-only registration payments report for campistas and equipe de trabalho, with payment status filtering and printable table output.
- Added shared financial filter options and reused them across campista, equipe de trabalho, and lancamento Filament tables.
- Added report thumbnail generation for printable campista photos and resized uploaded registration photos.
- Added Shield permission/config updates so Financeiro can access the payments report without general reports access.

## Testing
- Added coverage in `ReportsPageTest` for registration payment report access, filtering, and printable output.
- Added `RegistrationFinancialFiltersTest` for payment status/category filters across registration and financial resources.
- Added `PrintableReportImageTest` for thumbnail creation/reuse and upload image resize configuration.