### PR TITLE
Require panel roles for user access and reset links

### DIFF
--- a/app/Filament/Pages/Auth/Login.php
+++ b/app/Filament/Pages/Auth/Login.php
@@ -2,26 +2,31 @@
 
 namespace App\Filament\Pages\Auth;
 
+use Filament\Auth\Http\Responses\Contracts\LoginResponse;
 use Filament\Auth\Pages\Login as BaseLogin;
+use Filament\Facades\Filament;
+use Filament\Models\Contracts\FilamentUser;
 use Filament\Support\Enums\Width;
+use Illuminate\Auth\SessionGuard;
 use Illuminate\Contracts\Support\Htmlable;
+use Illuminate\Validation\ValidationException;
 
 class Login extends BaseLogin
 {
     protected string $view = 'filament.pages.auth.login';
 
-    protected Width | string | null $maxContentWidth = Width::Full;
+    protected Width|string|null $maxContentWidth = Width::Full;
 
     protected array $extraBodyAttributes = [
         'class' => 'juvenil-admin-auth-body',
     ];
 
-    public function getTitle(): string | Htmlable
+    public function getTitle(): string|Htmlable
     {
         return 'Login do Painel';
     }
 
-    public function getHeading(): string | Htmlable | null
+    public function getHeading(): string|Htmlable|null
     {
         return null;
     }
@@ -29,5 +34,48 @@ class Login extends BaseLogin
     public function hasLogo(): bool
     {
         return false;
+    }
+
+    public function authenticate(): ?LoginResponse
+    {
+        try {
+            return parent::authenticate();
+        } catch (ValidationException $exception) {
+            $isAuthenticationFailure = in_array(
+                __('filament-panels::auth/pages/login.messages.failed'),
+                $exception->errors()['data.email'] ?? [],
+                true,
+            );
+
+            if ((! $isAuthenticationFailure) || (! $this->hasValidCredentialsWithoutPanelAccess())) {
+                throw $exception;
+            }
+
+            throw ValidationException::withMessages([
+                'data.email' => 'A senha está correta, mas este usuário não possui um perfil de acesso ao painel. Solicite a um administrador que atribua um perfil.',
+            ]);
+        }
+    }
+
+    protected function hasValidCredentialsWithoutPanelAccess(): bool
+    {
+        $data = $this->data ?? [];
+
+        if (blank($data['email'] ?? null) || blank($data['password'] ?? null)) {
+            return false;
+        }
+
+        /** @var SessionGuard $authGuard */
+        $authGuard = Filament::auth();
+        $authProvider = $authGuard->getProvider();
+        $credentials = $this->getCredentialsFromFormData($data);
+        $user = $authProvider->retrieveByCredentials($credentials);
+
+        if ((! $user) || (! $authProvider->validateCredentials($user, $credentials))) {
+            return false;
+        }
+
+        return ($user instanceof FilamentUser)
+            && (! $user->canAccessPanel(Filament::getCurrentOrDefaultPanel()));
     }
 }

--- a/app/Filament/Resources/CampistaResource/CampistaExport.php
+++ b/app/Filament/Resources/CampistaResource/CampistaExport.php
@@ -2,6 +2,7 @@
 
 namespace App\Filament\Resources\CampistaResource;
 
+use App\Enums\FormaPagamento;
 use App\Models\Campista;
 use Carbon\Carbon;
 use Filament\Actions\Exports\ExportColumn;
@@ -41,7 +42,7 @@ abstract class CampistaExport
 
             ExportColumn::make('forma_pagamento')
                 ->label('Forma de Pagamento')
-                ->formatStateUsing(fn ($state) => match ($state->value) {
+                ->formatStateUsing(fn (?FormaPagamento $state): string => match ($state?->value) {
                     1 => 'Pix',
                     2 => 'Dinheiro',
                     3 => 'Cartão',

--- a/app/Filament/Resources/UserResource.php
+++ b/app/Filament/Resources/UserResource.php
@@ -12,6 +12,7 @@ use Filament\Actions\DeleteBulkAction;
 use Filament\Actions\EditAction;
 use Filament\Forms\Components\DatePicker;
 use Filament\Forms\Components\Placeholder;
+use Filament\Forms\Components\Select;
 use Filament\Forms\Components\TextInput;
 use Filament\Resources\Resource;
 use Filament\Schemas\Components\Grid;
@@ -79,6 +80,17 @@ class UserResource extends Resource
                                         'md' => 12,
                                         'lg' => 6,
                                     ]),
+
+                                Select::make('roles')
+                                    ->label('Perfis de acesso')
+                                    ->relationship('roles', 'name')
+                                    ->multiple()
+                                    ->searchable()
+                                    ->preload()
+                                    ->optionsLimit(5)
+                                    ->required(fn (string $context): bool => $context === 'create')
+                                    ->helperText('Usuários sem perfil não podem entrar no painel.')
+                                    ->columnSpanFull(),
 
                                 TextInput::make('password')
                                     ->password()

--- a/app/Filament/Resources/UserResource/Actions/GeneratePasswordResetLinkAction.php
+++ b/app/Filament/Resources/UserResource/Actions/GeneratePasswordResetLinkAction.php
@@ -5,6 +5,7 @@ namespace App\Filament\Resources\UserResource\Actions;
 use App\Models\User;
 use App\Support\Auth\ManualPasswordResetLink;
 use Filament\Actions\Action;
+use Filament\Facades\Filament;
 use Filament\Forms\Components\TextInput;
 use Filament\Support\Enums\Width;
 
@@ -17,6 +18,10 @@ class GeneratePasswordResetLinkAction
             ->icon('heroicon-o-key')
             ->color('warning')
             ->authorize('update')
+            ->disabled(fn (User $record): bool => ! $record->canAccessPanel(Filament::getCurrentOrDefaultPanel()))
+            ->tooltip(fn (User $record): ?string => $record->canAccessPanel(Filament::getCurrentOrDefaultPanel())
+                ? null
+                : 'Atribua um perfil de acesso ao usuário antes de gerar o link.')
             ->modalHeading(fn (User $record): string => 'Redefinir a senha de '.$record->name)
             ->modalDescription(fn (): string => sprintf(
                 'Copie e envie este link ao usuário. Ele é válido por %d minutos e um novo link invalidará o anterior.',

--- a/tests/Feature/CampistaExportTest.php
+++ b/tests/Feature/CampistaExportTest.php
@@ -1,0 +1,16 @@
+<?php
+
+use App\Filament\Exports\CampistaExporter;
+use App\Models\Campista;
+use Filament\Actions\Exports\Models\Export;
+
+it('exports an unreported payment method without failing', function () {
+    $exporter = new CampistaExporter(
+        export: new Export,
+        columnMap: ['forma_pagamento' => 'Forma de Pagamento'],
+        options: [],
+    );
+    $campista = new Campista(['forma_pagamento' => null]);
+
+    expect($exporter($campista))->toBe(['Não Informado']);
+});

--- a/tests/Feature/ManualPasswordResetLinkTest.php
+++ b/tests/Feature/ManualPasswordResetLinkTest.php
@@ -17,6 +17,7 @@ use Illuminate\Support\Facades\Mail;
 use Illuminate\Support\Facades\Notification;
 use Illuminate\Support\Facades\Password;
 use Livewire\Livewire;
+use Spatie\Permission\Models\Role;
 
 uses(RefreshDatabase::class);
 
@@ -115,6 +116,30 @@ it('requires a panel access profile when creating a user', function () {
         ]);
 });
 
+it('saves the selected panel access profile when creating a user', function () {
+    $this->seed(ShieldSeeder::class);
+
+    $administrator = User::factory()->create();
+    $administrator->assignRole('Super Administrador');
+    $role = Role::findByName('Administrador');
+
+    $this->actingAs($administrator);
+
+    Livewire::test(CreateUser::class)
+        ->fillForm([
+            'name' => 'Usuário com perfil',
+            'email' => 'com-perfil@example.com',
+            'password' => 'NovaSenha123!',
+            'password_confirmation' => 'NovaSenha123!',
+            'roles' => [$role->getKey()],
+        ])
+        ->call('create')
+        ->assertHasNoFormErrors();
+
+    expect(User::query()->where('email', 'com-perfil@example.com')->firstOrFail()->hasRole($role))
+        ->toBeTrue();
+});
+
 it('resets the password of a registered user without a panel role through a generated one-time link', function () {
     $this->seed(ShieldSeeder::class);
 
@@ -202,6 +227,25 @@ it('allows login with the password defined through a manual reset link', functio
         ->assertHasNoFormErrors();
 
     expect(auth()->id())->toBe($targetUser->id);
+});
+
+it('keeps the generic credentials error when the password is invalid', function () {
+    $targetUser = User::factory()->create([
+        'password' => 'SenhaCorreta123!',
+    ]);
+
+    Filament::setCurrentPanel(Filament::getPanel('admin'));
+
+    Livewire::test(Login::class)
+        ->fillForm([
+            'email' => $targetUser->email,
+            'password' => 'SenhaIncorreta123!',
+            'remember' => false,
+        ])
+        ->call('authenticate')
+        ->assertHasErrors([
+            'data.email' => __('filament-panels::auth/pages/login.messages.failed'),
+        ]);
 });
 
 it('rejects an invalid password reset token for a registered user without a panel role', function () {


### PR DESCRIPTION
## Summary
- Adds role selection to the Filament user creation form and requires a panel access profile on create.
- Shows a specific login validation message when credentials are valid but the user lacks panel access.
- Disables manual password reset link generation for users without panel access, with an explanatory tooltip.
- Handles null `forma_pagamento` values in Campista exports as `Não Informado` instead of failing.

## Testing
- Added coverage for saving selected roles during user creation.
- Added coverage for preserving the generic login error on invalid passwords.
- Added coverage for exporting Campistas with an unreported payment method.