### PR TITLE
Fix work team export permission sync

### DIFF
--- a/app/Filament/Exports/EquipeTrabalhoExporter.php
+++ b/app/Filament/Exports/EquipeTrabalhoExporter.php
@@ -20,7 +20,7 @@ class EquipeTrabalhoExporter extends Exporter
                 ->label('Cod. Inscricão'),
 
             ExportColumn::make('nome')
-                ->label('Campista'),
+                ->label('Nome'),
 
             ExportColumn::make('descricao')
                 ->label('Equipe'),

--- a/database/migrations/2026_07_14_100144_sync_team_work_export_permission.php
+++ b/database/migrations/2026_07_14_100144_sync_team_work_export_permission.php
@@ -1,0 +1,25 @@
+<?php
+
+use Database\Seeders\ShieldSeeder;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        $tableNames = config('permission.table_names');
+
+        if (! Schema::hasTable($tableNames['roles'] ?? 'roles')
+            || ! Schema::hasTable($tableNames['permissions'] ?? 'permissions')) {
+            return;
+        }
+
+        ShieldSeeder::syncRolesAndPermissions();
+    }
+
+    public function down(): void
+    {
+        //
+    }
+};

--- a/tests/Feature/EquipeTrabalhoExportTest.php
+++ b/tests/Feature/EquipeTrabalhoExportTest.php
@@ -1,0 +1,64 @@
+<?php
+
+use App\Filament\Exports\EquipeTrabalhoExporter;
+use App\Filament\Resources\EquipeTrabalhoResource\Pages\ListEquipeTrabalhos;
+use App\Models\User;
+use Database\Seeders\ShieldSeeder;
+use Filament\Actions\Testing\TestAction;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Livewire\Livewire;
+use Spatie\Permission\Models\Permission;
+use Spatie\Permission\Models\Role;
+use Spatie\Permission\PermissionRegistrar;
+
+uses(RefreshDatabase::class);
+
+it('exports the work team name column with a generic heading', function () {
+    $nameColumn = collect(EquipeTrabalhoExporter::getColumns())
+        ->first(fn ($column): bool => $column->getName() === 'nome');
+
+    expect($nameColumn)
+        ->not->toBeNull()
+        ->getLabel()->toBe('Nome');
+});
+
+it('shows the work team export action to authorized users', function () {
+    $this->seed(ShieldSeeder::class);
+
+    $user = User::factory()->create();
+    $user->assignRole('Super Administrador');
+
+    $this->actingAs($user);
+
+    Livewire::test(ListEquipeTrabalhos::class)
+        ->assertActionVisible(TestAction::make('export')->table()->bulk());
+});
+
+it('repairs existing environments missing the work team export permission', function () {
+    $this->seed(ShieldSeeder::class);
+
+    $role = Role::findByName('Super Administrador');
+    $permission = Permission::findByName('export_equipe_trabalho');
+    $tableNames = config('permission.table_names');
+    $rolePivotKey = config('permission.column_names.role_pivot_key') ?? 'role_id';
+    $permissionPivotKey = config('permission.column_names.permission_pivot_key') ?? 'permission_id';
+
+    DB::table($tableNames['role_has_permissions'])
+        ->where($rolePivotKey, $role->getKey())
+        ->where($permissionPivotKey, $permission->getKey())
+        ->delete();
+
+    app(PermissionRegistrar::class)->forgetCachedPermissions();
+
+    expect($role->fresh()->hasPermissionTo('export_equipe_trabalho'))->toBeFalse();
+
+    $migrationFiles = glob(database_path('migrations/*_sync_team_work_export_permission.php'));
+
+    expect($migrationFiles)->toHaveCount(1);
+
+    $migration = include $migrationFiles[0];
+    $migration->up();
+
+    expect($role->fresh()->hasPermissionTo('export_equipe_trabalho'))->toBeTrue();
+});


### PR DESCRIPTION
## Summary
- Sync Shield roles and permissions during migration when permission tables exist, repairing environments missing `export_equipe_trabalho`.
- Update the work team export `nome` column heading from `Campista` to `Nome`.
- Add feature coverage for the export column label, authorized export action visibility, and migration permission repair.

## Testing
- Added `tests/Feature/EquipeTrabalhoExportTest.php` covering exporter labeling, export action authorization, and permission sync repair.