### PR TITLE
Restrict paid status changes for campista registrations

### DIFF
--- a/app/Filament/Resources/CampistaResource/CampistaForm.php
+++ b/app/Filament/Resources/CampistaResource/CampistaForm.php
@@ -664,7 +664,10 @@ abstract class CampistaForm
                                 ->label('Status da Inscrição')
                                 ->live()
                                 ->preload()
-                                ->options(StatusInscricao::class),
+                                ->options(StatusInscricao::class)
+                                ->disableOptionWhen(fn (int|string $value, ?Campista $record): bool => (int) $value === StatusInscricao::Pago->value
+                                    && $record?->status !== StatusInscricao::Pago
+                                    && ! ($record && auth()->user()?->can('markAsPaid', $record))),
 
                             ...self::getFormTribo(),
 

--- a/app/Filament/Resources/CampistaResource/Pages/EditCampista.php
+++ b/app/Filament/Resources/CampistaResource/Pages/EditCampista.php
@@ -5,12 +5,14 @@ namespace App\Filament\Resources\CampistaResource\Pages;
 use App\Enums\StatusInscricao;
 use App\Filament\Resources\CampistaResource;
 use App\Filament\Resources\CampistaResource\CampistaForm;
+use App\Models\Campista;
 use App\Models\User;
 use Filament\Actions;
-use Filament\Notifications\Actions\Action;
+use Filament\Actions\Action;
 use Filament\Notifications\Notification;
 use Filament\Resources\Pages\EditRecord;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Facades\Gate;
 use Illuminate\Support\HtmlString;
 
 class EditCampista extends EditRecord
@@ -27,14 +29,14 @@ class EditCampista extends EditRecord
     protected function handleRecordUpdate(Model $record, array $data): Model
     {
         $data = CampistaForm::preserveSensitiveHealthDetails($data, $record);
-        $sendNotificationStatusUpdate = false;
-        if(isset($data['status']) && $data['status'] != $record['status']) {
-            $sendNotificationStatusUpdate = true;
-        }
+        $newStatus = $this->normalizeStatus($data['status'] ?? null);
+        $this->authorizePaidStatusChange($record, $newStatus);
+
+        $sendNotificationStatusUpdate = $newStatus !== null && $newStatus !== $record->status;
 
         $record->update($data);
 
-        if($sendNotificationStatusUpdate) {
+        if ($sendNotificationStatusUpdate) {
 
             $userAuth = auth()->user();
             $recipient = User::whereNot('id', $userAuth->id)->get();
@@ -43,11 +45,11 @@ class EditCampista extends EditRecord
                 ->title('Status de incrição atualizado')
                 ->warning()
                 ->body(new HtmlString('O status da inscrição #'
-                    . $record['id']
-                    . ' foi atualizada para <strong>'
-                    . strtoupper(StatusInscricao::from($data['status'])->name)
-                    . '</strong> pelo usuário: ' . $userAuth->name
-                    . ', acesse as inscrições para mais detalhes.'))
+                    .$record['id']
+                    .' foi atualizada para <strong>'
+                    .strtoupper($newStatus->name)
+                    .'</strong> pelo usuário: '.$userAuth->name
+                    .', acesse as inscrições para mais detalhes.'))
                 ->actions([
                     Action::make('Visualizar Inscrição')
                         ->button()
@@ -59,6 +61,26 @@ class EditCampista extends EditRecord
         }
 
         return $record;
+    }
+
+    private function authorizePaidStatusChange(Campista $record, ?StatusInscricao $newStatus): void
+    {
+        if ($newStatus === StatusInscricao::Pago && $record->status !== StatusInscricao::Pago) {
+            Gate::authorize('markAsPaid', $record);
+        }
+    }
+
+    private function normalizeStatus(mixed $status): ?StatusInscricao
+    {
+        if ($status instanceof StatusInscricao) {
+            return $status;
+        }
+
+        if ($status === null || $status === '') {
+            return null;
+        }
+
+        return StatusInscricao::tryFrom((int) $status);
     }
 
     protected function mutateFormDataBeforeFill(array $data): array

--- a/app/Policies/CampistaPolicy.php
+++ b/app/Policies/CampistaPolicy.php
@@ -32,6 +32,11 @@ class CampistaPolicy
         return $authUser->can('update_campista');
     }
 
+    public function markAsPaid(AuthUser $authUser, Campista $campista): bool
+    {
+        return $authUser->can('update_lancamento');
+    }
+
     public function delete(AuthUser $authUser, Campista $campista): bool
     {
         return $authUser->can('delete_campista');

--- a/tests/Feature/CampistaResourceActionsTest.php
+++ b/tests/Feature/CampistaResourceActionsTest.php
@@ -31,6 +31,82 @@ it('does not expose a manual mark as paid action on campista registrations', fun
         ->assertTableActionDoesNotExist('Pago');
 });
 
+it('forbids marking a registration as paid without permission to edit financial entries', function () {
+    $this->seed(ShieldSeeder::class);
+
+    $user = User::factory()->create();
+    $user->assignRole('Administrador');
+    $user->givePermissionTo('view_sensitive_health_campista');
+    $this->actingAs($user);
+
+    $campista = Campista::factory()->create([
+        'form_data' => campistaActionsValidFormData(),
+        'status' => StatusInscricao::Pendente,
+        'tribo_id' => null,
+        'user_id' => null,
+    ]);
+
+    Livewire::test(EditCampista::class, ['record' => $campista->getKey()])
+        ->fillForm(['status' => StatusInscricao::Pago->value])
+        ->call('save')
+        ->assertHasFormErrors(['status']);
+
+    expect($user->can('markAsPaid', $campista))->toBeFalse()
+        ->and($campista->fresh()->status)->toBe(StatusInscricao::Pendente);
+});
+
+it('allows marking a registration as paid with permission to edit financial entries', function () {
+    $this->seed(ShieldSeeder::class);
+
+    $user = User::factory()->create();
+    $user->assignRole('Administrador');
+    $user->givePermissionTo([
+        'update_lancamento',
+        'view_sensitive_health_campista',
+    ]);
+    $this->actingAs($user);
+
+    $campista = Campista::factory()->create([
+        'form_data' => campistaActionsValidFormData(),
+        'status' => StatusInscricao::Pendente,
+        'tribo_id' => null,
+        'user_id' => null,
+    ]);
+
+    Livewire::test(EditCampista::class, ['record' => $campista->getKey()])
+        ->fillForm(['status' => StatusInscricao::Pago->value])
+        ->call('save')
+        ->assertHasNoFormErrors();
+
+    expect($campista->fresh()->status)->toBe(StatusInscricao::Pago);
+});
+
+it('allows editing a registration that is already paid without financial permission', function () {
+    $this->seed(ShieldSeeder::class);
+
+    $user = User::factory()->create();
+    $user->assignRole('Administrador');
+    $user->givePermissionTo('view_sensitive_health_campista');
+    $this->actingAs($user);
+
+    $campista = Campista::factory()->create([
+        'form_data' => campistaActionsValidFormData(),
+        'status' => StatusInscricao::Pago,
+        'observacoes' => 'Observação anterior',
+        'tribo_id' => null,
+        'user_id' => null,
+    ]);
+
+    Livewire::test(EditCampista::class, ['record' => $campista->getKey()])
+        ->fillForm(['observacoes' => 'Observação atualizada'])
+        ->call('save')
+        ->assertHasNoFormErrors();
+
+    expect($campista->fresh())
+        ->status->toBe(StatusInscricao::Pago)
+        ->observacoes->toBe('Observação atualizada');
+});
+
 it('removes direct payment and proof fields from the campista form', function () {
     $form = file_get_contents(app_path('Filament/Resources/CampistaResource/CampistaForm.php'));
 
@@ -329,6 +405,19 @@ function campistaActionsInscricaoCategory(): CategoriaLancamento
     return CategoriaLancamento::query()
         ->where('system_key', CategoriaLancamento::SYSTEM_CATEGORY_INSCRICAO)
         ->firstOrFail();
+}
+
+function campistaActionsValidFormData(): array
+{
+    return [
+        ...Campista::factory()->make()->form_data,
+        'toma_remedio' => true,
+        'tem_recomendacao' => true,
+        'ja_participou_retiro' => true,
+        'retiro_que_participou' => ['Acampamento Juvenil 2024'],
+        'algum_parente' => true,
+        'algum_parente_participante' => ['Parente Campista'],
+    ];
 }
 
 function campistaActionsPaidLaunch(


### PR DESCRIPTION
## Summary
- Adds a `markAsPaid` Campista policy ability backed by the `update_lancamento` permission.
- Prevents users without financial-entry permission from changing a campista registration status to `Pago` in the edit flow.
- Disables the `Pago` status option in the Filament form when the current user cannot mark the record as paid.
- Keeps already-paid registrations editable for users who can update campistas but cannot edit financial entries.

## Testing
- Added feature coverage for forbidden, allowed, and already-paid edit scenarios in `CampistaResourceActionsTest`.