### PR TITLE
Handle paid campista registration cancellation

### DIFF
--- a/app/Actions/Campistas/CancelCampistaRegistrationAction.php
+++ b/app/Actions/Campistas/CancelCampistaRegistrationAction.php
@@ -1,0 +1,202 @@
+<?php
+
+namespace App\Actions\Campistas;
+
+use App\Enums\StatusInscricao;
+use App\Enums\StatusLacamento;
+use App\Models\Campista;
+use App\Models\Lancamento;
+use App\Models\LancamentoItem;
+use App\Support\Financeiro\RegistrationPaymentAllocator;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
+use Illuminate\Validation\ValidationException;
+
+class CancelCampistaRegistrationAction
+{
+    public const string PAYMENT_REFUND = 'refund';
+
+    public const string PAYMENT_KEEP_PAID = 'keep_paid';
+
+    public function __construct(
+        private readonly RegistrationPaymentAllocator $paymentAllocator,
+    ) {}
+
+    public function hasPaidPayment(Campista $campista): bool
+    {
+        return $this->paidPaymentItemsQuery($campista)->exists();
+    }
+
+    public function execute(Campista $campista, ?string $reason, ?string $paymentAction): void
+    {
+        DB::transaction(function () use ($campista, $reason, $paymentAction): void {
+            $campista = Campista::query()
+                ->whereKey($campista->getKey())
+                ->lockForUpdate()
+                ->firstOrFail();
+            $paidItems = $this->paidPaymentItemsQuery($campista)
+                ->lockForUpdate()
+                ->get();
+
+            if ($paidItems->isNotEmpty() && ! in_array($paymentAction, [
+                self::PAYMENT_REFUND,
+                self::PAYMENT_KEEP_PAID,
+            ], true)) {
+                throw ValidationException::withMessages([
+                    'payment_action' => 'Escolha se o pagamento será estornado ou mantido como pago.',
+                ]);
+            }
+
+            $campista->forceFill([
+                'status' => StatusInscricao::Cancelado,
+                'observacoes' => filled($reason) ? trim((string) $reason) : null,
+            ])->save();
+
+            if ($paymentAction === self::PAYMENT_REFUND) {
+                $this->refundPaidPayments($campista, $paidItems, $reason);
+            }
+        });
+    }
+
+    /**
+     * @return Builder<LancamentoItem>
+     */
+    private function paidPaymentItemsQuery(Campista $campista): Builder
+    {
+        $categoryId = $this->paymentAllocator
+            ->categoryForRegistrationType($campista::class)?->getKey();
+
+        return LancamentoItem::query()
+            ->where('registration_type', $campista::class)
+            ->where('registration_id', $campista->getKey())
+            ->when(
+                $categoryId !== null,
+                fn (Builder $query): Builder => $query->where('categoria_lancamento_id', $categoryId),
+                fn (Builder $query): Builder => $query->whereRaw('1 = 0'),
+            )
+            ->whereHas(
+                'lancamento',
+                fn (Builder $query): Builder => $query->where('status', StatusLacamento::Pago),
+            );
+    }
+
+    /**
+     * @param  Collection<int, LancamentoItem>  $paidItems
+     */
+    private function refundPaidPayments(Campista $campista, Collection $paidItems, ?string $reason): void
+    {
+        $lancamentos = Lancamento::query()
+            ->whereKey($paidItems->pluck('lancamento_id')->unique()->all())
+            ->where('status', StatusLacamento::Pago)
+            ->lockForUpdate()
+            ->get()
+            ->keyBy(fn (Lancamento $lancamento): int => (int) $lancamento->getKey());
+
+        foreach ($paidItems->groupBy('lancamento_id') as $lancamentoId => $groupedPaidItems) {
+            $lancamento = $lancamentos->get((int) $lancamentoId);
+
+            if (! $lancamento instanceof Lancamento) {
+                continue;
+            }
+
+            $allItems = $lancamento->items()->lockForUpdate()->get();
+            $paidItemIds = $groupedPaidItems->modelKeys();
+            $refundedItems = $allItems
+                ->whereIn('id', $paidItemIds)
+                ->values();
+
+            if ($refundedItems->isEmpty()) {
+                continue;
+            }
+
+            $remainingItems = $allItems
+                ->whereNotIn('id', $paidItemIds)
+                ->values();
+            $refundAmount = (int) $refundedItems->sum('valor');
+            $refundNote = $this->refundNote($campista, $refundAmount, $reason);
+
+            if ($remainingItems->isEmpty()) {
+                $lancamento->forceFill([
+                    'status' => StatusLacamento::Cancelado,
+                    'descricao' => $this->appendObservation($lancamento->descricao, $refundNote),
+                ])->save();
+
+                continue;
+            }
+
+            $cancelledLancamento = Lancamento::query()->create([
+                'nome' => Str::limit('Estorno - '.$lancamento->nome, 255, ''),
+                'descricao' => $this->appendObservation($lancamento->descricao, $refundNote),
+                'comprador' => $lancamento->comprador,
+                'data' => $lancamento->data,
+                'valor' => $this->signedTotal($lancamento, $refundedItems),
+                'tipo' => $lancamento->tipo,
+                'status' => StatusLacamento::Cancelado,
+                'forma_pagamento' => $lancamento->forma_pagamento,
+                'comprovante' => $lancamento->comprovante ?? [],
+                'batch_code' => $lancamento->batch_code,
+                'user_id' => auth()->id() ?? $lancamento->user_id,
+                'origin' => $lancamento->origin,
+                'origin_context' => $lancamento->origin_context,
+            ]);
+
+            LancamentoItem::query()
+                ->whereKey($refundedItems->modelKeys())
+                ->update(['lancamento_id' => $cancelledLancamento->getKey()]);
+
+            $lancamento->forceFill([
+                'valor' => $this->signedTotal($lancamento, $remainingItems),
+                'descricao' => $this->appendObservation(
+                    $lancamento->descricao,
+                    $refundNote.' Lançamento cancelado gerado: #'.$cancelledLancamento->getKey().'.',
+                ),
+            ])->save();
+        }
+    }
+
+    /**
+     * @param  Collection<int, LancamentoItem>  $items
+     */
+    private function signedTotal(Lancamento $lancamento, Collection $items): int
+    {
+        return $this->paymentAllocator->signedTotalForItems(
+            $lancamento->tipo,
+            $items->map(fn (LancamentoItem $item): array => ['valor' => $item->valor])->all(),
+        );
+    }
+
+    private function refundNote(Campista $campista, int $amount, ?string $reason): string
+    {
+        $note = sprintf(
+            'Estorno registrado em %s para a inscrição #%s - %s. Quantia estornada: %s.',
+            now()->format('d/m/Y H:i'),
+            $campista->getKey(),
+            $campista->nome,
+            $this->money($amount),
+        );
+
+        if (filled($reason)) {
+            $note .= ' Motivo do cancelamento: '.trim((string) $reason).'.';
+        }
+
+        if (filled(auth()->user()?->name)) {
+            $note .= ' Registrado por: '.auth()->user()->name.'.';
+        }
+
+        return $note;
+    }
+
+    private function appendObservation(?string $description, string $observation): string
+    {
+        return filled($description)
+            ? rtrim((string) $description)."\n\n".$observation
+            : $observation;
+    }
+
+    private function money(int $amount): string
+    {
+        return 'R$ '.number_format(abs($amount) / 100, 2, ',', '.');
+    }
+}

--- a/app/Filament/Resources/CampistaResource.php
+++ b/app/Filament/Resources/CampistaResource.php
@@ -2,6 +2,7 @@
 
 namespace App\Filament\Resources;
 
+use App\Actions\Campistas\CancelCampistaRegistrationAction;
 use App\Enums\StatusInscricao;
 use App\Filament\Exports\CampistaExporter;
 use App\Filament\Resources\CampistaResource\CampistaForm;
@@ -15,6 +16,7 @@ use Filament\Actions\Action;
 use Filament\Actions\EditAction;
 use Filament\Actions\ExportBulkAction;
 use Filament\Actions\Exports\Models\Export;
+use Filament\Forms\Components\Radio;
 use Filament\Forms\Components\Select;
 use Filament\Forms\Components\Textarea;
 use Filament\Resources\Resource;
@@ -157,26 +159,65 @@ class CampistaResource extends Resource implements HasShieldPermissions
                     ->modalIcon('heroicon-o-hand-thumb-down'),
 
                 Action::make('Cancelar')
-                    ->action(fn (Campista $record, array $data) => $record->update([
-                        'status' => StatusInscricao::Cancelado->value,
-                        'observacoes' => $data['observacoes'],
-                    ]))
-                    ->visible(fn (Campista $record) => $record->status == StatusInscricao::Pendente || $record->status == StatusInscricao::Pago && auth()->user()->can('update', $record))
+                    ->action(fn (
+                        Campista $record,
+                        array $data,
+                        CancelCampistaRegistrationAction $cancelRegistration,
+                    ) => $cancelRegistration->execute(
+                        campista: $record,
+                        reason: $data['observacoes'] ?? null,
+                        paymentAction: $data['payment_action'] ?? null,
+                    ))
+                    ->visible(fn (Campista $record): bool => in_array($record->status, [
+                        StatusInscricao::Pendente,
+                        StatusInscricao::Pago,
+                    ], true) && auth()->user()->can('update', $record))
                     ->requiresConfirmation()
                     ->color('danger')
                     ->iconButton()
                     ->tooltip('Cancelar Inscrição')
+                    ->modalHeading(fn (
+                        Campista $record,
+                        CancelCampistaRegistrationAction $cancelRegistration,
+                    ): string => $cancelRegistration->hasPaidPayment($record)
+                        ? 'Cancelar inscrição paga'
+                        : 'Cancelar inscrição')
+                    ->modalDescription(fn (
+                        Campista $record,
+                        CancelCampistaRegistrationAction $cancelRegistration,
+                    ): string => $cancelRegistration->hasPaidPayment($record)
+                        ? 'Informe o motivo e escolha o que deve acontecer com o pagamento já confirmado.'
+                        : 'Informe o motivo do cancelamento da inscrição.')
+                    ->modalSubmitActionLabel('Confirmar cancelamento')
+                    ->closeModalByClickingAway(false)
                     ->fillForm(fn (Campista $record): array => [
                         'observacoes' => $record->observacoes,
+                        'payment_action' => null,
                     ])
-                    ->form([
+                    ->schema(fn (
+                        Campista $record,
+                        CancelCampistaRegistrationAction $cancelRegistration,
+                    ): array => [
                         Textarea::make('observacoes')
                             ->label('Observação')
-                            ->placeholder('Motivo do Cancelamento')
+                            ->placeholder('Motivo do cancelamento')
                             ->rows(5)
                             ->columnSpan(2),
+                        ...($cancelRegistration->hasPaidPayment($record) ? [
+                            Radio::make('payment_action')
+                                ->label('O que deseja fazer com o pagamento?')
+                                ->options([
+                                    CancelCampistaRegistrationAction::PAYMENT_REFUND => 'Cancelar o pagamento e registrar o estorno',
+                                    CancelCampistaRegistrationAction::PAYMENT_KEEP_PAID => 'Manter o pagamento como pago (sem estorno)',
+                                ])
+                                ->descriptions([
+                                    CancelCampistaRegistrationAction::PAYMENT_REFUND => 'O lançamento será cancelado e receberá uma observação com a quantia estornada.',
+                                    CancelCampistaRegistrationAction::PAYMENT_KEEP_PAID => 'A inscrição será cancelada, mas o lançamento continuará com status pago.',
+                                ])
+                                ->required()
+                                ->columnSpanFull(),
+                        ] : []),
                     ])
-                    ->icon('heroicon-s-arrow-left-on-rectangle')
                     ->icon('heroicon-s-arrow-left-on-rectangle'),
                 EditAction::make()
                     ->iconButton()

--- a/app/Filament/Resources/LancamentoResource/Pages/BatchLancamentos.php
+++ b/app/Filament/Resources/LancamentoResource/Pages/BatchLancamentos.php
@@ -146,6 +146,7 @@ class BatchLancamentos extends Page
                             ->label('Valor padrão')
                             ->intFormat()
                             ->prefix(RawJs::make('R$'))
+                            ->visible(fn (Get $get): bool => $get('registration_type') !== EquipeTrabalho::class)
                             ->live(onBlur: true)
                             ->afterStateUpdated(function (Get $get, Set $set): void {
                                 if ($get('registration_type') === EquipeTrabalho::class) {
@@ -162,6 +163,13 @@ class BatchLancamentos extends Page
 
                                 $set('registration_items', $items);
                             })
+                            ->columnSpan([
+                                'default' => 'full',
+                                'lg' => 3,
+                            ]),
+
+                        Html::make(fn (): HtmlString => new HtmlString($this->teamConfiguredAmountsHtml()))
+                            ->visible(fn (Get $get): bool => $get('registration_type') === EquipeTrabalho::class)
                             ->columnSpan([
                                 'default' => 'full',
                                 'lg' => 3,
@@ -490,12 +498,24 @@ class BatchLancamentos extends Page
         }
 
         /** @var class-string<Model> $registrationType */
-        return collect($ids)
+        $registrationIds = collect($ids)
             ->map(fn (mixed $id): int => (int) $id)
             ->filter()
             ->unique()
-            ->map(function (int $id) use ($registrationType, $amount): ?array {
-                $registration = $registrationType::query()->find($id);
+            ->values();
+
+        $columns = $registrationType === EquipeTrabalho::class
+            ? ['id', 'nome', 'tipo_equipe']
+            : ['id', 'nome'];
+        $registrations = $registrationType::query()
+            ->select($columns)
+            ->whereKey($registrationIds->all())
+            ->get()
+            ->keyBy(fn (Model $registration): int => (int) $registration->getKey());
+
+        return $registrationIds
+            ->map(function (int $id) use ($registrations, $amount): ?array {
+                $registration = $registrations->get($id);
 
                 if (! $registration) {
                     return null;
@@ -519,14 +539,7 @@ class BatchLancamentos extends Page
      */
     private function registrationOptionLabels(?string $registrationType, array $values): array
     {
-        $options = app(LancamentoBatchCreator::class)->registrationOptions($registrationType);
-
-        return collect($values)
-            ->map(fn (mixed $id): int => (int) $id)
-            ->filter()
-            ->unique()
-            ->mapWithKeys(fn (int $id): array => array_key_exists($id, $options) ? [$id => $options[$id]] : [])
-            ->all();
+        return app(RegistrationPaymentAllocator::class)->registrationOptionLabels($registrationType, $values);
     }
 
     private function defaultRegistrationAmount(): int
@@ -557,6 +570,18 @@ class BatchLancamentos extends Page
         return '<div role="alert" class="rounded-lg border border-warning-500/55 bg-warning-500/10 p-4 text-sm text-warning-100">'
             .'<strong class="block text-warning-300">Valor do acampamento não configurado</strong>'
             .'<span>O campo de inscrições pode ficar sem opções enquanto o valor estiver zerado nas configurações.</span>'
+            .'</div>';
+    }
+
+    private function teamConfiguredAmountsHtml(): string
+    {
+        $settings = app(GeneralSettings::class);
+        $internal = MoneyAmount::formatForInput($settings->valor_equipe_trabalho_interna ?? 0);
+        $external = MoneyAmount::formatForInput($settings->valor_equipe_trabalho_externa ?? 0);
+
+        return '<div class="grid grid-cols-2 gap-2 rounded-lg border border-gray-200 bg-gray-50 p-3 dark:border-white/10 dark:bg-white/5">'
+            .'<div class="grid gap-1"><span class="text-xs text-gray-500 dark:text-gray-400">Equipe interna</span><strong class="text-sm text-gray-950 dark:text-white">R$ '.e($internal).'</strong></div>'
+            .'<div class="grid gap-1"><span class="text-xs text-gray-500 dark:text-gray-400">Equipe externa</span><strong class="text-sm text-gray-950 dark:text-white">R$ '.e($external).'</strong></div>'
             .'</div>';
     }
 

--- a/app/Filament/Resources/LancamentoResource/Tables/LancamentoBatchCampistasTable.php
+++ b/app/Filament/Resources/LancamentoResource/Tables/LancamentoBatchCampistasTable.php
@@ -4,7 +4,7 @@ namespace App\Filament\Resources\LancamentoResource\Tables;
 
 use App\Filament\Resources\CampistaResource\CampistaTable;
 use App\Models\Campista;
-use App\Support\Financeiro\LancamentoBatchCreator;
+use App\Support\Financeiro\RegistrationPaymentAllocator;
 use Filament\Tables\Table;
 use Illuminate\Database\Eloquent\Builder;
 
@@ -13,8 +13,10 @@ class LancamentoBatchCampistasTable
     public static function configure(Table $table): Table
     {
         return $table
-            ->query(fn (): Builder => Campista::query()
-                ->whereKey(array_keys(app(LancamentoBatchCreator::class)->registrationOptions(Campista::class))))
+            ->query(fn (): Builder => app(RegistrationPaymentAllocator::class)->applyPaymentEligibilityQuery(
+                query: Campista::query(),
+                registrationType: Campista::class,
+            ))
             ->columns(CampistaTable::getListTableColumns())
             ->defaultSort('id', 'desc')
             ->paginationPageOptions([5, 10, 30, 50])

--- a/app/Filament/Resources/LancamentoResource/Tables/LancamentoBatchEquipeTrabalhoTable.php
+++ b/app/Filament/Resources/LancamentoResource/Tables/LancamentoBatchEquipeTrabalhoTable.php
@@ -4,7 +4,7 @@ namespace App\Filament\Resources\LancamentoResource\Tables;
 
 use App\Filament\Resources\EquipeTrabalhoResource\EquipeTrabalhoTable;
 use App\Models\EquipeTrabalho;
-use App\Support\Financeiro\LancamentoBatchCreator;
+use App\Support\Financeiro\RegistrationPaymentAllocator;
 use Filament\Tables\Table;
 use Illuminate\Database\Eloquent\Builder;
 
@@ -13,8 +13,10 @@ class LancamentoBatchEquipeTrabalhoTable
     public static function configure(Table $table): Table
     {
         return $table
-            ->query(fn (): Builder => EquipeTrabalho::query()
-                ->whereKey(array_keys(app(LancamentoBatchCreator::class)->registrationOptions(EquipeTrabalho::class))))
+            ->query(fn (): Builder => app(RegistrationPaymentAllocator::class)->applyPaymentEligibilityQuery(
+                query: EquipeTrabalho::query(),
+                registrationType: EquipeTrabalho::class,
+            ))
             ->columns(EquipeTrabalhoTable::getColumns())
             ->filters(EquipeTrabalhoTable::getFilters())
             ->defaultSort('id', 'desc')

--- a/app/Support/Financeiro/LancamentoBatchCreator.php
+++ b/app/Support/Financeiro/LancamentoBatchCreator.php
@@ -94,8 +94,8 @@ class LancamentoBatchCreator
             ]);
         }
 
-        $availableIds = array_keys($this->registrationOptions($registrationType));
         $selectedIds = collect($rows)->pluck('registration_id')->unique()->values()->all();
+        $availableIds = $this->allocator->eligibleRegistrationIds($registrationType, $selectedIds);
         $invalidIds = array_values(array_diff($selectedIds, $availableIds));
 
         if ($invalidIds !== []) {
@@ -189,12 +189,27 @@ class LancamentoBatchCreator
             ->unique()
             ->values();
 
+        $itemRegistrationIds = collect($data['registration_items'] ?? [])
+            ->pluck('registration_id')
+            ->map(fn (mixed $id): int => (int) $id)
+            ->filter();
+        $registrationIds = $selectedIds
+            ->merge($itemRegistrationIds)
+            ->unique()
+            ->values();
+        $registrationColumns = $registrationType === EquipeTrabalho::class
+            ? ['id', 'nome', 'tipo_equipe']
+            : ['id', 'nome'];
+        $registrations = $registrationType::query()
+            ->select($registrationColumns)
+            ->whereKey($registrationIds->all())
+            ->get()
+            ->keyBy(fn (Model $registration): int => (int) $registration->getKey());
+
         $rows = collect($data['registration_items'] ?? [])
-            ->map(function (array $row) use ($data, $registrationType): array {
+            ->map(function (array $row) use ($data, $registrations): array {
                 $registrationId = (int) ($row['registration_id'] ?? 0);
-                $registration = $registrationId > 0
-                    ? $registrationType::query()->find($registrationId)
-                    : null;
+                $registration = $registrations->get($registrationId);
 
                 return [
                     'registration_id' => $registrationId,
@@ -209,8 +224,8 @@ class LancamentoBatchCreator
             ->values();
 
         if ($rows->isEmpty()) {
-            $rows = $selectedIds->map(function (int $id) use ($data, $registrationType): array {
-                $registration = $registrationType::query()->find($id);
+            $rows = $selectedIds->map(function (int $id) use ($data, $registrations): array {
+                $registration = $registrations->get($id);
 
                 return [
                     'registration_id' => $id,

--- a/app/Support/Financeiro/RegistrationPaymentAllocator.php
+++ b/app/Support/Financeiro/RegistrationPaymentAllocator.php
@@ -72,6 +72,63 @@ class RegistrationPaymentAllocator
     }
 
     /**
+     * @param  array<int, mixed>  $registrationIds
+     * @return array<int, string>
+     */
+    public function registrationOptionLabels(?string $registrationType, array $registrationIds, ?int $excludingLancamentoId = null, ?int $currentRegistrationId = null, ?int $categoryId = null): array
+    {
+        if (! $this->isSupportedRegistrationType($registrationType)) {
+            return [];
+        }
+
+        $registrationIds = $this->normalizeRegistrationIds($registrationIds);
+
+        if ($registrationIds === []) {
+            return [];
+        }
+
+        /** @var class-string<Model> $registrationType */
+        return $this->registrationOptionResults(
+            registrationType: $registrationType,
+            excludingLancamentoId: $excludingLancamentoId,
+            currentRegistrationId: $currentRegistrationId,
+            categoryId: $categoryId,
+            registrationIds: $registrationIds,
+        );
+    }
+
+    /**
+     * @param  array<int, mixed>  $registrationIds
+     * @return array<int, int>
+     */
+    public function eligibleRegistrationIds(?string $registrationType, array $registrationIds, ?int $excludingLancamentoId = null, ?int $currentRegistrationId = null, ?int $categoryId = null): array
+    {
+        if (! $this->isSupportedRegistrationType($registrationType)) {
+            return [];
+        }
+
+        $registrationIds = $this->normalizeRegistrationIds($registrationIds);
+
+        if ($registrationIds === []) {
+            return [];
+        }
+
+        /** @var class-string<Model> $registrationType */
+        $query = $this->applyPaymentEligibilityQuery(
+            query: $registrationType::query()->whereKey($registrationIds),
+            registrationType: $registrationType,
+            excludingLancamentoId: $excludingLancamentoId,
+            currentRegistrationId: $currentRegistrationId,
+            categoryId: $categoryId,
+        );
+
+        return $query
+            ->pluck($query->getModel()->getKeyName())
+            ->map(fn (mixed $id): int => (int) $id)
+            ->all();
+    }
+
+    /**
      * @param  array<int, array<string, mixed>>  $items
      * @return array<int, array{nome: string, descricao: ?string, valor: int, categoria_lancamento_id: int, registration_type: class-string<Model>|null, registration_id: int|null}>
      */
@@ -538,7 +595,7 @@ class RegistrationPaymentAllocator
      * @param  class-string<Model>  $registrationType
      * @return array<int, string>
      */
-    private function registrationOptionResults(string $registrationType, ?int $excludingLancamentoId = null, ?int $currentRegistrationId = null, ?int $categoryId = null, ?string $search = null, ?int $limit = null): array
+    private function registrationOptionResults(string $registrationType, ?int $excludingLancamentoId = null, ?int $currentRegistrationId = null, ?int $categoryId = null, ?string $search = null, ?int $limit = null, ?array $registrationIds = null): array
     {
         $query = $registrationType::query();
 
@@ -549,6 +606,8 @@ class RegistrationPaymentAllocator
             currentRegistrationId: $currentRegistrationId,
             categoryId: $categoryId,
         )
+            ->select($this->registrationOptionColumns($registrationType))
+            ->when($registrationIds !== null, fn (Builder $query): Builder => $query->whereKey($registrationIds))
             ->when(filled($search), fn ($query) => $query->where('nome', 'like', '%'.str_replace(['%', '_'], ['\\%', '\\_'], trim((string) $search)).'%'))
             ->when(
                 filled($search),
@@ -572,6 +631,31 @@ class RegistrationPaymentAllocator
                     paidAmount: $paidAmounts[$registration->getKey()] ?? 0,
                 ),
             ])
+            ->all();
+    }
+
+    /**
+     * @param  class-string<Model>  $registrationType
+     * @return array<int, string>
+     */
+    private function registrationOptionColumns(string $registrationType): array
+    {
+        return $registrationType === EquipeTrabalho::class
+            ? ['id', 'nome', 'tipo_equipe']
+            : ['id', 'nome'];
+    }
+
+    /**
+     * @param  array<int, mixed>  $registrationIds
+     * @return array<int, int>
+     */
+    private function normalizeRegistrationIds(array $registrationIds): array
+    {
+        return collect($registrationIds)
+            ->map(fn (mixed $id): int => (int) $id)
+            ->filter()
+            ->unique()
+            ->values()
             ->all();
     }
 

--- a/tests/Feature/CampistaResourceActionsTest.php
+++ b/tests/Feature/CampistaResourceActionsTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Actions\Campistas\CancelCampistaRegistrationAction;
 use App\Enums\FormaPagamento;
 use App\Enums\StatusInscricao;
 use App\Enums\StatusLacamento;
@@ -12,6 +13,7 @@ use App\Models\CategoriaLancamento;
 use App\Models\Lancamento;
 use App\Models\User;
 use Database\Seeders\ShieldSeeder;
+use Filament\Actions\Testing\TestAction;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Livewire\Livewire;
 
@@ -121,6 +123,205 @@ it('renders the linked payment summary on the campista edit form', function () {
         ->assertDontSee('Data de Pagamento');
 });
 
+it('asks what to do with a paid payment while keeping the cancellation reason field', function () {
+    $this->seed(ShieldSeeder::class);
+
+    $user = User::factory()->create();
+    $user->assignRole('Super Administrador');
+    $this->actingAs($user);
+
+    $campista = Campista::factory()->create([
+        'nome' => 'Mariana Modal',
+        'status' => StatusInscricao::Pago,
+        'observacoes' => 'Observação anterior',
+        'tribo_id' => null,
+        'user_id' => null,
+    ]);
+    $lancamento = campistaActionsPaidLaunch($campista);
+
+    Livewire::test(ListCampistas::class)
+        ->loadTable()
+        ->mountAction(TestAction::make('Cancelar')->table($campista))
+        ->assertMountedActionModalSee([
+            'Cancelar inscrição paga',
+            'Observação',
+            'O que deseja fazer com o pagamento?',
+            'Cancelar o pagamento e registrar o estorno',
+            'Manter o pagamento como pago (sem estorno)',
+        ])
+        ->assertActionDataSet([
+            'observacoes' => 'Observação anterior',
+            'payment_action' => null,
+        ])
+        ->setActionData([
+            'observacoes' => 'Irá fazer cirurgia',
+        ])
+        ->callMountedAction()
+        ->assertHasFormErrors(['payment_action' => 'required']);
+
+    expect($campista->fresh()->status)->toBe(StatusInscricao::Pago)
+        ->and($lancamento->fresh()->status)->toBe(StatusLacamento::Pago);
+});
+
+it('cancels and annotates a paid payment when the amount was refunded', function () {
+    $this->seed(ShieldSeeder::class);
+
+    $user = User::factory()->create(['name' => 'Usuário Financeiro']);
+    $user->assignRole('Super Administrador');
+    $this->actingAs($user);
+
+    $campista = Campista::factory()->create([
+        'nome' => 'Mariana Estorno',
+        'status' => StatusInscricao::Pago,
+        'tribo_id' => null,
+        'user_id' => null,
+    ]);
+    $lancamento = campistaActionsPaidLaunch($campista, 27550, 'Pagamento confirmado');
+
+    Livewire::test(ListCampistas::class)
+        ->loadTable()
+        ->callAction(TestAction::make('Cancelar')->table($campista), [
+            'observacoes' => 'Irá fazer cirurgia',
+            'payment_action' => CancelCampistaRegistrationAction::PAYMENT_REFUND,
+        ])
+        ->assertHasNoFormErrors();
+
+    expect($campista->fresh())
+        ->status->toBe(StatusInscricao::Cancelado)
+        ->observacoes->toBe('Irá fazer cirurgia')
+        ->and($lancamento->fresh())
+        ->status->toBe(StatusLacamento::Cancelado)
+        ->descricao->toContain('Pagamento confirmado')
+        ->descricao->toContain('Quantia estornada: R$ 275,50')
+        ->descricao->toContain('Motivo do cancelamento: Irá fazer cirurgia')
+        ->descricao->toContain('Registrado por: Usuário Financeiro');
+});
+
+it('keeps a paid payment unchanged when there was no refund', function () {
+    $this->seed(ShieldSeeder::class);
+
+    $user = User::factory()->create();
+    $user->assignRole('Super Administrador');
+    $this->actingAs($user);
+
+    $campista = Campista::factory()->create([
+        'nome' => 'Mariana Sem Estorno',
+        'status' => StatusInscricao::Pago,
+        'tribo_id' => null,
+        'user_id' => null,
+    ]);
+    $lancamento = campistaActionsPaidLaunch($campista, 25000, 'Pagamento mantido');
+
+    Livewire::test(ListCampistas::class)
+        ->loadTable()
+        ->callAction(TestAction::make('Cancelar')->table($campista), [
+            'observacoes' => 'Não solicitou estorno',
+            'payment_action' => CancelCampistaRegistrationAction::PAYMENT_KEEP_PAID,
+        ])
+        ->assertHasNoFormErrors();
+
+    expect($campista->fresh())
+        ->status->toBe(StatusInscricao::Cancelado)
+        ->observacoes->toBe('Não solicitou estorno')
+        ->and($lancamento->fresh())
+        ->status->toBe(StatusLacamento::Pago)
+        ->descricao->toBe('Pagamento mantido');
+});
+
+it('separates only the refunded registration when a paid launch has other items', function () {
+    $this->seed(ShieldSeeder::class);
+
+    $user = User::factory()->create();
+    $user->assignRole('Super Administrador');
+    $this->actingAs($user);
+
+    $refundedCampista = Campista::factory()->create([
+        'nome' => 'Campista Estornado',
+        'status' => StatusInscricao::Pago,
+        'tribo_id' => null,
+        'user_id' => null,
+    ]);
+    $paidCampista = Campista::factory()->create([
+        'nome' => 'Campista Mantido',
+        'status' => StatusInscricao::Pago,
+        'tribo_id' => null,
+        'user_id' => null,
+    ]);
+    $category = campistaActionsInscricaoCategory();
+    $lancamento = Lancamento::factory()->create([
+        'nome' => 'Pagamento compartilhado',
+        'descricao' => 'Duas inscrições',
+        'valor' => 50000,
+        'tipo' => TipoLacamento::Receita,
+        'status' => StatusLacamento::Pago,
+        'forma_pagamento' => FormaPagamento::Pix,
+        'data' => '2026-07-14',
+        'comprovante' => [],
+        'user_id' => null,
+    ]);
+
+    foreach ([$refundedCampista, $paidCampista] as $campista) {
+        $lancamento->items()->create([
+            'nome' => $campista->nome,
+            'valor' => 25000,
+            'categoria_lancamento_id' => $category->id,
+            'registration_type' => $campista::class,
+            'registration_id' => $campista->id,
+        ]);
+    }
+
+    app(CancelCampistaRegistrationAction::class)->execute(
+        campista: $refundedCampista,
+        reason: 'Estorno parcial',
+        paymentAction: CancelCampistaRegistrationAction::PAYMENT_REFUND,
+    );
+
+    $cancelledLancamento = Lancamento::query()
+        ->where('id', '<>', $lancamento->id)
+        ->where('status', StatusLacamento::Cancelado)
+        ->firstOrFail();
+
+    expect($lancamento->fresh())
+        ->status->toBe(StatusLacamento::Pago)
+        ->valor->toBe(25000)
+        ->and($lancamento->items()->pluck('registration_id')->all())->toBe([$paidCampista->id])
+        ->and($cancelledLancamento)
+        ->status->toBe(StatusLacamento::Cancelado)
+        ->valor->toBe(25000)
+        ->descricao->toContain('Quantia estornada: R$ 250,00')
+        ->and($cancelledLancamento->items()->pluck('registration_id')->all())->toBe([$refundedCampista->id]);
+});
+
+it('keeps the original reason-only modal when the registration has no paid payment', function () {
+    $this->seed(ShieldSeeder::class);
+
+    $user = User::factory()->create();
+    $user->assignRole('Super Administrador');
+    $this->actingAs($user);
+
+    $campista = Campista::factory()->create([
+        'nome' => 'Mariana Pendente',
+        'status' => StatusInscricao::Pendente,
+        'tribo_id' => null,
+        'user_id' => null,
+    ]);
+
+    Livewire::test(ListCampistas::class)
+        ->loadTable()
+        ->mountAction(TestAction::make('Cancelar')->table($campista))
+        ->assertMountedActionModalSee(['Cancelar inscrição', 'Observação'])
+        ->assertMountedActionModalDontSee('O que deseja fazer com o pagamento?')
+        ->setActionData([
+            'observacoes' => 'Desistência antes do pagamento',
+        ])
+        ->callMountedAction()
+        ->assertHasNoFormErrors();
+
+    expect($campista->fresh())
+        ->status->toBe(StatusInscricao::Cancelado)
+        ->observacoes->toBe('Desistência antes do pagamento');
+});
+
 function campistaActionsInscricaoCategory(): CategoriaLancamento
 {
     CategoriaLancamento::ensureSystemDefaults();
@@ -128,4 +329,32 @@ function campistaActionsInscricaoCategory(): CategoriaLancamento
     return CategoriaLancamento::query()
         ->where('system_key', CategoriaLancamento::SYSTEM_CATEGORY_INSCRICAO)
         ->firstOrFail();
+}
+
+function campistaActionsPaidLaunch(
+    Campista $campista,
+    int $amount = 25000,
+    ?string $description = 'Pagamento da inscrição',
+): Lancamento {
+    $lancamento = Lancamento::factory()->create([
+        'nome' => 'Pagamento - '.$campista->nome,
+        'descricao' => $description,
+        'valor' => $amount,
+        'tipo' => TipoLacamento::Receita,
+        'status' => StatusLacamento::Pago,
+        'forma_pagamento' => FormaPagamento::Pix,
+        'data' => '2026-07-14',
+        'comprovante' => [],
+        'user_id' => null,
+    ]);
+
+    $lancamento->items()->create([
+        'nome' => $campista->nome,
+        'valor' => $amount,
+        'categoria_lancamento_id' => campistaActionsInscricaoCategory()->id,
+        'registration_type' => $campista::class,
+        'registration_id' => $campista->id,
+    ]);
+
+    return $lancamento;
 }

--- a/tests/Feature/LancamentoBatchPageTest.php
+++ b/tests/Feature/LancamentoBatchPageTest.php
@@ -9,15 +9,18 @@ use App\Enums\TipoLacamento;
 use App\Filament\Resources\LancamentoResource;
 use App\Filament\Resources\LancamentoResource\Forms\LancamentoForm;
 use App\Filament\Resources\LancamentoResource\Pages\BatchLancamentos;
+use App\Filament\Resources\LancamentoResource\Tables\LancamentoBatchEquipeTrabalhoTable;
 use App\Models\Campista;
 use App\Models\CategoriaLancamento;
 use App\Models\EquipeTrabalho;
 use App\Models\Lancamento;
 use App\Models\User;
 use App\Support\Financeiro\LancamentoBatchCreator;
+use App\Support\Financeiro\RegistrationPaymentAllocator;
 use Carbon\Carbon;
 use Database\Seeders\ShieldSeeder;
 use Filament\Forms\Components\Repeater;
+use Filament\Forms\Components\TableSelect\Livewire\TableSelectLivewireComponent;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Validation\ValidationException;
@@ -49,10 +52,13 @@ it('registers a dedicated batch launch page and list action', function () {
         ->toContain("Action::make('createBatch')")
         ->and(file_get_contents(app_path('Filament/Resources/LancamentoResource/Tables/LancamentoBatchCampistasTable.php')))
         ->toContain('CampistaTable::getListTableColumns()')
-        ->toContain('LancamentoBatchCreator::class')
+        ->toContain('RegistrationPaymentAllocator::class')
+        ->toContain('applyPaymentEligibilityQuery')
         ->and($equipeTrabalhoBatchTable)
         ->toContain('EquipeTrabalhoTable::getColumns()')
         ->toContain('EquipeTrabalhoTable::getFilters()')
+        ->toContain('RegistrationPaymentAllocator::class')
+        ->toContain('applyPaymentEligibilityQuery')
         ->and($view)
         ->toContain('{{ $this->form }}');
 });
@@ -216,6 +222,116 @@ it('fills selected team work batch rows with internal and external configured va
         ])
         ->assertSet('data.registration_items.0.valor', '120,00')
         ->assertSet('data.registration_items.1.valor', '80,00');
+});
+
+it('shows the configured internal and external team work values instead of the camp default', function () {
+    $this->seed(ShieldSeeder::class);
+    seedLancamentoBatchSettings(35000, teamInternalAmount: 12000, teamExternalAmount: 8000);
+
+    $user = User::factory()->create();
+    $user->assignRole('Super Administrador');
+    $this->actingAs($user);
+
+    Livewire::test(BatchLancamentos::class)
+        ->fillForm([
+            'registration_type' => EquipeTrabalho::class,
+        ])
+        ->assertFormFieldHidden('default_value')
+        ->assertSee('Equipe interna')
+        ->assertSee('R$ 120,00')
+        ->assertSee('Equipe externa')
+        ->assertSee('R$ 80,00');
+});
+
+it('hydrates only the visible page when opening the team work batch selector', function () {
+    seedLancamentoBatchSettings(35000, teamInternalAmount: 12000, teamExternalAmount: 8000);
+    CategoriaLancamento::ensureSystemDefaults();
+
+    EquipeTrabalho::factory()->count(30)->create([
+        'status' => StatusInscricaoEquipeTrabalho::Pendente->value,
+        'tipo_equipe' => TipoEquipeTrabalho::Interna->value,
+    ]);
+
+    $retrievedRegistrations = 0;
+    $isMeasuring = true;
+
+    EquipeTrabalho::retrieved(function () use (&$retrievedRegistrations, &$isMeasuring): void {
+        if ($isMeasuring) {
+            $retrievedRegistrations++;
+        }
+    });
+
+    Livewire::test(TableSelectLivewireComponent::class, [
+        'tableConfiguration' => base64_encode(LancamentoBatchEquipeTrabalhoTable::class),
+        'state' => [],
+    ])->assertSuccessful();
+
+    $isMeasuring = false;
+
+    expect($retrievedRegistrations)->toBeLessThanOrEqual(10);
+});
+
+it('hydrates only selected team work registrations when resolving selector labels', function () {
+    seedLancamentoBatchSettings(35000, teamInternalAmount: 12000, teamExternalAmount: 8000);
+    CategoriaLancamento::ensureSystemDefaults();
+
+    $registrations = EquipeTrabalho::factory()->count(30)->create([
+        'status' => StatusInscricaoEquipeTrabalho::Pendente->value,
+        'tipo_equipe' => TipoEquipeTrabalho::Interna->value,
+    ]);
+    $selectedRegistrationId = $registrations->first()->id;
+    $retrievedRegistrations = 0;
+    $isMeasuring = true;
+
+    EquipeTrabalho::retrieved(function () use (&$retrievedRegistrations, &$isMeasuring): void {
+        if ($isMeasuring) {
+            $retrievedRegistrations++;
+        }
+    });
+
+    $labels = app(RegistrationPaymentAllocator::class)->registrationOptionLabels(
+        EquipeTrabalho::class,
+        [$selectedRegistrationId],
+    );
+
+    $isMeasuring = false;
+
+    expect($labels)
+        ->toHaveCount(1)
+        ->toHaveKey($selectedRegistrationId)
+        ->and($retrievedRegistrations)->toBe(1);
+});
+
+it('validates only selected team work registrations when creating a batch', function () {
+    seedLancamentoBatchSettings(35000, teamInternalAmount: 12000, teamExternalAmount: 8000);
+    CategoriaLancamento::ensureSystemDefaults();
+
+    $registrations = EquipeTrabalho::factory()->count(30)->create([
+        'status' => StatusInscricaoEquipeTrabalho::Pendente->value,
+        'tipo_equipe' => TipoEquipeTrabalho::Interna->value,
+    ]);
+
+    $retrievedRegistrations = 0;
+    $isMeasuring = true;
+
+    EquipeTrabalho::retrieved(function () use (&$retrievedRegistrations, &$isMeasuring): void {
+        if ($isMeasuring) {
+            $retrievedRegistrations++;
+        }
+    });
+
+    $created = app(LancamentoBatchCreator::class)->create([
+        'mode' => LancamentoBatchCreator::MODE_REGISTRATIONS,
+        'registration_type' => EquipeTrabalho::class,
+        'registration_ids' => [$registrations->first()->id],
+        'data' => '2026-07-14',
+    ]);
+
+    $isMeasuring = false;
+
+    expect($created)
+        ->toHaveCount(1)
+        ->and($retrievedRegistrations)->toBeLessThanOrEqual(6);
 });
 
 it('excludes cancelled and already linked registrations from batch options and validation', function () {


### PR DESCRIPTION
## Summary
- Adds a dedicated cancellation action for campista registrations with paid payment handling.
- Prompts admins to either refund/cancel the paid lançamento or keep it paid when cancelling a paid inscrição.
- Records refund notes with amount, reason, and user, and splits shared paid lançamentos so only refunded registration items move to a cancelled lançamento.
- Improves batch lançamento registration selection to use payment eligibility queries and avoid hydrating unnecessary records.
- Shows configured internal/external equipe trabalho amounts instead of the generic default value.

## Testing
- Added feature coverage for paid cancellation modal validation, refund cancellation, keeping paid lançamentos unchanged, partial refunds from shared lançamentos, and unpaid cancellation behavior.
- Added batch lançamento tests for equipe trabalho amount display and reduced hydration during selector labels, selector pages, and batch validation.