### PR TITLE
Add manual admin password reset links

### DIFF
--- a/app/Filament/Pages/Auth/RequestPasswordReset.php
+++ b/app/Filament/Pages/Auth/RequestPasswordReset.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace App\Filament\Pages\Auth;
+
+use Filament\Actions\Action;
+use Filament\Auth\Pages\PasswordReset\RequestPasswordReset as BaseRequestPasswordReset;
+use Filament\Notifications\Notification;
+use Filament\Schemas\Components\Text;
+use Filament\Schemas\Schema;
+use Illuminate\Contracts\Support\Htmlable;
+
+class RequestPasswordReset extends BaseRequestPasswordReset
+{
+    public function request(): void
+    {
+        Notification::make()
+            ->title('Solicite o link a um administrador')
+            ->body('Nenhum e-mail de redefinição será enviado por este sistema.')
+            ->info()
+            ->send();
+    }
+
+    public function form(Schema $schema): Schema
+    {
+        return $schema
+            ->components([
+                Text::make('Este sistema não envia links de redefinição por e-mail. Solicite seu link a um administrador e abra-o para cadastrar uma nova senha.'),
+            ]);
+    }
+
+    public function getTitle(): string|Htmlable
+    {
+        return 'Recuperação de senha';
+    }
+
+    public function getHeading(): string|Htmlable|null
+    {
+        return 'Solicite seu link ao administrador';
+    }
+
+    public function getSubheading(): string|Htmlable|null
+    {
+        return null;
+    }
+
+    /**
+     * @return array<Action>
+     */
+    protected function getFormActions(): array
+    {
+        return [$this->loginAction()];
+    }
+}

--- a/app/Filament/Pages/Auth/ResetPassword.php
+++ b/app/Filament/Pages/Auth/ResetPassword.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace App\Filament\Pages\Auth;
+
+use DanHarrin\LivewireRateLimiting\Exceptions\TooManyRequestsException;
+use Filament\Auth\Http\Responses\Contracts\PasswordResetResponse;
+use Filament\Auth\Pages\PasswordReset\ResetPassword as BaseResetPassword;
+use Filament\Facades\Filament;
+use Filament\Notifications\Notification;
+use Illuminate\Auth\Events\PasswordReset as PasswordResetEvent;
+use Illuminate\Contracts\Auth\Authenticatable;
+use Illuminate\Contracts\Auth\CanResetPassword;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Facades\Hash;
+use Illuminate\Support\Facades\Password;
+use Illuminate\Support\Str;
+
+class ResetPassword extends BaseResetPassword
+{
+    public function resetPassword(): ?PasswordResetResponse
+    {
+        try {
+            $this->rateLimit(2);
+        } catch (TooManyRequestsException $exception) {
+            $this->getRateLimitedNotification($exception)?->send();
+
+            return null;
+        }
+
+        if ($this->isResetPasswordRateLimited($this->email)) {
+            return null;
+        }
+
+        $data = $this->form->getState();
+        $data['email'] = $this->email;
+        $data['token'] = $this->token;
+
+        $status = Password::broker(Filament::getAuthPasswordBroker())->reset(
+            $this->getCredentialsFromFormData($data),
+            function (CanResetPassword|Model|Authenticatable $user) use ($data): void {
+                $user->forceFill([
+                    $user->getAuthPasswordName() => Hash::make($data['password']),
+                    $user->getRememberTokenName() => Str::random(60),
+                ])->save();
+
+                event(new PasswordResetEvent($user));
+            },
+        );
+
+        if ($status === Password::PASSWORD_RESET) {
+            Notification::make()
+                ->title(__($status))
+                ->success()
+                ->send();
+
+            return app(PasswordResetResponse::class);
+        }
+
+        Notification::make()
+            ->title(__($status))
+            ->danger()
+            ->send();
+
+        return null;
+    }
+}

--- a/app/Filament/Resources/UserResource.php
+++ b/app/Filament/Resources/UserResource.php
@@ -3,6 +3,7 @@
 namespace App\Filament\Resources;
 
 use App\Enums\RoleEnum;
+use App\Filament\Resources\UserResource\Actions\GeneratePasswordResetLinkAction;
 use App\Filament\Resources\UserResource\Pages;
 use App\Models\User;
 use Filament\Actions\BulkActionGroup;
@@ -177,6 +178,7 @@ class UserResource extends Resource
                     ->visible(fn () => auth()->user()->isSuperAdmin())
                     ->label('Simular acesso do usuário')
                     ->color(Color::Amber),
+                GeneratePasswordResetLinkAction::make(),
                 EditAction::make()
                     ->iconButton()
                     ->tooltip('Editar'),

--- a/app/Filament/Resources/UserResource/Actions/GeneratePasswordResetLinkAction.php
+++ b/app/Filament/Resources/UserResource/Actions/GeneratePasswordResetLinkAction.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace App\Filament\Resources\UserResource\Actions;
+
+use App\Models\User;
+use App\Support\Auth\ManualPasswordResetLink;
+use Filament\Actions\Action;
+use Filament\Forms\Components\TextInput;
+use Filament\Support\Enums\Width;
+
+class GeneratePasswordResetLinkAction
+{
+    public static function make(): Action
+    {
+        return Action::make('generatePasswordResetLink')
+            ->label('Gerar link de redefinição')
+            ->icon('heroicon-o-key')
+            ->color('warning')
+            ->authorize('update')
+            ->modalHeading(fn (User $record): string => 'Redefinir a senha de '.$record->name)
+            ->modalDescription(fn (): string => sprintf(
+                'Copie e envie este link ao usuário. Ele é válido por %d minutos e um novo link invalidará o anterior.',
+                app(ManualPasswordResetLink::class)->expirationMinutes(),
+            ))
+            ->modalWidth(Width::Large)
+            ->schema([
+                TextInput::make('reset_url')
+                    ->label('Link de redefinição de senha')
+                    ->readOnly()
+                    ->copyable(
+                        copyMessage: 'Link copiado',
+                        copyMessageDuration: 2000,
+                    ),
+            ])
+            ->fillForm(fn (User $record): array => [
+                'reset_url' => app(ManualPasswordResetLink::class)->generate($record),
+            ])
+            ->modalSubmitAction(false)
+            ->modalCancelActionLabel('Fechar')
+            ->closeModalByClickingAway(false);
+    }
+}

--- a/app/Filament/Resources/UserResource/Pages/EditUser.php
+++ b/app/Filament/Resources/UserResource/Pages/EditUser.php
@@ -3,6 +3,7 @@
 namespace App\Filament\Resources\UserResource\Pages;
 
 use App\Filament\Resources\UserResource;
+use App\Filament\Resources\UserResource\Actions\GeneratePasswordResetLinkAction;
 use Filament\Actions;
 use Filament\Resources\Pages\EditRecord;
 
@@ -13,6 +14,7 @@ class EditUser extends EditRecord
     protected function getHeaderActions(): array
     {
         return [
+            GeneratePasswordResetLinkAction::make(),
             Actions\DeleteAction::make(),
         ];
     }

--- a/app/Providers/Filament/AdminPanelProvider.php
+++ b/app/Providers/Filament/AdminPanelProvider.php
@@ -4,6 +4,8 @@ namespace App\Providers\Filament;
 
 use App\Filament\Dashboard;
 use App\Filament\Pages\Auth\Login;
+use App\Filament\Pages\Auth\RequestPasswordReset;
+use App\Filament\Pages\Auth\ResetPassword;
 use BezhanSalleh\FilamentShield\FilamentShieldPlugin;
 use Filament\Enums\ThemeMode;
 use Filament\Forms\Components\FileUpload;
@@ -47,6 +49,11 @@ class AdminPanelProvider extends PanelProvider
             ->id('admin')
             ->path('admin')
             ->login(Login::class)
+            ->passwordReset(
+                requestAction: RequestPasswordReset::class,
+                resetAction: ResetPassword::class,
+            )
+            ->authPasswordBroker('users')
             ->colors([
                 'primary' => Color::generatePalette('#f46b12'),
                 'info' => Color::Cyan,

--- a/app/Support/Auth/ManualPasswordResetLink.php
+++ b/app/Support/Auth/ManualPasswordResetLink.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace App\Support\Auth;
+
+use App\Models\User;
+use Filament\Facades\Filament;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\Password;
+use RuntimeException;
+
+class ManualPasswordResetLink
+{
+    public function generate(User $user): string
+    {
+        $panel = Filament::getPanel('admin');
+
+        if (! $panel->hasPasswordReset()) {
+            throw new RuntimeException('O fluxo de redefinição de senha não está habilitado no painel administrativo.');
+        }
+
+        $token = Password::broker($panel->getAuthPasswordBroker())->createToken($user);
+
+        Log::notice('Link manual de redefinição de senha gerado.', [
+            'actor_id' => auth()->id(),
+            'target_user_id' => $user->getKey(),
+        ]);
+
+        return $panel->getResetPasswordUrl($token, $user);
+    }
+
+    public function expirationMinutes(): int
+    {
+        $broker = Filament::getPanel('admin')->getAuthPasswordBroker()
+            ?? config('auth.defaults.passwords');
+
+        return (int) config("auth.passwords.{$broker}.expire", 60);
+    }
+}

--- a/tests/Feature/ManualPasswordResetLinkTest.php
+++ b/tests/Feature/ManualPasswordResetLinkTest.php
@@ -1,8 +1,9 @@
 <?php
 
+use App\Filament\Pages\Auth\Login;
 use App\Filament\Pages\Auth\RequestPasswordReset;
 use App\Filament\Pages\Auth\ResetPassword;
-use App\Filament\Pages\Auth\Login;
+use App\Filament\Resources\UserResource\Pages\CreateUser;
 use App\Filament\Resources\UserResource\Pages\ListUsers;
 use App\Models\User;
 use App\Support\Auth\ManualPasswordResetLink;
@@ -77,6 +78,43 @@ it('hides password reset link generation from users without permission to update
         ->assertActionHidden(TestAction::make('generatePasswordResetLink')->table($targetUser));
 });
 
+it('disables password reset link generation until the user has panel access', function () {
+    $this->seed(ShieldSeeder::class);
+
+    $administrator = User::factory()->create();
+    $administrator->assignRole('Super Administrador');
+    $targetUser = User::factory()->create();
+
+    $this->actingAs($administrator);
+
+    Livewire::test(ListUsers::class)
+        ->loadTable()
+        ->assertActionDisabled(TestAction::make('generatePasswordResetLink')->table($targetUser));
+});
+
+it('requires a panel access profile when creating a user', function () {
+    $this->seed(ShieldSeeder::class);
+
+    $administrator = User::factory()->create();
+    $administrator->assignRole('Super Administrador');
+
+    $this->actingAs($administrator);
+
+    Livewire::test(CreateUser::class)
+        ->assertFormFieldExists('roles')
+        ->fillForm([
+            'name' => 'Usuário sem perfil',
+            'email' => 'sem-perfil@example.com',
+            'password' => 'NovaSenha123!',
+            'password_confirmation' => 'NovaSenha123!',
+            'roles' => [],
+        ])
+        ->call('create')
+        ->assertHasFormErrors([
+            'roles' => 'required',
+        ]);
+});
+
 it('resets the password of a registered user without a panel role through a generated one-time link', function () {
     $this->seed(ShieldSeeder::class);
 
@@ -115,6 +153,17 @@ it('resets the password of a registered user without a panel role through a gene
         ->toBeFalse()
         ->and($targetUser->fresh()->canAccessPanel(Filament::getPanel('admin')))
         ->toBeFalse();
+
+    Livewire::test(Login::class)
+        ->fillForm([
+            'email' => $targetUser->email,
+            'password' => 'NovaSenha123!',
+            'remember' => false,
+        ])
+        ->call('authenticate')
+        ->assertHasErrors([
+            'data.email' => 'A senha está correta, mas este usuário não possui um perfil de acesso ao painel. Solicite a um administrador que atribua um perfil.',
+        ]);
 });
 
 it('allows login with the password defined through a manual reset link', function () {

--- a/tests/Feature/ManualPasswordResetLinkTest.php
+++ b/tests/Feature/ManualPasswordResetLinkTest.php
@@ -1,0 +1,223 @@
+<?php
+
+use App\Filament\Pages\Auth\RequestPasswordReset;
+use App\Filament\Pages\Auth\ResetPassword;
+use App\Filament\Pages\Auth\Login;
+use App\Filament\Resources\UserResource\Pages\ListUsers;
+use App\Models\User;
+use App\Support\Auth\ManualPasswordResetLink;
+use Database\Seeders\ShieldSeeder;
+use Filament\Actions\Testing\TestAction;
+use Filament\Facades\Filament;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Hash;
+use Illuminate\Support\Facades\Mail;
+use Illuminate\Support\Facades\Notification;
+use Illuminate\Support\Facades\Password;
+use Livewire\Livewire;
+
+uses(RefreshDatabase::class);
+
+it('allows authorized administrators to generate a password reset link without sending email', function () {
+    $this->seed(ShieldSeeder::class);
+
+    $administrator = User::factory()->create();
+    $administrator->assignRole('Super Administrador');
+    $targetUser = User::factory()->create();
+    $targetUser->assignRole('Administrador');
+
+    $this->actingAs($administrator);
+    Mail::fake();
+    Notification::fake();
+
+    $resetUrl = null;
+
+    Livewire::test(ListUsers::class)
+        ->loadTable()
+        ->mountAction(TestAction::make('generatePasswordResetLink')->table($targetUser))
+        ->assertActionDataSet(function (array $data) use (&$resetUrl, $targetUser): array {
+            $resetUrl = $data['reset_url'] ?? null;
+
+            expect($resetUrl)->toBeString();
+
+            parse_str((string) parse_url($resetUrl, PHP_URL_QUERY), $query);
+
+            expect($query)
+                ->email->toBe($targetUser->email)
+                ->token->not->toBeEmpty()
+                ->signature->not->toBeEmpty();
+
+            return ['reset_url' => $resetUrl];
+        });
+
+    expect(DB::table('password_reset_tokens')->where('email', $targetUser->email)->exists())
+        ->toBeTrue();
+
+    auth()->logout();
+
+    $this->get($resetUrl)->assertSuccessful();
+
+    Mail::assertNothingSent();
+    Notification::assertNothingSent();
+});
+
+it('hides password reset link generation from users without permission to update users', function () {
+    $this->seed(ShieldSeeder::class);
+
+    $viewer = User::factory()->create();
+    $viewer->givePermissionTo('view_any_user');
+    $targetUser = User::factory()->create();
+    $targetUser->assignRole('Administrador');
+
+    $this->actingAs($viewer);
+
+    Livewire::test(ListUsers::class)
+        ->loadTable()
+        ->assertActionHidden(TestAction::make('generatePasswordResetLink')->table($targetUser));
+});
+
+it('resets the password of a registered user without a panel role through a generated one-time link', function () {
+    $this->seed(ShieldSeeder::class);
+
+    $administrator = User::factory()->create();
+    $administrator->assignRole('Super Administrador');
+    $targetUser = User::factory()->create([
+        'password' => 'SenhaAntiga123!',
+    ]);
+
+    $this->actingAs($administrator);
+
+    $resetUrl = app(ManualPasswordResetLink::class)->generate($targetUser);
+
+    parse_str((string) parse_url($resetUrl, PHP_URL_QUERY), $query);
+
+    auth()->logout();
+    Filament::setCurrentPanel(Filament::getPanel('admin'));
+
+    Livewire::test(ResetPassword::class, [
+        'email' => $query['email'],
+        'token' => $query['token'],
+    ])
+        ->fillForm([
+            'email' => $query['email'],
+            'password' => 'NovaSenha123!',
+            'passwordConfirmation' => 'NovaSenha123!',
+        ])
+        ->call('resetPassword')
+        ->assertHasNoFormErrors()
+        ->assertNotified(__('passwords.reset'))
+        ->assertNotNotified(__('passwords.user'));
+
+    expect(Hash::check('NovaSenha123!', $targetUser->fresh()->password))
+        ->toBeTrue()
+        ->and(DB::table('password_reset_tokens')->where('email', $targetUser->email)->exists())
+        ->toBeFalse()
+        ->and($targetUser->fresh()->canAccessPanel(Filament::getPanel('admin')))
+        ->toBeFalse();
+});
+
+it('allows login with the password defined through a manual reset link', function () {
+    $this->seed(ShieldSeeder::class);
+
+    $targetUser = User::factory()->create([
+        'password' => 'SenhaAntiga123!',
+    ]);
+    $targetUser->assignRole('Administrador');
+
+    $resetUrl = app(ManualPasswordResetLink::class)->generate($targetUser);
+
+    parse_str((string) parse_url($resetUrl, PHP_URL_QUERY), $query);
+
+    Filament::setCurrentPanel(Filament::getPanel('admin'));
+
+    Livewire::test(ResetPassword::class, [
+        'email' => $query['email'],
+        'token' => $query['token'],
+    ])
+        ->fillForm([
+            'email' => $query['email'],
+            'password' => 'NovaSenha123!',
+            'passwordConfirmation' => 'NovaSenha123!',
+        ])
+        ->call('resetPassword')
+        ->assertHasNoFormErrors();
+
+    Livewire::test(Login::class)
+        ->fillForm([
+            'email' => $targetUser->email,
+            'password' => 'NovaSenha123!',
+            'remember' => false,
+        ])
+        ->call('authenticate')
+        ->assertHasNoFormErrors();
+
+    expect(auth()->id())->toBe($targetUser->id);
+});
+
+it('rejects an invalid password reset token for a registered user without a panel role', function () {
+    $targetUser = User::factory()->create([
+        'password' => 'SenhaAntiga123!',
+    ]);
+
+    Filament::setCurrentPanel(Filament::getPanel('admin'));
+
+    Livewire::test(ResetPassword::class, [
+        'email' => $targetUser->email,
+        'token' => 'token-invalido',
+    ])
+        ->fillForm([
+            'email' => $targetUser->email,
+            'password' => 'NovaSenha123!',
+            'passwordConfirmation' => 'NovaSenha123!',
+        ])
+        ->call('resetPassword')
+        ->assertHasNoFormErrors()
+        ->assertNotified(__('passwords.token'));
+
+    expect(Hash::check('SenhaAntiga123!', $targetUser->fresh()->password))
+        ->toBeTrue();
+});
+
+it('invalidates the previous password reset link when generating a new one', function () {
+    $targetUser = User::factory()->create();
+
+    $firstUrl = app(ManualPasswordResetLink::class)->generate($targetUser);
+    $secondUrl = app(ManualPasswordResetLink::class)->generate($targetUser);
+
+    parse_str((string) parse_url($firstUrl, PHP_URL_QUERY), $firstQuery);
+    parse_str((string) parse_url($secondUrl, PHP_URL_QUERY), $secondQuery);
+
+    $broker = Password::broker('users');
+
+    expect($broker->tokenExists($targetUser, $firstQuery['token']))
+        ->toBeFalse()
+        ->and($broker->tokenExists($targetUser, $secondQuery['token']))
+        ->toBeTrue();
+});
+
+it('shows instructions instead of an email password reset request form', function () {
+    Filament::setCurrentPanel(Filament::getPanel('admin'));
+
+    $requestUrl = Filament::getPanel('admin')->getRequestPasswordResetUrl();
+
+    expect($requestUrl)->not->toBeNull();
+
+    $this->get($requestUrl)
+        ->assertSuccessful()
+        ->assertSee('não envia links de redefinição por e-mail')
+        ->assertSee('administrador');
+
+    $user = User::factory()->create();
+
+    Mail::fake();
+
+    Livewire::test(RequestPasswordReset::class)
+        ->set('data.email', $user->email)
+        ->call('request');
+
+    expect(DB::table('password_reset_tokens')->where('email', $user->email)->exists())
+        ->toBeFalse();
+
+    Mail::assertNothingSent();
+});


### PR DESCRIPTION
## Summary
- Adds custom Filament password reset pages that disable email-based reset requests and instruct users to request a link from an administrator.
- Adds a reusable UserResource action for authorized admins to generate copyable one-time password reset links from the users table and edit page.
- Adds ManualPasswordResetLink support for creating signed reset URLs through the admin panel password broker and logging generation events.
- Configures the admin panel password reset flow to use the custom request/reset pages and users broker.

## Testing
- Added feature coverage for authorized and unauthorized reset link generation, panel-role restrictions, reset token validity, one-time link invalidation, login after reset, and the no-email request flow.